### PR TITLE
Add delay to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ ffuf -w /path/to/postdata.txt -X POST -d "username=admin\&password=FUZZ" https:/
 To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-u`), headers (`-H`), or POST data (`-d`).
 
 ```
-Usage of ./ffuf:
   -H "Name: Value"
     	Header "Name: Value", separated by colon. Multiple -H flags are accepted.
+  -V	Show version information.
   -X string
     	HTTP method to use. (default "GET")
   -c	Colorize output.
@@ -89,13 +89,15 @@ Usage of ./ffuf:
     	Filter by amount of words in response
   -k	Skip TLS identity verification (insecure)
   -mc string
-    	Match HTTP status codes from respose (default "200,204,301,302,307,401")
+    	Match HTTP status codes from respose (default "200,204,301,302,307,401,403")
   -mr string
     	Match regexp
   -ms string
     	Match HTTP response size
   -mw string
     	Match amount of words in response
+  -p delay
+    	Seconds of delay between requests, or a range of random delay. For example "0.1" or "0.1-2.0"
   -s	Do not print additional information (silent mode)
   -t int
     	Number of concurrent threads. (default 40)

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -4,6 +4,15 @@ import (
 	"context"
 )
 
+//optRange stores either a single float, in which case the value is stored in min and IsRange is false,
+//or a range of floats, in which case IsRange is true
+type optRange struct {
+	Min      float64
+	Max      float64
+	IsRange  bool
+	HasDelay bool
+}
+
 type Config struct {
 	StaticHeaders map[string]string
 	FuzzHeaders   map[string]string
@@ -14,6 +23,7 @@ type Config struct {
 	Quiet         bool
 	Colors        bool
 	Wordlist      string
+	Delay         optRange
 	Filters       []FilterProvider
 	Matchers      []FilterProvider
 	Threads       int
@@ -31,5 +41,6 @@ func NewConfig(ctx context.Context) Config {
 	conf.Data = ""
 	conf.Quiet = false
 	conf.Filters = make([]FilterProvider, 0)
+	conf.Delay = optRange{0, 0, false, false}
 	return conf
 }


### PR DESCRIPTION
A new command line flag to add a static delay to requests in seconds. 

Examples: for static delay of 0.1 seconds: `-p 0.1` or a random delay between one and two and a half seconds: `-p 1-5`. The delay is per thread.