### PR TITLE
-e flag to provide a list of extensions and -D for DirSearch wordlist format compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ ffuf -w /path/to/postdata.txt -X POST -d "username=admin\&password=FUZZ" https:/
 
 To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-u`), headers (`-H`), or POST data (`-d`).
 ```
+  -D	DirSearch style wordlist compatibility mode. Used in conjunction with -e flag. Replaces %EXT% in wordlist entry with each of the extensions provided by -e.
   -H "Name: Value"
     	Header "Name: Value", separated by colon. Multiple -H flags are accepted.
   -V	Show version information.
@@ -78,6 +79,8 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
   -c	Colorize output.
   -d string
     	POST data.
+  -e string
+    	Comma separated list of extensions to apply. Each extension provided will extend the wordlist entry once.
   -fc string
     	Filter HTTP status codes from response
   -fr string
@@ -138,6 +141,7 @@ The only dependency of ffuf is Go 1.11. No dependencies outside of Go standard l
       - Erroring connections will be retried once
       - Error counter in status bar
       - New CLI flags: -se (stop on spurious errors) and -sa (stop on all errors, implies -se and -sf)
+      - New CLI flags: -e to provide a list of extensions to add to wordlist entries, and -D to provide DirSearch wordlist format compatibility.
 - v0.8
    - New
       - New CLI flag to write output to a file in JSON format

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 )
 
 type cliOptions struct {
+	extensions    string
 	delay         string
 	filterStatus  string
 	filterSize    string
@@ -49,6 +50,7 @@ func main() {
 	defer cancel()
 	conf := ffuf.NewConfig(ctx)
 	opts := cliOptions{}
+	flag.StringVar(&opts.extensions, "e", "", "extensions to bruteforce separated by a comma. `\"wordlist must contain %EXT%\"`")
 	flag.Var(&opts.headers, "H", "Header `\"Name: Value\"`, separated by colon. Multiple -H flags are accepted.")
 	flag.StringVar(&conf.Url, "u", "", "Target URL")
 	flag.StringVar(&conf.Wordlist, "w", "", "Wordlist path")
@@ -134,6 +136,12 @@ func prepareConfig(parseOpts *cliOptions, conf *ffuf.Config) error {
 	if len(conf.Wordlist) == 0 {
 		errs.Add(fmt.Errorf("-w flag is required"))
 	}
+	// prepare extensions
+	if parseOpts.extensions != "" {
+		extensions := strings.Split(parseOpts.extensions, ",")
+		conf.Extensions = extensions
+	}
+
 	//Prepare headers
 	for _, v := range parseOpts.headers {
 		hs := strings.SplitN(v, ":", 2)

--- a/main.go
+++ b/main.go
@@ -50,7 +50,8 @@ func main() {
 	defer cancel()
 	conf := ffuf.NewConfig(ctx)
 	opts := cliOptions{}
-	flag.StringVar(&opts.extensions, "e", "", "extensions to bruteforce separated by a comma. `\"wordlist must contain %EXT%\"`")
+	flag.StringVar(&opts.extensions, "e", "", "List of extensions to apply. Each extension provided will extend the wordlist entry once.")
+	flag.BoolVar(&conf.DirSearchCompat, "D", false, "DirSearch style wordlist compatibility mode. Used in conjunction with -e flag. Replaces %EXT% in wordlist entry with each of the extensions provided by -e.")
 	flag.Var(&opts.headers, "H", "Header `\"Name: Value\"`, separated by colon. Multiple -H flags are accepted.")
 	flag.StringVar(&conf.Url, "u", "", "Target URL")
 	flag.StringVar(&conf.Wordlist, "w", "", "Wordlist path")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -18,6 +18,7 @@ type optRange struct {
 type Config struct {
 	StaticHeaders   map[string]string
 	FuzzHeaders     map[string]string
+	Extensions      []string
 	Method          string
 	Url             string
 	TLSVerify       bool
@@ -57,5 +58,6 @@ func NewConfig(ctx context.Context) Config {
 	conf.ProxyURL = http.ProxyFromEnvironment
 	conf.Filters = make([]FilterProvider, 0)
 	conf.Delay = optRange{0, 0, false, false}
+	conf.Extensions = make([]string, 0)
 	return conf
 }

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	StaticHeaders   map[string]string
 	FuzzHeaders     map[string]string
 	Extensions      []string
+	DirSearchCompat bool
 	Method          string
 	Url             string
 	TLSVerify       bool
@@ -59,5 +60,6 @@ func NewConfig(ctx context.Context) Config {
 	conf.Filters = make([]FilterProvider, 0)
 	conf.Delay = optRange{0, 0, false, false}
 	conf.Extensions = make([]string, 0)
+	conf.DirSearchCompat = false
 	return conf
 }

--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -3,6 +3,7 @@ package input
 import (
 	"bufio"
 	"os"
+	"strings"
 
 	"github.com/ffuf/ffuf/pkg/ffuf"
 )
@@ -71,7 +72,15 @@ func (w *WordlistInput) readFile(path string) error {
 	var data [][]byte
 	reader := bufio.NewScanner(file)
 	for reader.Scan() {
-		data = append(data, []byte(reader.Text()))
+		if strings.Index(reader.Text(), "%EXT%") != -1 {
+			extensions := w.config.Extensions
+			for _, ext := range extensions {
+				contnt := strings.Replace(reader.Text(), "%EXT%", ext, -1)
+				data = append(data, []byte(contnt))
+			}
+		} else {
+			data = append(data, []byte(reader.Text()))
+		}
 	}
 	w.data = data
 	return reader.Err()

--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -78,13 +78,16 @@ func (w *WordlistInput) readFile(path string) error {
 					contnt := strings.Replace(reader.Text(), "%EXT%", ext, -1)
 					data = append(data, []byte(contnt))
 				}
-			}
-		} else if len(w.config.Extensions) > 0 {
-			for _, ext := range w.config.Extensions {
-				data = append(data, []byte(reader.Text()+ext))
+			} else {
+				data = append(data, []byte(reader.Text()))
 			}
 		} else {
 			data = append(data, []byte(reader.Text()))
+			if len(w.config.Extensions) > 0 {
+				for _, ext := range w.config.Extensions {
+					data = append(data, []byte(reader.Text()+ext))
+				}
+			}
 		}
 	}
 	w.data = data

--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -72,11 +72,16 @@ func (w *WordlistInput) readFile(path string) error {
 	var data [][]byte
 	reader := bufio.NewScanner(file)
 	for reader.Scan() {
-		if strings.Index(reader.Text(), "%EXT%") != -1 {
-			extensions := w.config.Extensions
-			for _, ext := range extensions {
-				contnt := strings.Replace(reader.Text(), "%EXT%", ext, -1)
-				data = append(data, []byte(contnt))
+		if w.config.DirSearchCompat && len(w.config.Extensions) > 0 {
+			if strings.Index(reader.Text(), "%EXT%") != -1 {
+				for _, ext := range w.config.Extensions {
+					contnt := strings.Replace(reader.Text(), "%EXT%", ext, -1)
+					data = append(data, []byte(contnt))
+				}
+			}
+		} else if len(w.config.Extensions) > 0 {
+			for _, ext := range w.config.Extensions {
+				data = append(data, []byte(reader.Text()+ext))
 			}
 		} else {
 			data = append(data, []byte(reader.Text()))


### PR DESCRIPTION
This PR builds on work of @C0RB3N in #23 

Two flags are added in this PR:
`-e` that allows you to provide list of extensions to append to each of the wordlist entries.
For example, a wordlist with single entry : `example`, and `-e .first,.second,.third` would result into three different test cases: `example.first, example.second and example.third`.

`-D` flag to provide compatibility with DirSearch wordlists. Only the wordlist entries that contain `%EXT%` will get appended with extensions provided by `-e`

Fixes: #19 