### PR TITLE
Add wildcard option to status code matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
     	Filter by amount of words in response
   -k	TLS identity verification
   -mc string
-    	Match HTTP status codes from respose (default "200,204,301,302,307,401,403")
+    	Match HTTP status codes from respose, use "all" to match every response code. (default "200,204,301,302,307,401,403")
   -mr string
     	Match regexp
   -ms string
@@ -142,6 +142,7 @@ The only dependency of ffuf is Go 1.11. No dependencies outside of Go standard l
       - Error counter in status bar
       - New CLI flags: -se (stop on spurious errors) and -sa (stop on all errors, implies -se and -sf)
       - New CLI flags: -e to provide a list of extensions to add to wordlist entries, and -D to provide DirSearch wordlist format compatibility.
+      - Wildcard option for response status code matcher.
 - v0.8
    - New
       - New CLI flag to write output to a file in JSON format

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	flag.StringVar(&opts.filterWords, "fw", "", "Filter by amount of words in response")
 	flag.StringVar(&conf.Data, "d", "", "POST data.")
 	flag.BoolVar(&conf.Colors, "c", false, "Colorize output.")
-	flag.StringVar(&opts.matcherStatus, "mc", "200,204,301,302,307,401,403", "Match HTTP status codes from respose")
+	flag.StringVar(&opts.matcherStatus, "mc", "200,204,301,302,307,401,403", "Match HTTP status codes from respose, use \"all\" to match every response code.")
 	flag.StringVar(&opts.matcherSize, "ms", "", "Match HTTP response size")
 	flag.StringVar(&opts.matcherRegexp, "mr", "", "Match regexp")
 	flag.StringVar(&opts.matcherWords, "mw", "", "Match amount of words in response")

--- a/pkg/filter/status.go
+++ b/pkg/filter/status.go
@@ -15,17 +15,25 @@ type StatusFilter struct {
 func NewStatusFilter(value string) (ffuf.FilterProvider, error) {
 	var intvals []int64
 	for _, sv := range strings.Split(value, ",") {
-		intval, err := strconv.ParseInt(sv, 10, 0)
-		if err != nil {
-			return &StatusFilter{}, fmt.Errorf("Status filter or matcher (-fc / -mc): invalid value %s", value)
+		if sv == "all" {
+			intvals = append(intvals, 0)
+		} else {
+			intval, err := strconv.ParseInt(sv, 10, 0)
+			if err != nil {
+				return &StatusFilter{}, fmt.Errorf("Status filter or matcher (-fc / -mc): invalid value %s", value)
+			}
+			intvals = append(intvals, intval)
 		}
-		intvals = append(intvals, intval)
 	}
 	return &StatusFilter{Value: intvals}, nil
 }
 
 func (f *StatusFilter) Filter(response *ffuf.Response) (bool, error) {
 	for _, iv := range f.Value {
+		if iv == 0 {
+			// Handle the "all" case
+			return true, nil
+		}
 		if iv == response.StatusCode {
 			return true, nil
 		}
@@ -36,7 +44,11 @@ func (f *StatusFilter) Filter(response *ffuf.Response) (bool, error) {
 func (f *StatusFilter) Repr() string {
 	var strval []string
 	for _, iv := range f.Value {
-		strval = append(strval, strconv.Itoa(int(iv)))
+		if iv == 0 {
+			strval = append(strval, "all")
+		} else {
+			strval = append(strval, strconv.Itoa(int(iv)))
+		}
 	}
 	return fmt.Sprintf("Response status: %s", strings.Join(strval, ","))
 }


### PR DESCRIPTION
Adds a new keyword for response status matcher - "all". This allows result matching based on blacklist filtering instead of the previous whitelist model. For example:
```
ffuf -w /path/to/wordlist -u https://example.com/FUZZ -mc all -fc 404,500
```
matches all response codes but 404 and 500.

Fixes: #21 