### PR TITLE
Feature to autocalibrate the size and word count filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The only dependency of ffuf is Go 1.11. No dependencies outside of Go standard l
 
 - master
    - New
+      - New CLI flag: -ac to autocalibrate response size and word filters based on few preset URLs.
 
    - Changed
 

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	StopOnErrors    bool
 	StopOnAll       bool
 	FollowRedirects bool
+	AutoCalibration bool
 	Delay           optRange
 	Filters         []FilterProvider
 	Matchers        []FilterProvider

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -26,5 +26,5 @@ type OutputProvider interface {
 	Progress(status string)
 	Error(errstring string)
 	Warning(warnstring string)
-	Result(resp Response) bool
+	Result(resp Response)
 }

--- a/pkg/ffuf/util.go
+++ b/pkg/ffuf/util.go
@@ -1,0 +1,16 @@
+package ffuf
+
+import (
+	"math/rand"
+)
+
+//used for random string generation in calibration function
+var chars = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randomString(n int) string {
+	s := make([]rune, n)
+	for i := range s {
+		s[i] = chars[rand.Intn(len(chars))]
+	}
+	return string(s)
+}

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -103,32 +103,10 @@ func (s *Stdoutput) Finalize() error {
 	return nil
 }
 
-func (s *Stdoutput) Result(resp ffuf.Response) bool {
-	matched := false
-	for _, m := range s.config.Matchers {
-		match, err := m.Filter(&resp)
-		if err != nil {
-			continue
-		}
-		if match {
-			matched = true
-		}
-	}
-	// The response was not matched, return before running filters
-	if !matched {
-		return false
-	}
-	for _, f := range s.config.Filters {
-		fv, err := f.Filter(&resp)
-		if err != nil {
-			continue
-		}
-		if fv {
-			return false
-		}
-	}
-	// Response survived the filtering, output the result
+func (s *Stdoutput) Result(resp ffuf.Response) {
+	// Output the result
 	s.printResult(resp)
+	// Check if we need the data later
 	if s.config.OutputFile != "" {
 		// No need to store results if we're not going to use them later
 		sResult := Result{
@@ -139,7 +117,6 @@ func (s *Stdoutput) Result(resp ffuf.Response) bool {
 		}
 		s.Results = append(s.Results, sResult)
 	}
-	return true
 }
 
 func (s *Stdoutput) printResult(resp ffuf.Response) {


### PR DESCRIPTION
New command line flag `-ac` to autocalibrate the filters. Calibration only happens, if the responses from the test requests are not filtered by other flags provided on command line.

Fixes: #20 