### PR TITLE
Support for more curl opts (-i, --data-ascii/-binary, -b/--cookie)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 ```
-        /'___\  /'___\           /'___\       
-       /\ \__/ /\ \__/  __  __  /\ \__/       
-       \ \ ,__\\ \ ,__\/\ \/\ \ \ \ ,__\      
-        \ \ \_/ \ \ \_/\ \ \_\ \ \ \ \_/      
-         \ \_\   \ \_\  \ \____/  \ \_\       
-          \/_/    \/_/   \/___/    \/_/       
+        /'___\  /'___\           /'___\
+       /\ \__/ /\ \__/  __  __  /\ \__/
+       \ \ ,__\\ \ ,__\/\ \/\ \ \ \ ,__\
+        \ \ \_/ \ \ \_/\ \ \_\ \ \ \ \_/
+         \ \_\   \ \_\  \ \____/  \ \_\
+          \/_/    \/_/   \/___/    \/_/
 ```
 
 
 # ffuf - Fuzz Faster U Fool
 
-A fast web fuzzer written in Go. 
+A fast web fuzzer written in Go.
 
 Heavily inspired by the great projects [gobuster](https://github.com/OJ/gobuster) and [wfuzz](https://github.com/xmendez/wfuzz).
 
@@ -101,6 +101,9 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
     	HTTP method to use (default "GET")
   -ac
     	Automatically calibrate filtering options
+  -b "NAME1=VALUE1; NAME2=VALUE2"
+    	Cookie data "NAME1=VALUE1; NAME2=VALUE2" for copy as curl functionality.
+    	Results unpredictable when combined with -H "Cookie: ..."
   -c	Colorize output.
   -compressed
     	Dummy flag for copy as curl functionality (ignored) (default true)
@@ -172,6 +175,8 @@ The only dependency of ffuf is Go 1.11. No dependencies outside of Go standard l
 - master
    - New
    - Changed
+      - New CLI flags: --compressed and -i, dummy flags that do nothing. for compatibility with copy as curl.
+      - New CLI flag: -b/--cookie, cookie data for compatibility with copy as curl.
 
 - v0.10
    - New

--- a/README.md
+++ b/README.md
@@ -101,9 +101,13 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
     	HTTP method to use (default "GET")
   -ac
     	Automatically calibrate filtering options
+  -i
+      Dummy flag for copy as curl functionality (ignored)
   -b "NAME1=VALUE1; NAME2=VALUE2"
     	Cookie data "NAME1=VALUE1; NAME2=VALUE2" for copy as curl functionality.
     	Results unpredictable when combined with -H "Cookie: ..."
+  -cookie
+      Cookie data (alias of -b)
   -c	Colorize output.
   -compressed
     	Dummy flag for copy as curl functionality (ignored) (default true)
@@ -175,7 +179,7 @@ The only dependency of ffuf is Go 1.11. No dependencies outside of Go standard l
 - master
    - New
    - Changed
-      - New CLI flags: --compressed and -i, dummy flags that do nothing. for compatibility with copy as curl.
+      - New CLI flag: -i, dummy flag that does nothing. for compatibility with copy as curl.
       - New CLI flag: -b/--cookie, cookie data for compatibility with copy as curl.
 
 - v0.10
@@ -183,7 +187,7 @@ The only dependency of ffuf is Go 1.11. No dependencies outside of Go standard l
       - New CLI flag: -ac to autocalibrate response size and word filters based on few preset URLs.
       - New CLI flag: -timeout to specify custom timeouts for all HTTP requests.
       - New CLI flag: --data for compatibility with copy as curl functionality of browsers.
-      - New CLI flag: --compress, dummy flag that does nothing. for compatibility with copy as curl.
+      - New CLI flag: --compressed, dummy flag that does nothing. for compatibility with copy as curl.
       - New CLI flags: --input-cmd, and --input-num to handle input generation using external commands. Mutators for example. Environment variable FFUF_NUM will be updated on every call of the command.
       - When --input-cmd is used, display position instead of the payload in results. The output file (of all formats) will include the payload in addition to the position however.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
     	Dummy flag for copy as curl functionality (ignored) (default true)
   -d string
     	POST data
+  -data-ascii
+      POST data (alias of -d)
+  -data-binary
+      POST data (alias of -d)
   -data string
     	POST data (alias of -d)
   -e string

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ type cliOptions struct {
 	proxyURL      string
 	outputFormat  string
 	headers       multiStringFlag
+	cookies       multiStringFlag
 	showVersion   bool
 }
 
@@ -64,10 +65,15 @@ func main() {
 	flag.StringVar(&opts.filterWords, "fw", "", "Filter by amount of words in response")
 	flag.StringVar(&conf.Data, "d", "", "POST data")
 	flag.StringVar(&conf.Data, "data", "", "POST data (alias of -d)")
+	flag.StringVar(&conf.Data, "data-ascii", "", "POST data (alias of -d)")
+	flag.StringVar(&conf.Data, "data-binary", "", "POST data (alias of -d)")
 	flag.BoolVar(&conf.Colors, "c", false, "Colorize output.")
 	flag.BoolVar(&ignored, "compressed", true, "Dummy flag for copy as curl functionality (ignored)")
 	flag.StringVar(&conf.InputCommand, "input-cmd", "", "Command producing the input. --input-num is required when using this input method. Overrides -w.")
 	flag.IntVar(&conf.InputNum, "input-num", 100, "Number of inputs to test. Used in conjunction with --input-cmd.")
+	flag.BoolVar(&ignored, "i", true, "Dummy flag for copy as curl functionality (ignored)")
+	flag.Var(&opts.cookies, "b", "Cookie data `\"NAME1=VALUE1; NAME2=VALUE2\"` for copy as curl functionality.\nResults unpredictable when combined with -H \"Cookie: ...\"")
+	flag.Var(&opts.cookies, "cookie", "Cookie data (alias of -b)")
 	flag.StringVar(&opts.matcherStatus, "mc", "200,204,301,302,307,401,403", "Match HTTP status codes from respose, use \"all\" to match every response code.")
 	flag.StringVar(&opts.matcherSize, "ms", "", "Match HTTP response size")
 	flag.StringVar(&opts.matcherRegexp, "mr", "", "Match regexp")
@@ -206,6 +212,10 @@ func prepareConfig(parseOpts *cliOptions, conf *ffuf.Config) error {
 		conf.Extensions = extensions
 	}
 
+	// Convert cookies to a header
+	if len(parseOpts.cookies) > 0 {
+		parseOpts.headers.Set("Cookie: " + strings.Join(parseOpts.cookies, "; "))
+	}
 	//Prepare headers
 	for _, v := range parseOpts.headers {
 		hs := strings.SplitN(v, ":", 2)


### PR DESCRIPTION
At least "Copy as curl command" functionality in BurpSuite uses --data-binary/--data-ascii, -i and -b flags. Added support (-i is ignored, -b/--cookie adds Cookie header, --data-* are an alias of -d) for those. Additionally, fixed the misspelled --compressed in the README.