### PR TITLE
New input provider --input-cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
   -u string
     	Target URL
   -w string
-    	Wordlist path
+    	Wordlist file path or - to read from standard input
   -x string
     	HTTP Proxy URL
 ```

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The only dependency of ffuf is Go 1.11. No dependencies outside of Go standard l
       - New CLI flag: --data for compatibility with copy as curl functionality of browsers.
       - New CLI flag: --compress, dummy flag that does nothing. for compatibility with copy as curl.
       - New CLI flags: --input-cmd, and --input-num to handle input generation using external commands. Mutators for example. Environment variable FFUF_NUM will be updated on every call of the command.
+      - When --input-cmd is used, display position instead of the payload in results. The output file (of all formats) will include the payload in addition to the position however.
 
    - Changed
       - Wordlist can also be read from standard input

--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ This is a very straightforward operation, again by using the `FUZZ` keyword. Thi
 ffuf -w /path/to/postdata.txt -X POST -d "username=admin\&password=FUZZ" https://target/login.php -fc 401
 ```
 
+### Using external mutator to produce test cases
+
+For this example, we'll fuzz JSON data that's sent over POST. [Radamsa](https://gitlab.com/akihe/radamsa) is used as the mutator.
+
+When `--input-cmd` is used, ffuf will display matches as their position. This same position value will be available for the callee as an environment variable `$FFUF_NUM`. We'll use this position value as the seed for the mutator. Files example1.txt and example2.txt contain valid JSON payloads. We are matching all the responses, but filtering out response code `400 - Bad request`:
+
+```
+ffuf --input-cmd 'radamsa --seed $FFUF_NUM example1.txt example2.txt' -H "Content-Type: application/json" -X POST -u https://ffuf.io.fi/ -mc all -fc 400
+```
+
+It of course isn't very efficient to call the mutator for each payload, so we can also pre-generate the payloads, still using [Radamsa](https://gitlab.com/akihe/radamsa) as an example:
+
+```
+# Generate 1000 example payloads
+radamsa -n 1000 -o %n.txt example1.txt example2.txt
+
+# This results into files 1.txt ... 1000.txt
+# Now we can just read the payload data in a loop from file for ffuf
+
+ffuf --input-cmd 'cat $FFUF_NUM.txt' -H "Content-Type: application/json" -X POST -u https://ffuf.io.fi/ -mc all -fc 400
+```
+
 ## Usage
 
 To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-u`), headers (`-H`), or POST data (`-d`).

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ ffuf -w /path/to/postdata.txt -X POST -d "username=admin\&password=FUZZ" https:/
 ## Usage
 
 To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-u`), headers (`-H`), or POST data (`-d`).
+
 ```
   -D	DirSearch style wordlist compatibility mode. Used in conjunction with -e flag. Replaces %EXT% in wordlist entry with each of the extensions provided by -e.
   -H "Name: Value"
@@ -79,8 +80,12 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
   -ac
     	Automatically calibrate filtering options
   -c	Colorize output.
+  -compressed
+    	Dummy flag for copy as curl functionality (ignored) (default true)
   -d string
-    	POST data.
+    	POST data
+  -data string
+    	POST data (alias of -d)
   -e string
     	Comma separated list of extensions to apply. Each extension provided will extend the wordlist entry once.
   -fc string
@@ -91,6 +96,12 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
     	Filter HTTP response size
   -fw string
     	Filter by amount of words in response
+  -input-cmd string
+    	Command producing the input. --input-num is required when using this input method. Overrides -w.
+  -input-cmd-shell string
+    	Shell to use to execute input command. (default "/bin/sh")
+  -input-num int
+    	Number of inputs to test. Used in conjunction with --input-cmd. (default 100)
   -k	TLS identity verification
   -mc string
     	Match HTTP status codes from respose, use "all" to match every response code. (default "200,204,301,302,307,401,403")
@@ -121,7 +132,7 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
   -u string
     	Target URL
   -w string
-    	Wordlist file path or - to read from standard input
+    	Wordlist path
   -x string
     	HTTP Proxy URL
 ```
@@ -144,6 +155,7 @@ The only dependency of ffuf is Go 1.11. No dependencies outside of Go standard l
       - New CLI flag: -timeout to specify custom timeouts for all HTTP requests.
       - New CLI flag: --data for compatibility with copy as curl functionality of browsers.
       - New CLI flag: --compress, dummy flag that does nothing. for compatibility with copy as curl.
+      - New CLI flags: --input-cmd, --input-cmd-shell and --input-num to handle input generation using external commands. Mutators for example.
 
    - Changed
       - Wordlist can also be read from standard input

--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
     	Filter by amount of words in response
   -input-cmd string
     	Command producing the input. --input-num is required when using this input method. Overrides -w.
-  -input-cmd-shell string
-    	Shell to use to execute input command. (default "/bin/sh")
   -input-num int
     	Number of inputs to test. Used in conjunction with --input-cmd. (default 100)
   -k	TLS identity verification
@@ -155,7 +153,7 @@ The only dependency of ffuf is Go 1.11. No dependencies outside of Go standard l
       - New CLI flag: -timeout to specify custom timeouts for all HTTP requests.
       - New CLI flag: --data for compatibility with copy as curl functionality of browsers.
       - New CLI flag: --compress, dummy flag that does nothing. for compatibility with copy as curl.
-      - New CLI flags: --input-cmd, --input-cmd-shell and --input-num to handle input generation using external commands. Mutators for example.
+      - New CLI flags: --input-cmd, and --input-num to handle input generation using external commands. Mutators for example. Environment variable FFUF_NUM will be updated on every call of the command.
 
    - Changed
       - Wordlist can also be read from standard input

--- a/main.go
+++ b/main.go
@@ -67,7 +67,6 @@ func main() {
 	flag.BoolVar(&conf.Colors, "c", false, "Colorize output.")
 	flag.BoolVar(&ignored, "compressed", true, "Dummy flag for copy as curl functionality (ignored)")
 	flag.StringVar(&conf.InputCommand, "input-cmd", "", "Command producing the input. --input-num is required when using this input method. Overrides -w.")
-	flag.StringVar(&conf.InputCommandShell, "input-cmd-shell", "/bin/sh", "Shell to use to execute input command.")
 	flag.IntVar(&conf.InputNum, "input-num", 100, "Number of inputs to test. Used in conjunction with --input-cmd.")
 	flag.StringVar(&opts.matcherStatus, "mc", "200,204,301,302,307,401,403", "Match HTTP status codes from respose, use \"all\" to match every response code.")
 	flag.StringVar(&opts.matcherSize, "ms", "", "Match HTTP response size")

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	flag.BoolVar(&conf.DirSearchCompat, "D", false, "DirSearch style wordlist compatibility mode. Used in conjunction with -e flag. Replaces %EXT% in wordlist entry with each of the extensions provided by -e.")
 	flag.Var(&opts.headers, "H", "Header `\"Name: Value\"`, separated by colon. Multiple -H flags are accepted.")
 	flag.StringVar(&conf.Url, "u", "", "Target URL")
-	flag.StringVar(&conf.Wordlist, "w", "", "Wordlist path")
+	flag.StringVar(&conf.Wordlist, "w", "", "Wordlist file path or - to read from standard input")
 	flag.BoolVar(&conf.TLSVerify, "k", false, "TLS identity verification")
 	flag.StringVar(&opts.delay, "p", "", "Seconds of `delay` between requests, or a range of random delay. For example \"0.1\" or \"0.1-2.0\"")
 	flag.StringVar(&opts.filterStatus, "fc", "", "Filter HTTP status codes from response")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -28,7 +28,6 @@ type Config struct {
 	Colors            bool
 	Wordlist          string
 	InputCommand      string
-	InputCommandShell string
 	InputNum          int
 	OutputFile        string
 	OutputFormat      string
@@ -63,7 +62,6 @@ func NewConfig(ctx context.Context) Config {
 	conf.StopOnAll = false
 	conf.FollowRedirects = false
 	conf.InputCommand = ""
-	conf.InputCommandShell = ""
 	conf.InputNum = 0
 	conf.ProxyURL = http.ProxyFromEnvironment
 	conf.Filters = make([]FilterProvider, 0)

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -27,6 +27,9 @@ type Config struct {
 	Quiet             bool
 	Colors            bool
 	Wordlist          string
+	InputCommand      string
+	InputCommandShell string
+	InputNum          int
 	OutputFile        string
 	OutputFormat      string
 	StopOn403         bool
@@ -59,6 +62,9 @@ func NewConfig(ctx context.Context) Config {
 	conf.StopOnErrors = false
 	conf.StopOnAll = false
 	conf.FollowRedirects = false
+	conf.InputCommand = ""
+	conf.InputCommandShell = ""
+	conf.InputNum = 0
 	conf.ProxyURL = http.ProxyFromEnvironment
 	conf.Filters = make([]FilterProvider, 0)
 	conf.Delay = optRange{0, 0, false, false}

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -15,6 +15,7 @@ type RunnerProvider interface {
 //InputProvider interface handles the input data for RunnerProvider
 type InputProvider interface {
 	Next() bool
+	Position() int
 	Value() []byte
 	Total() int
 }

--- a/pkg/ffuf/request.go
+++ b/pkg/ffuf/request.go
@@ -2,11 +2,12 @@ package ffuf
 
 // Request holds the meaningful data that is passed for runner for making the query
 type Request struct {
-	Method  string
-	Url     string
-	Headers map[string]string
-	Data    []byte
-	Input   []byte
+	Method   string
+	Url      string
+	Headers  map[string]string
+	Data     []byte
+	Input    []byte
+	Position int
 }
 
 func NewRequest(conf *Config) Request {

--- a/pkg/input/command.go
+++ b/pkg/input/command.go
@@ -2,7 +2,9 @@ package input
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
+	"strconv"
 
 	"github.com/ffuf/ffuf/pkg/ffuf"
 )
@@ -31,7 +33,8 @@ func (c *CommandInput) Next() bool {
 //Value returns the input from command stdoutput
 func (c *CommandInput) Value() []byte {
 	var stdout bytes.Buffer
-	cmd := exec.Command(c.config.InputCommandShell, "-c", c.config.InputCommand)
+	os.Setenv("FFUF_NUM", strconv.Itoa(c.count))
+	cmd := exec.Command(SHELL_CMD, SHELL_ARG, c.config.InputCommand)
 	cmd.Stdout = &stdout
 	err := cmd.Run()
 	if err != nil {

--- a/pkg/input/command.go
+++ b/pkg/input/command.go
@@ -21,6 +21,11 @@ func NewCommandInput(conf *ffuf.Config) (*CommandInput, error) {
 	return &cmd, nil
 }
 
+//Position will return the current position in the input list
+func (c *CommandInput) Position() int {
+	return c.count
+}
+
 //Next will increment the cursor position, and return a boolean telling if there's iterations left
 func (c *CommandInput) Next() bool {
 	c.count++

--- a/pkg/input/command.go
+++ b/pkg/input/command.go
@@ -1,0 +1,46 @@
+package input
+
+import (
+	"bytes"
+	"os/exec"
+
+	"github.com/ffuf/ffuf/pkg/ffuf"
+)
+
+type CommandInput struct {
+	config *ffuf.Config
+	count  int
+}
+
+func NewCommandInput(conf *ffuf.Config) (*CommandInput, error) {
+	var cmd CommandInput
+	cmd.config = conf
+	cmd.count = -1
+	return &cmd, nil
+}
+
+//Next will increment the cursor position, and return a boolean telling if there's iterations left
+func (c *CommandInput) Next() bool {
+	c.count++
+	if c.count >= c.config.InputNum {
+		return false
+	}
+	return true
+}
+
+//Value returns the input from command stdoutput
+func (c *CommandInput) Value() []byte {
+	var stdout bytes.Buffer
+	cmd := exec.Command(c.config.InputCommandShell, "-c", c.config.InputCommand)
+	cmd.Stdout = &stdout
+	err := cmd.Run()
+	if err != nil {
+		return []byte("")
+	}
+	return stdout.Bytes()
+}
+
+//Total returns the size of wordlist
+func (c *CommandInput) Total() int {
+	return c.config.InputNum
+}

--- a/pkg/input/const.go
+++ b/pkg/input/const.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package input
+
+const (
+	SHELL_CMD = "/bin/sh"
+	SHELL_ARG = "-c"
+)

--- a/pkg/input/const_windows.go
+++ b/pkg/input/const_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package input
+
+const (
+	SHELL_CMD = "cmd.exe"
+	SHELL_ARG = "/C"
+)

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -5,6 +5,10 @@ import (
 )
 
 func NewInputProviderByName(name string, conf *ffuf.Config) (ffuf.InputProvider, error) {
-	// We have only one inputprovider at the moment
-	return NewWordlistInput(conf)
+	if name == "command" {
+		return NewCommandInput(conf)
+	} else {
+		// Default to wordlist
+		return NewWordlistInput(conf)
+	}
 }

--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -37,6 +37,11 @@ func NewWordlistInput(conf *ffuf.Config) (*WordlistInput, error) {
 	return &wl, err
 }
 
+//Position will return the current position in the input list
+func (w *WordlistInput) Position() int {
+	return w.position
+}
+
 //Next will increment the cursor position, and return a boolean telling if there's words left in the list
 func (w *WordlistInput) Next() bool {
 	w.position++

--- a/pkg/output/file_csv.go
+++ b/pkg/output/file_csv.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ffuf/ffuf/pkg/ffuf"
 )
 
-var header = []string{"input", "status_code", "content_length", "content_words"}
+var header = []string{"input", "position", "status_code", "content_length", "content_words"}
 
 func writeCSV(config *ffuf.Config, res []Result, encode bool) error {
 	f, err := os.Create(config.OutputFile)
@@ -44,6 +44,7 @@ func base64encode(in string) string {
 func toCSV(r Result) []string {
 	return []string{
 		r.Input,
+		strconv.Itoa(r.Position),
 		strconv.FormatInt(r.StatusCode, 10),
 		strconv.FormatInt(r.ContentLength, 10),
 		strconv.FormatInt(r.ContentWords, 10),


### PR DESCRIPTION
This new input provider enables users to use mutators or any other means to produce the desired input data. 

New command line flags:
--input-cmd  - The command that produces the ffuf input data to stdout
--input-num - Number of iterations to call the command

For each call, an environment variable `$FFUF_NUM` will be set. This can be used to produce unique input data for each call. Examples are added to README as well.