### PR TITLE
Custom autocalibration strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
     	HTTP method to use (default "GET")
   -ac
     	Automatically calibrate filtering options
+  -acc
+      Custom auto-calibration string. Can be used multiple times. Implies -ac
   -i
       Dummy flag for copy as curl functionality (ignored)
   -b "NAME1=VALUE1; NAME2=VALUE2"

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ The only dependency of ffuf is Go 1.11. No dependencies outside of Go standard l
 
   - New
     - New CLI flag: -l, shows target location of redirect responses
+    - New CLI flac: -acc, custom auto-calibration strings
   - Changed
     - New CLI flag: -i, dummy flag that does nothing. for compatibility with copy as curl.
     - New CLI flag: -b/--cookie, cookie data for compatibility with copy as curl.

--- a/main.go
+++ b/main.go
@@ -18,21 +18,22 @@ import (
 )
 
 type cliOptions struct {
-	extensions    string
-	delay         string
-	filterStatus  string
-	filterSize    string
-	filterRegexp  string
-	filterWords   string
-	matcherStatus string
-	matcherSize   string
-	matcherRegexp string
-	matcherWords  string
-	proxyURL      string
-	outputFormat  string
-	headers       multiStringFlag
-	cookies       multiStringFlag
-	showVersion   bool
+	extensions             string
+	delay                  string
+	filterStatus           string
+	filterSize             string
+	filterRegexp           string
+	filterWords            string
+	matcherStatus          string
+	matcherSize            string
+	matcherRegexp          string
+	matcherWords           string
+	proxyURL               string
+	outputFormat           string
+	headers                multiStringFlag
+	cookies                multiStringFlag
+	AutoCalibrationStrings multiStringFlag
+	showVersion            bool
 }
 
 type multiStringFlag []string
@@ -89,6 +90,7 @@ func main() {
 	flag.BoolVar(&conf.StopOnAll, "sa", false, "Stop on all error cases. Implies -sf and -se")
 	flag.BoolVar(&conf.FollowRedirects, "r", false, "Follow redirects")
 	flag.BoolVar(&conf.AutoCalibration, "ac", false, "Automatically calibrate filtering options")
+	flag.Var(&opts.AutoCalibrationStrings, "acc", "Custom auto-calibration string. Can be used multiple times. Implies -ac")
 	flag.IntVar(&conf.Threads, "t", 40, "Number of concurrent threads.")
 	flag.IntVar(&conf.Timeout, "timeout", 10, "HTTP request timeout in seconds.")
 	flag.BoolVar(&opts.showVersion, "V", false, "Show version information.")
@@ -283,6 +285,13 @@ func prepareConfig(parseOpts *cliOptions, conf *ffuf.Config) error {
 		if !found {
 			errs.Add(fmt.Errorf("Unknown output file format (-of): %s", parseOpts.outputFormat))
 		}
+	}
+
+	// Auto-calibration strings
+	conf.AutoCalibrationStrings = parseOpts.AutoCalibrationStrings
+	// Using -acc implies -ac
+	if len(conf.AutoCalibrationStrings) > 0 {
+		conf.AutoCalibration = true
 	}
 
 	// Handle copy as curl situation where POST method is implied by --data flag. If method is set to anything but GET, NOOP

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -75,31 +75,3 @@ func NewConfig(ctx context.Context) Config {
 	conf.DirSearchCompat = false
 	return conf
 }
-
-type CliOptions struct {
-	extensions    string
-	delay         string
-	filterStatus  string
-	filterSize    string
-	filterRegexp  string
-	filterWords   string
-	matcherStatus string
-	matcherSize   string
-	matcherRegexp string
-	matcherWords  string
-	proxyURL      string
-	outputFormat  string
-	headers       multiStringFlag
-	showVersion   bool
-}
-
-type multiStringFlag []string
-
-func (m *multiStringFlag) String() string {
-	return ""
-}
-
-func (m *multiStringFlag) Set(value string) error {
-	*m = append(*m, value)
-	return nil
-}

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -16,36 +16,37 @@ type optRange struct {
 }
 
 type Config struct {
-	StaticHeaders        map[string]string
-	FuzzHeaders          map[string]string
-	Extensions           []string
-	DirSearchCompat      bool
-	Method               string
-	Url                  string
-	TLSVerify            bool
-	Data                 string
-	Quiet                bool
-	Colors               bool
-	Wordlist             string
-	InputCommand         string
-	InputNum             int
-	OutputFile           string
-	OutputFormat         string
-	StopOn403            bool
-	StopOnErrors         bool
-	StopOnAll            bool
-	FollowRedirects      bool
-	AutoCalibration      bool
-	ShowRedirectLocation bool
-	Timeout              int
-	ProgressFrequency    int
-	Delay                optRange
-	Filters              []FilterProvider
-	Matchers             []FilterProvider
-	Threads              int
-	Context              context.Context
-	ProxyURL             func(*http.Request) (*url.URL, error)
-	CommandLine          string
+	StaticHeaders          map[string]string
+	FuzzHeaders            map[string]string
+	Extensions             []string
+	DirSearchCompat        bool
+	Method                 string
+	Url                    string
+	TLSVerify              bool
+	Data                   string
+	Quiet                  bool
+	Colors                 bool
+	Wordlist               string
+	InputCommand           string
+	InputNum               int
+	OutputFile             string
+	OutputFormat           string
+	StopOn403              bool
+	StopOnErrors           bool
+	StopOnAll              bool
+	FollowRedirects        bool
+	AutoCalibration        bool
+	AutoCalibrationStrings []string
+	ShowRedirectLocation   bool
+	Timeout                int
+	ProgressFrequency      int
+	Delay                  optRange
+	Filters                []FilterProvider
+	Matchers               []FilterProvider
+	Threads                int
+	Context                context.Context
+	ProxyURL               func(*http.Request) (*url.URL, error)
+	CommandLine            string
 }
 
 func NewConfig(ctx context.Context) Config {

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -194,10 +194,19 @@ func (j *Job) runTask(input []byte, position int, retried bool) {
 //CalibrateResponses returns slice of Responses for randomly generated filter autocalibration requests
 func (j *Job) CalibrateResponses() ([]Response, error) {
 	cInputs := make([]string, 0)
-	cInputs = append(cInputs, "admin"+RandomString(16)+"/")
-	cInputs = append(cInputs, ".htaccess"+RandomString(16))
-	cInputs = append(cInputs, RandomString(16)+"/")
-	cInputs = append(cInputs, RandomString(16))
+	if len(j.Config.AutoCalibrationStrings) < 1 {
+		cInputs = append(cInputs, "admin"+RandomString(16)+"/")
+		cInputs = append(cInputs, ".htaccess"+RandomString(16))
+		cInputs = append(cInputs, RandomString(16)+"/")
+		cInputs = append(cInputs, RandomString(16))
+	} else {
+		for _, str := range j.Config.AutoCalibrationStrings {
+			cInputs = append(cInputs, "admin"+str+"/")
+			cInputs = append(cInputs, ".htaccess"+str)
+			cInputs = append(cInputs, str+"/")
+			cInputs = append(cInputs, str)
+		}
+	}
 
 	results := make([]Response, 0)
 	for _, input := range cInputs {

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -200,12 +200,7 @@ func (j *Job) CalibrateResponses() ([]Response, error) {
 		cInputs = append(cInputs, RandomString(16)+"/")
 		cInputs = append(cInputs, RandomString(16))
 	} else {
-		for _, str := range j.Config.AutoCalibrationStrings {
-			cInputs = append(cInputs, "admin"+str+"/")
-			cInputs = append(cInputs, ".htaccess"+str)
-			cInputs = append(cInputs, str+"/")
-			cInputs = append(cInputs, str)
-		}
+		cInputs = append(cInputs, j.Config.AutoCalibrationStrings...)
 	}
 
 	results := make([]Response, 0)


### PR DESCRIPTION
Added support for using multiple user-supplied auto-calibration strings. Each string is used in place of curent random strings, creating four calibration requests per string. Command line flag -acc, implies -ac.

Like so:
ffuf -w wordlist.txt -u http://www.example.com/FUZZ -acc foobar -acc xyzzy