### PR TITLE
Add option for -debug-log.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
     	Wordlist file path or - to read from standard input
   -x string
     	HTTP Proxy URL
+  -debug-log string
+      Write the debug logging information to the specified file.
 ```
 
 eg. `ffuf -u https://example.org/FUZZ -w /path/to/wordlist`
@@ -183,10 +185,12 @@ The only dependency of ffuf is Go 1.11. No dependencies outside of Go standard l
 
   - New
     - New CLI flag: -l, shows target location of redirect responses
+    - New CLI flag: -debug-log, writes the debug logging to the specified file.
   - Changed
     - New CLI flag: -i, dummy flag that does nothing. for compatibility with copy as curl.
     - New CLI flag: -b/--cookie, cookie data for compatibility with copy as curl.
     - Filtering and matching by status code, response size or word count now allow using ranges in addition to single values
+    - Changed the internal logging information to be discarded, and can be written to a file with the new `-debug-log` flag.
 
 - v0.10
 

--- a/main.go
+++ b/main.go
@@ -20,23 +20,22 @@ import (
 )
 
 type cliOptions struct {
-	extensions     string
-	delay          string
-	filterStatus   string
-	filterSize     string
-	filterRegexp   string
-	filterWords    string
-	matcherStatus  string
-	matcherSize    string
-	matcherRegexp  string
-	matcherWords   string
-	proxyURL       string
-	outputFormat   string
-	headers        multiStringFlag
-	cookies        multiStringFlag
-	showVersion    bool
-	disableLogging bool
-	logFile        string
+	extensions    string
+	delay         string
+	filterStatus  string
+	filterSize    string
+	filterRegexp  string
+	filterWords   string
+	matcherStatus string
+	matcherSize   string
+	matcherRegexp string
+	matcherWords  string
+	proxyURL      string
+	outputFormat  string
+	headers       multiStringFlag
+	cookies       multiStringFlag
+	showVersion   bool
+	debugLog      string
 }
 
 type multiStringFlag []string
@@ -95,23 +94,23 @@ func main() {
 	flag.IntVar(&conf.Threads, "t", 40, "Number of concurrent threads.")
 	flag.IntVar(&conf.Timeout, "timeout", 10, "HTTP request timeout in seconds.")
 	flag.BoolVar(&opts.showVersion, "V", false, "Show version information.")
-	flag.BoolVar(&opts.disableLogging, "disable-logging", false, "Disable internal logging.")
-	flag.StringVar(&opts.logFile, "l", "", "Write all internal logging to a file.")
-	flag.StringVar(&opts.logFile, "log-file", "", "Alias for -l.")
+	flag.StringVar(&opts.debugLog, "debug-log", "", "Write all of the internal logging to the specified file.")
 	flag.Parse()
 	if opts.showVersion {
 		fmt.Printf("ffuf version: %s\n", ffuf.VERSION)
 		os.Exit(0)
 	}
-	if opts.disableLogging {
-		log.SetOutput(ioutil.Discard)
-	} else if len(opts.logFile) != 0 {
-		f, err := os.OpenFile(opts.logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if len(opts.debugLog) != 0 {
+		f, err := os.OpenFile(opts.debugLog, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Encountered error(s): %s\n", err)
+			fmt.Fprintf(os.Stderr, "Disabling logging, encountered error(s): %s\n", err)
+			log.SetOutput(ioutil.Discard)
+		} else {
+			log.SetOutput(f)
+			defer f.Close()
 		}
-		log.SetOutput(f)
-		defer f.Close()
+	} else {
+		log.SetOutput(ioutil.Discard)
 	}
 	if err := prepareConfig(&opts, &conf); err != nil {
 		fmt.Fprintf(os.Stderr, "Encountered error(s): %s\n", err)


### PR DESCRIPTION
Both of these options have to do with the logging surrounding issues
such as #39. Where in that issue the server was returning data after
the connection was closed. Therefore, I added two options one for
completely disabling all of the internal logging functionality aka
sending it to /dev/null. Another for writing the logging information
to a file so it can be retrieved later if need be.