### PR TITLE
Multiple wordlist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ ffuf --input-cmd 'cat $FFUF_NUM.txt' -H "Content-Type: application/json" -X POST
 To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-u`), headers (`-H`), or POST data (`-d`).
 
 ```
+Usage of ./ffuf:
   -D	DirSearch style wordlist compatibility mode. Used in conjunction with -e flag. Replaces %EXT% in wordlist entry with each of the extensions provided by -e.
   -H "Name: Value"
     	Header "Name: Value", separated by colon. Multiple -H flags are accepted.
@@ -100,57 +101,59 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
     	HTTP method to use (default "GET")
   -ac
     	Automatically calibrate filtering options
-  -acc
-      Custom auto-calibration string. Can be used multiple times. Implies -ac
-  -i
-      Dummy flag for copy as curl functionality (ignored)
+  -acc value
+    	Custom auto-calibration string. Can be used multiple times. Implies -ac
   -b "NAME1=VALUE1; NAME2=VALUE2"
     	Cookie data "NAME1=VALUE1; NAME2=VALUE2" for copy as curl functionality.
     	Results unpredictable when combined with -H "Cookie: ..."
-  -cookie
-      Cookie data (alias of -b)
   -c	Colorize output.
   -compressed
     	Dummy flag for copy as curl functionality (ignored) (default true)
+  -cookie value
+    	Cookie data (alias of -b)
   -d string
     	POST data
-  -data-ascii
-      POST data (alias of -d)
-  -data-binary
-      POST data (alias of -d)
   -data string
     	POST data (alias of -d)
+  -data-ascii string
+    	POST data (alias of -d)
+  -data-binary string
+    	POST data (alias of -d)
+  -debug-log string
+    	Write all of the internal logging to the specified file.
   -e string
     	Comma separated list of extensions to apply. Each extension provided will extend the wordlist entry once.
   -fc string
     	Filter HTTP status codes from response. Comma separated list of codes and ranges
+  -fl string
+    	Filter by amount of lines in response. Comma separated list of line counts and ranges
   -fr string
     	Filter regexp
   -fs string
     	Filter HTTP response size. Comma separated list of sizes and ranges
   -fw string
     	Filter by amount of words in response. Comma separated list of word counts and ranges
-  -fl string
-    	Filter by amount of lines in response. Comma separated list of line counts and ranges
-  -input-cmd string
+  -i	Dummy flag for copy as curl functionality (ignored) (default true)
+  -input-cmd value
     	Command producing the input. --input-num is required when using this input method. Overrides -w.
   -input-num int
     	Number of inputs to test. Used in conjunction with --input-cmd. (default 100)
   -k	TLS identity verification
+  -l	Show target location of redirect responses
   -mc string
     	Match HTTP status codes from respose, use "all" to match every response code. (default "200,204,301,302,307,401,403")
+  -ml string
+    	Match amount of lines in response
   -mr string
     	Match regexp
   -ms string
     	Match HTTP response size
   -mw string
     	Match amount of words in response
-  -ml string
-    	Match amount of lines in response
   -o string
     	Write output to file
   -of string
-    	Output file format. Available formats: json, csv, ecsv (default "json")
+    	Output file format. Available formats: json, html, md, csv, ecsv (default "json")
   -p delay
     	Seconds of delay between requests, or a range of random delay. For example "0.1" or "0.1-2.0"
   -r	Follow redirects
@@ -167,12 +170,10 @@ To define the test case for ffuf, use the keyword `FUZZ` anywhere in the URL (`-
     	HTTP request timeout in seconds. (default 10)
   -u string
     	Target URL
-  -w string
-    	Wordlist file path or - to read from standard input
+  -w value
+    	Wordlist file path and (optional) custom fuzz keyword, using colon as delimiter. Use file path '-' to read from standard input. Can be supplied multiple times. Format: '/path/to/wordlist:KEYWORD'
   -x string
     	HTTP Proxy URL
-  -debug-log string
-      Write the debug logging information to the specified file.
 ```
 
 eg. `ffuf -u https://example.org/FUZZ -w /path/to/wordlist`

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The only dependency of ffuf is Go 1.11. No dependencies outside of Go standard l
     - New CLI flac: -acc, custom auto-calibration strings
     - New CLI flag: -debug-log, writes the debug logging to the specified file.
     - New CLI flags -ml and -fl, filters/matches line count in response
+    - Ability to use multiple wordlists / keywords by defining multiple -w command line flags. The if no keyword is defined, the default is FUZZ to keep backwards compatibility. Example: `-w "wordlists/custom.txt:CUSTOM" -H "RandomHeader: CUSTOM"`.
 
   - Changed
 

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 	flag.BoolVar(&conf.DirSearchCompat, "D", false, "DirSearch style wordlist compatibility mode. Used in conjunction with -e flag. Replaces %EXT% in wordlist entry with each of the extensions provided by -e.")
 	flag.Var(&opts.headers, "H", "Header `\"Name: Value\"`, separated by colon. Multiple -H flags are accepted.")
 	flag.StringVar(&conf.Url, "u", "", "Target URL")
-	flag.Var(&opts.wordlists, "w", "Wordlist file path or - to read from standard input")
+	flag.Var(&opts.wordlists, "w", "Wordlist file path and (optional) custom fuzz keyword, using colon as delimiter. Use file path '-' to read from standard input. Can be supplied multiple times. Format: '/path/to/wordlist:KEYWORD'")
 	flag.BoolVar(&conf.TLSVerify, "k", false, "TLS identity verification")
 	flag.StringVar(&opts.delay, "p", "", "Seconds of `delay` between requests, or a range of random delay. For example \"0.1\" or \"0.1-2.0\"")
 	flag.StringVar(&opts.filterStatus, "fc", "", "Filter HTTP status codes from response. Comma separated list of codes and ranges")
@@ -252,14 +252,14 @@ func prepareConfig(parseOpts *cliOptions, conf *ffuf.Config) error {
 		if len(wl) == 2 {
 			conf.InputProviders = append(conf.InputProviders, ffuf.InputProviderConfig{
 				Name:    "wordlist",
-				Keyword: wl[0],
-				Value:   wl[1],
+				Value:   wl[0],
+				Keyword: wl[1],
 			})
 		} else {
 			conf.InputProviders = append(conf.InputProviders, ffuf.InputProviderConfig{
 				Name:    "wordlist",
-				Keyword: "FUZZ",
 				Value:   wl[0],
+				Keyword: "FUZZ",
 			})
 		}
 	}
@@ -268,15 +268,15 @@ func prepareConfig(parseOpts *cliOptions, conf *ffuf.Config) error {
 		if len(ic) == 2 {
 			conf.InputProviders = append(conf.InputProviders, ffuf.InputProviderConfig{
 				Name:    "command",
-				Keyword: ic[0],
-				Value:   ic[1],
+				Value:   ic[0],
+				Keyword: ic[1],
 			})
 			conf.CommandKeywords = append(conf.CommandKeywords, ic[0])
 		} else {
 			conf.InputProviders = append(conf.InputProviders, ffuf.InputProviderConfig{
 				Name:    "command",
-				Keyword: "FUZZ",
 				Value:   ic[0],
+				Keyword: "FUZZ",
 			})
 			conf.CommandKeywords = append(conf.CommandKeywords, "FUZZ")
 		}

--- a/main.go
+++ b/main.go
@@ -156,10 +156,10 @@ func prepareJob(conf *ffuf.Config) (*ffuf.Job, error) {
 	runprovider := runner.NewRunnerByName("http", conf)
 	// Initialize the correct inputprovider
 	for _, v := range conf.InputProviders {
-		inputprovider.AddProvider(v)
-	}
-	if err != nil {
-		errs.Add(fmt.Errorf("%s", err))
+		err = inputprovider.AddProvider(v)
+		if err != nil {
+			errs.Add(fmt.Errorf("%s", err))
+		}
 	}
 	// We only have stdout outputprovider right now
 	outprovider := output.NewOutputProviderByName("stdout", conf)

--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ type cliOptions struct {
 	matcherWords  string
 	proxyURL      string
 	outputFormat  string
+	wordlists     multiStringFlag
+	inputcommands multiStringFlag
 	headers       multiStringFlag
 	cookies       multiStringFlag
 	showVersion   bool
@@ -56,7 +58,7 @@ func main() {
 	flag.BoolVar(&conf.DirSearchCompat, "D", false, "DirSearch style wordlist compatibility mode. Used in conjunction with -e flag. Replaces %EXT% in wordlist entry with each of the extensions provided by -e.")
 	flag.Var(&opts.headers, "H", "Header `\"Name: Value\"`, separated by colon. Multiple -H flags are accepted.")
 	flag.StringVar(&conf.Url, "u", "", "Target URL")
-	flag.StringVar(&conf.Wordlist, "w", "", "Wordlist file path or - to read from standard input")
+	flag.Var(&opts.wordlists, "w", "Wordlist file path or - to read from standard input")
 	flag.BoolVar(&conf.TLSVerify, "k", false, "TLS identity verification")
 	flag.StringVar(&opts.delay, "p", "", "Seconds of `delay` between requests, or a range of random delay. For example \"0.1\" or \"0.1-2.0\"")
 	flag.StringVar(&opts.filterStatus, "fc", "", "Filter HTTP status codes from response. Comma separated list of codes and ranges")
@@ -69,7 +71,7 @@ func main() {
 	flag.StringVar(&conf.Data, "data-binary", "", "POST data (alias of -d)")
 	flag.BoolVar(&conf.Colors, "c", false, "Colorize output.")
 	flag.BoolVar(&ignored, "compressed", true, "Dummy flag for copy as curl functionality (ignored)")
-	flag.StringVar(&conf.InputCommand, "input-cmd", "", "Command producing the input. --input-num is required when using this input method. Overrides -w.")
+	flag.Var(&opts.inputcommands, "input-cmd", "Command producing the input. --input-num is required when using this input method. Overrides -w.")
 	flag.IntVar(&conf.InputNum, "input-num", 100, "Number of inputs to test. Used in conjunction with --input-cmd.")
 	flag.BoolVar(&ignored, "i", true, "Dummy flag for copy as curl functionality (ignored)")
 	flag.Var(&opts.cookies, "b", "Cookie data `\"NAME1=VALUE1; NAME2=VALUE2\"` for copy as curl functionality.\nResults unpredictable when combined with -H \"Cookie: ...\"")
@@ -125,15 +127,13 @@ func main() {
 func prepareJob(conf *ffuf.Config) (*ffuf.Job, error) {
 	errs := ffuf.NewMultierror()
 	var err error
-	var inputprovider ffuf.InputProvider
+	inputprovider := input.NewInputProvider(conf)
 	// TODO: implement error handling for runnerprovider and outputprovider
 	// We only have http runner right now
 	runprovider := runner.NewRunnerByName("http", conf)
 	// Initialize the correct inputprovider
-	if len(conf.InputCommand) > 0 {
-		inputprovider, err = input.NewInputProviderByName("command", conf)
-	} else {
-		inputprovider, err = input.NewInputProviderByName("wordlist", conf)
+	for _, v := range conf.InputProviders {
+		inputprovider.AddProvider(v)
 	}
 	if err != nil {
 		errs.Add(fmt.Errorf("%s", err))
@@ -196,15 +196,11 @@ func prepareFilters(parseOpts *cliOptions, conf *ffuf.Config) error {
 func prepareConfig(parseOpts *cliOptions, conf *ffuf.Config) error {
 	//TODO: refactor in a proper flag library that can handle things like required flags
 	errs := ffuf.NewMultierror()
-	foundkeyword := false
 
 	var err error
 	var err2 error
 	if len(conf.Url) == 0 {
 		errs.Add(fmt.Errorf("-u flag is required"))
-	}
-	if len(conf.Wordlist) == 0 && len(conf.InputCommand) == 0 {
-		errs.Add(fmt.Errorf("Either -w or --input-cmd flag is required"))
 	}
 	// prepare extensions
 	if parseOpts.extensions != "" {
@@ -216,23 +212,52 @@ func prepareConfig(parseOpts *cliOptions, conf *ffuf.Config) error {
 	if len(parseOpts.cookies) > 0 {
 		parseOpts.headers.Set("Cookie: " + strings.Join(parseOpts.cookies, "; "))
 	}
+
+	//Prepare inputproviders
+	for _, v := range parseOpts.wordlists {
+		wl := strings.SplitN(v, ":", 2)
+		if len(wl) == 2 {
+			conf.InputProviders = append(conf.InputProviders, ffuf.InputProviderConfig{
+				Name:    "wordlist",
+				Keyword: wl[0],
+				Value:   wl[1],
+			})
+		} else {
+			conf.InputProviders = append(conf.InputProviders, ffuf.InputProviderConfig{
+				Name:    "wordlist",
+				Keyword: "FUZZ",
+				Value:   wl[0],
+			})
+		}
+	}
+	for _, v := range parseOpts.inputcommands {
+		ic := strings.SplitN(v, ":", 2)
+		if len(ic) == 2 {
+			conf.InputProviders = append(conf.InputProviders, ffuf.InputProviderConfig{
+				Name:    "command",
+				Keyword: ic[0],
+				Value:   ic[1],
+			})
+			conf.CommandKeywords = append(conf.CommandKeywords, ic[0])
+		} else {
+			conf.InputProviders = append(conf.InputProviders, ffuf.InputProviderConfig{
+				Name:    "command",
+				Keyword: "FUZZ",
+				Value:   ic[0],
+			})
+			conf.CommandKeywords = append(conf.CommandKeywords, "FUZZ")
+		}
+	}
+
+	if len(conf.InputProviders) == 0 {
+		errs.Add(fmt.Errorf("Either -w or --input-cmd flag is required"))
+	}
+
 	//Prepare headers
 	for _, v := range parseOpts.headers {
 		hs := strings.SplitN(v, ":", 2)
 		if len(hs) == 2 {
-			fuzzedheader := false
-			for _, fv := range hs {
-				if strings.Index(fv, "FUZZ") != -1 {
-					// Add to fuzzheaders
-					fuzzedheader = true
-				}
-			}
-			if fuzzedheader {
-				conf.FuzzHeaders[strings.TrimSpace(hs[0])] = strings.TrimSpace(hs[1])
-				foundkeyword = true
-			} else {
-				conf.StaticHeaders[strings.TrimSpace(hs[0])] = strings.TrimSpace(hs[1])
-			}
+			conf.Headers[strings.TrimSpace(hs[0])] = strings.TrimSpace(hs[1])
 		} else {
 			errs.Add(fmt.Errorf("Header defined by -H needs to have a value. \":\" should be used as a separator"))
 		}
@@ -293,20 +318,34 @@ func prepareConfig(parseOpts *cliOptions, conf *ffuf.Config) error {
 
 	conf.CommandLine = strings.Join(os.Args, " ")
 
-	//Search for keyword from HTTP method, URL and POST data too
-	if conf.Method == "FUZZ" {
-		foundkeyword = true
-	}
-	if strings.Index(conf.Url, "FUZZ") != -1 {
-		foundkeyword = true
-	}
-	if strings.Index(conf.Data, "FUZZ") != -1 {
-		foundkeyword = true
-	}
-
-	if !foundkeyword {
-		errs.Add(fmt.Errorf("No FUZZ keyword(s) found in headers, method, URL or POST data, nothing to do"))
+	for _, provider := range conf.InputProviders {
+		if !keywordPresent(provider.Keyword, conf) {
+			errmsg := fmt.Sprintf("Keyword %s defined, but not found in headers, method, URL or POST data.", provider.Keyword)
+			errs.Add(fmt.Errorf(errmsg))
+		}
 	}
 
 	return errs.ErrorOrNil()
+}
+
+func keywordPresent(keyword string, conf *ffuf.Config) bool {
+	//Search for keyword from HTTP method, URL and POST data too
+	if strings.Index(conf.Method, keyword) != -1 {
+		return true
+	}
+	if strings.Index(conf.Url, keyword) != -1 {
+		return true
+	}
+	if strings.Index(conf.Data, keyword) != -1 {
+		return true
+	}
+	for k, v := range conf.Headers {
+		if strings.Index(k, keyword) != -1 {
+			return true
+		}
+		if strings.Index(v, keyword) != -1 {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -16,8 +16,7 @@ type optRange struct {
 }
 
 type Config struct {
-	StaticHeaders     map[string]string
-	FuzzHeaders       map[string]string
+	Headers           map[string]string
 	Extensions        []string
 	DirSearchCompat   bool
 	Method            string
@@ -26,8 +25,9 @@ type Config struct {
 	Data              string
 	Quiet             bool
 	Colors            bool
+	InputProviders    []InputProviderConfig
+	CommandKeywords   []string
 	Wordlist          string
-	InputCommand      string
 	InputNum          int
 	OutputFile        string
 	OutputFormat      string
@@ -47,11 +47,16 @@ type Config struct {
 	CommandLine       string
 }
 
+type InputProviderConfig struct {
+	Name    string
+	Keyword string
+	Value   string
+}
+
 func NewConfig(ctx context.Context) Config {
 	var conf Config
 	conf.Context = ctx
-	conf.StaticHeaders = make(map[string]string)
-	conf.FuzzHeaders = make(map[string]string)
+	conf.Headers = make(map[string]string)
 	conf.Method = "GET"
 	conf.Url = ""
 	conf.TLSVerify = false
@@ -61,7 +66,8 @@ func NewConfig(ctx context.Context) Config {
 	conf.StopOnErrors = false
 	conf.StopOnAll = false
 	conf.FollowRedirects = false
-	conf.InputCommand = ""
+	conf.InputProviders = make([]InputProviderConfig, 0)
+	conf.CommandKeywords = make([]string, 0)
 	conf.InputNum = 0
 	conf.ProxyURL = http.ProxyFromEnvironment
 	conf.Filters = make([]FilterProvider, 0)

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -8,14 +8,25 @@ type FilterProvider interface {
 
 //RunnerProvider is an interface for request executors
 type RunnerProvider interface {
-	Prepare(input []byte) (Request, error)
+	Prepare(input map[string][]byte) (Request, error)
 	Execute(req *Request) (Response, error)
 }
 
 //InputProvider interface handles the input data for RunnerProvider
 type InputProvider interface {
+	AddProvider(InputProviderConfig) error
 	Next() bool
 	Position() int
+	Value() map[string][]byte
+	Total() int
+}
+
+//InternalInputProvider interface handles providing input data to InputProvider
+type InternalInputProvider interface {
+	Keyword() string
+	Next() bool
+	Position() int
+	ResetPosition()
 	Value() []byte
 	Total() int
 }

--- a/pkg/ffuf/request.go
+++ b/pkg/ffuf/request.go
@@ -6,7 +6,7 @@ type Request struct {
 	Url      string
 	Headers  map[string]string
 	Data     []byte
-	Input    []byte
+	Input    map[string][]byte
 	Position int
 }
 

--- a/pkg/input/command.go
+++ b/pkg/input/command.go
@@ -10,20 +10,34 @@ import (
 )
 
 type CommandInput struct {
-	config *ffuf.Config
-	count  int
+	config  *ffuf.Config
+	count   int
+	keyword string
+	command string
 }
 
-func NewCommandInput(conf *ffuf.Config) (*CommandInput, error) {
+func NewCommandInput(keyword string, value string, conf *ffuf.Config) (*CommandInput, error) {
 	var cmd CommandInput
+	cmd.keyword = keyword
 	cmd.config = conf
 	cmd.count = -1
+	cmd.command = value
 	return &cmd, nil
+}
+
+//Keyword returns the keyword assigned to this InternalInputProvider
+func (c *CommandInput) Keyword() string {
+	return c.keyword
 }
 
 //Position will return the current position in the input list
 func (c *CommandInput) Position() int {
 	return c.count
+}
+
+//ResetPosition will reset the current position of the InternalInputProvider
+func (c *CommandInput) ResetPosition() {
+	c.count = 0
 }
 
 //Next will increment the cursor position, and return a boolean telling if there's iterations left
@@ -39,7 +53,7 @@ func (c *CommandInput) Next() bool {
 func (c *CommandInput) Value() []byte {
 	var stdout bytes.Buffer
 	os.Setenv("FFUF_NUM", strconv.Itoa(c.count))
-	cmd := exec.Command(SHELL_CMD, SHELL_ARG, c.config.InputCommand)
+	cmd := exec.Command(SHELL_CMD, SHELL_ARG, c.command)
 	cmd.Stdout = &stdout
 	err := cmd.Run()
 	if err != nil {

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -4,11 +4,63 @@ import (
 	"github.com/ffuf/ffuf/pkg/ffuf"
 )
 
-func NewInputProviderByName(name string, conf *ffuf.Config) (ffuf.InputProvider, error) {
-	if name == "command" {
-		return NewCommandInput(conf)
+type MainInputProvider struct {
+	Providers []ffuf.InternalInputProvider
+	Config    *ffuf.Config
+	position  int
+}
+
+func NewInputProvider(conf *ffuf.Config) ffuf.InputProvider {
+	return &MainInputProvider{Config: conf}
+}
+
+func (i *MainInputProvider) AddProvider(provider ffuf.InputProviderConfig) error {
+	if provider.Name == "command" {
+		newcomm, _ := NewCommandInput(provider.Keyword, provider.Value, i.Config)
+		i.Providers = append(i.Providers, newcomm)
 	} else {
 		// Default to wordlist
-		return NewWordlistInput(conf)
+		newwl, err := NewWordlistInput(provider.Keyword, provider.Value, i.Config)
+		if err != nil {
+			return err
+		}
+		i.Providers = append(i.Providers, newwl)
 	}
+	return nil
+}
+
+//Position will return the current position of progress
+func (i *MainInputProvider) Position() int {
+	return i.position
+}
+
+//Next will increment the cursor position, and return a boolean telling if there's inputs left
+func (i *MainInputProvider) Next() bool {
+	i.position++
+	if i.position >= i.Total() {
+		return false
+	}
+	return true
+}
+
+//Value returns a map of keyword:value pairs including all inputs
+func (i *MainInputProvider) Value() map[string][]byte {
+	values := make(map[string][]byte)
+	for _, p := range i.Providers {
+		if !p.Next() {
+			// Loop to beginning if the inputprovider has been exhausted
+			p.ResetPosition()
+		}
+		values[p.Keyword()] = p.Value()
+	}
+	return values
+}
+
+//Total returns the amount of input combinations available
+func (i *MainInputProvider) Total() int {
+	count := 1
+	for _, p := range i.Providers {
+		count = count * p.Total()
+	}
+	return count
 }

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -36,10 +36,10 @@ func (i *MainInputProvider) Position() int {
 
 //Next will increment the cursor position, and return a boolean telling if there's inputs left
 func (i *MainInputProvider) Next() bool {
-	i.position++
 	if i.position >= i.Total() {
 		return false
 	}
+	i.position++
 	return true
 }
 

--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -12,10 +12,12 @@ type WordlistInput struct {
 	config   *ffuf.Config
 	data     [][]byte
 	position int
+	keyword  string
 }
 
-func NewWordlistInput(conf *ffuf.Config) (*WordlistInput, error) {
+func NewWordlistInput(keyword string, value string, conf *ffuf.Config) (*WordlistInput, error) {
 	var wl WordlistInput
+	wl.keyword = keyword
 	wl.config = conf
 	wl.position = -1
 	var valid bool
@@ -26,13 +28,13 @@ func NewWordlistInput(conf *ffuf.Config) (*WordlistInput, error) {
 		valid = true
 	} else {
 		// no
-		valid, err = wl.validFile(conf.Wordlist)
+		valid, err = wl.validFile(value)
 	}
 	if err != nil {
 		return &wl, err
 	}
 	if valid {
-		err = wl.readFile(conf.Wordlist)
+		err = wl.readFile(value)
 	}
 	return &wl, err
 }
@@ -40,6 +42,16 @@ func NewWordlistInput(conf *ffuf.Config) (*WordlistInput, error) {
 //Position will return the current position in the input list
 func (w *WordlistInput) Position() int {
 	return w.position
+}
+
+//ResetPosition resets the position back to beginning of the wordlist.
+func (w *WordlistInput) ResetPosition() {
+	w.position = 0
+}
+
+//Keyword returns the keyword assigned to this InternalInputProvider
+func (w *WordlistInput) Keyword() string {
+	return w.keyword
 }
 
 //Next will increment the cursor position, and return a boolean telling if there's words left in the list

--- a/pkg/output/file_csv.go
+++ b/pkg/output/file_csv.go
@@ -9,9 +9,10 @@ import (
 	"github.com/ffuf/ffuf/pkg/ffuf"
 )
 
-var header = []string{"input", "position", "status_code", "content_length", "content_words", "content_lines"}
+var staticheaders = []string{"position", "status_code", "content_length", "content_words", "content_lines"}
 
 func writeCSV(config *ffuf.Config, res []Result, encode bool) error {
+	header := make([]string, 0)
 	f, err := os.Create(config.OutputFile)
 	if err != nil {
 		return err
@@ -20,6 +21,14 @@ func writeCSV(config *ffuf.Config, res []Result, encode bool) error {
 
 	w := csv.NewWriter(f)
 	defer w.Flush()
+
+	for _, inputprovider := range config.InputProviders {
+		header = append(header, inputprovider.Keyword)
+	}
+
+	for _, item := range staticheaders {
+		header = append(header, item)
+	}
 
 	if err := w.Write(header); err != nil {
 		return err
@@ -47,8 +56,8 @@ func base64encode(in []byte) string {
 
 func toCSV(r Result) []string {
 	res := make([]string, 0)
-	for k, v := range r.Input {
-		res = append(res, k+":"+string(v))
+	for _, v := range r.Input {
+		res = append(res, string(v))
 	}
 	res = append(res, strconv.Itoa(r.Position))
 	res = append(res, strconv.FormatInt(r.StatusCode, 10))

--- a/pkg/output/file_csv.go
+++ b/pkg/output/file_csv.go
@@ -26,7 +26,11 @@ func writeCSV(config *ffuf.Config, res []Result, encode bool) error {
 	}
 	for _, r := range res {
 		if encode {
-			r.Input = base64encode(r.Input)
+			inputs := make(map[string][]byte, 0)
+			for k, v := range r.Input {
+				inputs[k] = []byte(base64encode(v))
+			}
+			r.Input = inputs
 		}
 
 		err := w.Write(toCSV(r))
@@ -37,16 +41,18 @@ func writeCSV(config *ffuf.Config, res []Result, encode bool) error {
 	return nil
 }
 
-func base64encode(in string) string {
-	return base64.StdEncoding.EncodeToString([]byte(in))
+func base64encode(in []byte) string {
+	return base64.StdEncoding.EncodeToString(in)
 }
 
 func toCSV(r Result) []string {
-	return []string{
-		r.Input,
-		strconv.Itoa(r.Position),
-		strconv.FormatInt(r.StatusCode, 10),
-		strconv.FormatInt(r.ContentLength, 10),
-		strconv.FormatInt(r.ContentWords, 10),
+	res := make([]string, 0)
+	for k, v := range r.Input {
+		res = append(res, k+":"+string(v))
 	}
+	res = append(res, strconv.Itoa(r.Position))
+	res = append(res, strconv.FormatInt(r.StatusCode, 10))
+	res = append(res, strconv.FormatInt(r.ContentLength, 10))
+	res = append(res, strconv.FormatInt(r.ContentWords, 10))
+	return res
 }

--- a/pkg/output/file_md.go
+++ b/pkg/output/file_md.go
@@ -8,33 +8,32 @@ import (
 	"github.com/ffuf/ffuf/pkg/ffuf"
 )
 
-type markdownFileOutput struct {
-	CommandLine string
-	Time        string
-	Results     []Result
-}
-
 const (
 	markdownTemplate = `# FFUF Report
 
   Command line : ` + "`{{.CommandLine}}`" + `
   Time: ` + "{{ .Time }}" + `
 
-  | Input | Position | Status Code | Content Length | Content Words | Content Lines |
-  | :---- | :------- | :---------- | :------------- | :------------ | :------------ |
-  {{range .Results}}| {{ .Input }} | {{ .Position }} | {{ .StatusCode }} | {{ .ContentLength }} | {{ .ContentWords }} | {{ .ContentLines }} |
-  {{end}}
-	` // The template format is not pretty but follows the markdown guide
+  {{ range .Keys }}| {{ . }} {{ end }}| Position | Status Code | Content Length | Content Words | Content Lines |
+  {{ range .Keys }}| :- {{ end }}| :---- | :------- | :---------- | :------------- | :------------ | :------------ |
+  {{range .Results}}{{ range $keyword, $value := .Input }}| {{ $value | printf "%s" }} {{ end }}| {{ .Position }} | {{ .StatusCode }} | {{ .ContentLength }} | {{ .ContentWords }} | {{ .ContentLines }} |
+  {{end}}` // The template format is not pretty but follows the markdown guide
 )
 
 func writeMarkdown(config *ffuf.Config, res []Result) error {
 
 	ti := time.Now()
 
-	outHTML := htmlFileOutput{
+	keywords := make([]string, 0)
+	for _, inputprovider := range config.InputProviders {
+		keywords = append(keywords, inputprovider.Keyword)
+	}
+
+	outMD := htmlFileOutput{
 		CommandLine: config.CommandLine,
 		Time:        ti.Format(time.RFC3339),
 		Results:     res,
+		Keys:        keywords,
 	}
 
 	f, err := os.Create(config.OutputFile)
@@ -46,6 +45,6 @@ func writeMarkdown(config *ffuf.Config, res []Result) error {
 	templateName := "output.md"
 	t := template.New(templateName).Delims("{{", "}}")
 	t.Parse(markdownTemplate)
-	t.Execute(f, outHTML)
+	t.Execute(f, outMD)
 	return nil
 }

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -187,7 +187,7 @@ func (s *Stdoutput) resultQuiet(resp ffuf.Response) {
 
 func (s *Stdoutput) resultNormal(resp ffuf.Response) {
 	var res_str string
-	res_str = fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d]", TERMINAL_CLEAR_LINE, s.prepareInputs(resp), s.colorizeStatus(resp.StatusCode), resp.ContentLength, resp.ContentWords, resp.ContentLines)
+	res_str = fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d%s]", TERMINAL_CLEAR_LINE, s.prepareInputs(resp), s.colorizeStatus(resp.StatusCode), resp.ContentLength, resp.ContentWords, resp.ContentLines, s.addRedirectLocation(resp))
 	fmt.Println(res_str)
 }
 

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -33,7 +33,7 @@ type Result struct {
 	ContentLength int64             `json:"length"`
 	ContentWords  int64             `json:"words"`
 	ContentLines  int64             `json:"lines"`
-	HTMLColor     string            `json:"html_color"`
+	HTMLColor     string            `json:"-"`
 }
 
 func NewStdoutput(conf *ffuf.Config) *Stdoutput {


### PR DESCRIPTION
This PR enables usage of multiple wordlists and custom keywords.
The usage example is:
```
ffuf -u https://example.com/FIRST/SECOND -w "FIRST:/path/to/wordlist" -w "SECOND:/path/to/second/wordlist"
```
Todo:
- Change the help text for -w
- Figure out an output format that works, the current one is ugly