### PR TITLE
Add flag for ignoring comments in wordlist

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ func main() {
 	flag.BoolVar(&conf.StopOnErrors, "se", false, "Stop on spurious errors")
 	flag.BoolVar(&conf.StopOnAll, "sa", false, "Stop on all error cases. Implies -sf and -se")
 	flag.BoolVar(&conf.FollowRedirects, "r", false, "Follow redirects")
+	flag.BoolVar(&conf.IgnoreWordlistComments, "ic", false, "Ignore wordlist comments")
 	flag.BoolVar(&conf.AutoCalibration, "ac", false, "Automatically calibrate filtering options")
 	flag.Var(&opts.AutoCalibrationStrings, "acc", "Custom auto-calibration string. Can be used multiple times. Implies -ac")
 	flag.IntVar(&conf.Threads, "t", 40, "Number of concurrent threads.")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	StopOnErrors           bool
 	StopOnAll              bool
 	FollowRedirects        bool
+	IgnoreWordlistComments bool
 	AutoCalibration        bool
 	AutoCalibrationStrings []string
 	Timeout                int
@@ -68,6 +69,7 @@ func NewConfig(ctx context.Context) Config {
 	conf.StopOnErrors = false
 	conf.StopOnAll = false
 	conf.FollowRedirects = false
+	conf.IgnoreWordlistComments = false
 	conf.InputProviders = make([]InputProviderConfig, 0)
 	conf.CommandKeywords = make([]string, 0)
 	conf.InputNum = 0

--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/ffuf/ffuf/pkg/ffuf"
 )
@@ -117,13 +118,23 @@ func (w *WordlistInput) readFile(path string) error {
 					data = append(data, []byte(contnt))
 				}
 			} else {
-				data = append(data, []byte(reader.Text()))
+				text := reader.Text()
+
+				if w.config.IgnoreWordlistComments && strings.HasPrefix(text, "#") {
+					continue
+				}
+				data = append(data, []byte(text))
 			}
 		} else {
-			data = append(data, []byte(reader.Text()))
+			text := reader.Text()
+
+			if w.config.IgnoreWordlistComments && strings.HasPrefix(text, "#") {
+				continue
+			}
+			data = append(data, []byte(text))
 			if w.keyword == "FUZZ" && len(w.config.Extensions) > 0 {
 				for _, ext := range w.config.Extensions {
-					data = append(data, []byte(reader.Text()+ext))
+					data = append(data, []byte(text+ext))
 				}
 			}
 		}


### PR DESCRIPTION
Not sure if this is already implemented somehow, but I think it's nice to have it. Implemented as a flag to not break any default behaviour.