### PR TITLE
remove -k flag support, convert to dummy flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
     - Limit the use of `-e` (extensions) to a single keyword: FUZZ
     - Regexp matching and filtering (-mr/-fr) allow using keywords in patterns
     - Take 429 responses into account when -sa (stop on all error cases) is used
+    - Remove -k flag support, convert to dummy flag #134
+
 
 - v0.12
   - New

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,4 @@
 * [SakiiR](https://github.com/SakiiR)
 * [seblw](https://github.com/seblw)
 * [SolomonSklash](https://github.com/SolomonSklash)
+* [Shaked](https://github.com/Shaked)

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 	flag.Var(&opts.headers, "H", "Header `\"Name: Value\"`, separated by colon. Multiple -H flags are accepted.")
 	flag.StringVar(&conf.Url, "u", "", "Target URL")
 	flag.Var(&opts.wordlists, "w", "Wordlist file path and (optional) custom fuzz keyword, using colon as delimiter. Use file path '-' to read from standard input. Can be supplied multiple times. Format: '/path/to/wordlist:KEYWORD'")
-	flag.BoolVar(&conf.TLSVerify, "k", false, "TLS identity verification")
+	flag.BoolVar(&ignored, "k", false, "Dummy flag for backwards compatibility")
 	flag.StringVar(&opts.delay, "p", "", "Seconds of `delay` between requests, or a range of random delay. For example \"0.1\" or \"0.1-2.0\"")
 	flag.StringVar(&opts.filterStatus, "fc", "", "Filter HTTP status codes from response. Comma separated list of codes and ranges")
 	flag.StringVar(&opts.filterSize, "fs", "", "Filter HTTP response size. Comma separated list of sizes and ranges")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -21,7 +21,6 @@ type Config struct {
 	DirSearchCompat        bool
 	Method                 string
 	Url                    string
-	TLSVerify              bool
 	Data                   string
 	Quiet                  bool
 	Colors                 bool
@@ -65,7 +64,6 @@ func NewConfig(ctx context.Context) Config {
 	conf.Headers = make(map[string]string)
 	conf.Method = "GET"
 	conf.Url = ""
-	conf.TLSVerify = false
 	conf.Data = ""
 	conf.Quiet = false
 	conf.StopOn403 = false

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -34,7 +34,7 @@ func NewSimpleRunner(conf *ffuf.Config) ffuf.RunnerProvider {
 			MaxIdleConnsPerHost: 500,
 			MaxConnsPerHost:     500,
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: !conf.TLSVerify,
+				InsecureSkipVerify: true,
 			},
 		}}
 


### PR DESCRIPTION
Hey,

This is my first time contributing to `ffuf`.

This PR should remove -k support and convert the flag itself to a dummy in order to have backwards compatibility. 

`ffuf` will automatically set the `InsecureSkipVerify` flag to `true` as seen bellow. 

Please let me know if I missed something and how I can make it better.

Thank you 
Shaked