### PR TITLE
Added ignore comment option 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - master
   - New
+    - New CLI flag `-ic` to ignore comments from wordlist.
     - New CLI flag `-od` (output directory) to enable writing requests and responses for matched results to a file for postprocessing or debugging purposes.
     - New CLI flag `-maxtime` to limit the running time of ffuf
     - New CLI flags `-recursion` and `-recursion-depth` to control recursive ffuf jobs if directories are found. This requires the `-u` to end with FUZZ keyword.

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ func main() {
 	conf := ffuf.NewConfig(ctx)
 	opts := cliOptions{}
 	var ignored bool
+	flag.BoolVar(&conf.IgnoreWordlistComments, "ic", false, "Ignore wordlist comments")
 	flag.StringVar(&opts.extensions, "e", "", "Comma separated list of extensions to apply. Each extension provided will extend the wordlist entry once. Only extends a wordlist with (default) FUZZ keyword.")
 	flag.BoolVar(&conf.DirSearchCompat, "D", false, "DirSearch style wordlist compatibility mode. Used in conjunction with -e flag. Replaces %EXT% in wordlist entry with each of the extensions provided by -e.")
 	flag.Var(&opts.headers, "H", "Header `\"Name: Value\"`, separated by colon. Multiple -H flags are accepted.")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	OutputDirectory        string                    `json:"outputdirectory"`
 	OutputFile             string                    `json:"outputfile"`
 	OutputFormat           string                    `json:"outputformat"`
+	IgnoreWordlistComments bool                      `json:"ignore_wordlist_comments"`
 	StopOn403              bool                      `json:"stop_403"`
 	StopOnErrors           bool                      `json:"stop_errors"`
 	StopOnAll              bool                      `json:"stop_all"`
@@ -55,6 +56,7 @@ func NewConfig(ctx context.Context) Config {
 	conf.Url = ""
 	conf.Data = ""
 	conf.Quiet = false
+	conf.IgnoreWordlistComments = false
 	conf.StopOn403 = false
 	conf.StopOnErrors = false
 	conf.StopOnAll = false


### PR DESCRIPTION
Ignore comments in multiple stuff - 
1. Ignore comment starting with comments.
2. Ignore comments in lines with space in front 
3. Strip comments from the end of the wordlist 

This addresses shortcomings that PR #115 failed to address.