### PR TITLE
Replay matches using a chosen proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     - New CLI flag `-od` (output directory) to enable writing requests and responses for matched results to a file for postprocessing or debugging purposes.
     - New CLI flag `-maxtime` to limit the running time of ffuf
     - New CLI flags `-recursion` and `-recursion-depth` to control recursive ffuf jobs if directories are found. This requires the `-u` to end with FUZZ keyword.
+    - New CLI flag `-replay-proxy` to replay matched requests using a custom proxy.
   - Changed
     - Limit the use of `-e` (extensions) to a single keyword: FUZZ
     - Regexp matching and filtering (-mr/-fr) allow using keywords in patterns

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	Threads                int                       `json:"threads"`
 	Context                context.Context           `json:"-"`
 	ProxyURL               string                    `json:"proxyurl"`
+	ReplayProxyURL         string                    `json:"replayproxyurl"`
 	CommandLine            string                    `json:"cmdline"`
 	Verbose                bool                      `json:"verbose"`
 	MaxTime                int                       `json:"maxtime"`

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -87,6 +87,16 @@ func (s *Stdoutput) Banner() error {
 	autocalib := fmt.Sprintf("%t", s.config.AutoCalibration)
 	printOption([]byte("Calibration"), []byte(autocalib))
 
+	// Proxies
+	if len(s.config.ProxyURL) > 0 {
+		proxy := fmt.Sprintf("%s", s.config.ProxyURL)
+		printOption([]byte("Proxy"), []byte(proxy))
+	}
+	if len(s.config.ReplayProxyURL) > 0 {
+		replayproxy := fmt.Sprintf("%s", s.config.ReplayProxyURL)
+		printOption([]byte("ReplayProxy"), []byte(replayproxy))
+	}
+
 	// Timeout
 	timeout := fmt.Sprintf("%d", s.config.Timeout)
 	printOption([]byte("Timeout"), []byte(timeout))

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ffuf/ffuf/pkg/ffuf"
 )
 
-func NewRunnerByName(name string, conf *ffuf.Config) ffuf.RunnerProvider {
+func NewRunnerByName(name string, conf *ffuf.Config, replay bool) ffuf.RunnerProvider {
 	// We have only one Runner at the moment
-	return NewSimpleRunner(conf)
+	return NewSimpleRunner(conf, replay)
 }

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -23,12 +23,18 @@ type SimpleRunner struct {
 	client *http.Client
 }
 
-func NewSimpleRunner(conf *ffuf.Config) ffuf.RunnerProvider {
+func NewSimpleRunner(conf *ffuf.Config, replay bool) ffuf.RunnerProvider {
 	var simplerunner SimpleRunner
 	proxyURL := http.ProxyFromEnvironment
+	customProxy := ""
 
-	if len(conf.ProxyURL) > 0 {
-		pu, err := url.Parse(conf.ProxyURL)
+	if replay {
+		customProxy = conf.ReplayProxyURL
+	} else {
+		customProxy = conf.ProxyURL
+	}
+	if len(customProxy) > 0 {
+		pu, err := url.Parse(customProxy)
 		if err == nil {
 			proxyURL = http.ProxyURL(pu)
 		}


### PR DESCRIPTION
This feature adds the functionality to resend the matches through a proxy of choice. Usually used to add the matches to Burp suite.