### PR TITLE
Add Output Checkpoint option

### DIFF
--- a/help.go
+++ b/help.go
@@ -96,7 +96,7 @@ func Usage() {
 		Description:   "Options for output. Output file formats, file names and debug file locations.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"debug-log", "o", "of", "od"},
+		ExpectedFlags: []string{"debug-log", "o", "of", "od", "oc"},
 	}
 	sections := []UsageSection{u_http, u_general, u_compat, u_matcher, u_filter, u_input, u_output}
 

--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func main() {
 	flag.StringVar(&conf.OutputFile, "o", "", "Write output to file")
 	flag.StringVar(&opts.outputFormat, "of", "json", "Output file format. Available formats: json, ejson, html, md, csv, ecsv")
 	flag.StringVar(&conf.OutputDirectory, "od", "", "Directory path to store matched results to.")
+	flag.IntVar(&conf.OutputCheckpoint, "oc", -1, "Write output to file every n requests (-1 to disable).")
 	flag.BoolVar(&conf.IgnoreBody, "ignore-body", false, "Do not fetch the response content.")
 	flag.BoolVar(&conf.Quiet, "s", false, "Do not print additional information (silent mode)")
 	flag.BoolVar(&conf.StopOn403, "sf", false, "Stop when > 95% of responses return 403 Forbidden")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	OutputDirectory        string                    `json:"outputdirectory"`
 	OutputFile             string                    `json:"outputfile"`
 	OutputFormat           string                    `json:"outputformat"`
+	OutputCheckpoint       int                       `json:"outputcheckpoint"`
 	IgnoreBody             bool                      `json:"ignorebody"`
 	IgnoreWordlistComments bool                      `json:"ignore_wordlist_comments"`
 	StopOn403              bool                      `json:"stop_403"`

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -36,6 +36,7 @@ type InternalInputProvider interface {
 //OutputProvider is responsible of providing output from the RunnerProvider
 type OutputProvider interface {
 	Banner() error
+	WriteOutputFile()
 	Finalize() error
 	Progress(status Progress)
 	Info(infostring string)

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -157,6 +157,9 @@ func (j *Job) startExecution() {
 			defer func() { <-limiter }()
 			defer wg.Done()
 			j.runTask(nextInput, nextPosition, false)
+			if j.Config.OutputCheckpoint != -1 && j.Counter % j.Config.OutputCheckpoint == 0 {
+				j.Output.WriteOutputFile()
+			}
 			if j.Config.Delay.HasDelay {
 				var sleepDurationMS time.Duration
 				if j.Config.Delay.IsRange {

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -188,7 +188,7 @@ func (s *Stdoutput) Warning(warnstring string) {
 	}
 }
 
-func (s *Stdoutput) Finalize() error {
+func (s *Stdoutput) WriteOutputFile() {
 	var err error
 	if s.config.OutputFile != "" {
 		if s.config.OutputFormat == "json" {
@@ -208,6 +208,10 @@ func (s *Stdoutput) Finalize() error {
 			s.Error(fmt.Sprintf("%s", err))
 		}
 	}
+}
+
+func (s *Stdoutput) Finalize() error {
+	s.WriteOutputFile()
 	fmt.Fprintf(os.Stderr, "\n")
 	return nil
 }


### PR DESCRIPTION
The option specifies how often output writing should be done (every n
requests) while a job is in progress

This is a naive attempt to fix #205, I'm new to Go and `ffuf` - guidance would be appreciated!

Known issues:

* File writing isn't atomic (But then again it never was). Repeatedly reading the Output File outside of `ffuf` doesn't guarantee you're getting complete and hence legal output
* It doesn't care for concurrency? A low enough `-oc` value might result in parallel attempts to write to the Output File?
* I don't really know how jobs work, or if this could cause issues with recursive mode (Something I don't use)
* I don't know if we can trust `j.Counter` for this kind of thing. I've sometimes seen the `func()` loop inside of `startExecution()` be executed with identical `j.Counter` values. This is especially evident at the end of `ffuf`'s execution, perhaps when we're waiting for the final requests to come back? If we're unlucky, and at that time `j.Counter` is a multiple of `-oc`, we'll be writing the Output File (In parallel threads?) in a tight loop?
* Provides a potentially needless config knob. If we could fix the above issues, perhaps we could just always checkpoint the output with a sane `-oc` value?