### PR TITLE
Add the wordlists to the header information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     - New CLI flag `-maxtime-job` to set max. execution time per job.
     - Changed behaviour of `-maxtime`, can now be used for entire process.
     - A new flag `-ignore-body` so ffuf does not fetch the response content. Default value=false.
+    - Added the wordlists to the header information.
 
   - Changed
     - Added tls renegotiation flag to fix #193 in http.Client

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@
 * [delic](https://github.com/delic)
 * [eur0pa](https://github.com/eur0pa)
 * [fang0654](https://github.com/fang0654)
+* [helpermika](https://github.com/helpermika)
 * [Ice3man543](https://github.com/Ice3man543)
 * [JamTookTheBait](https://github.com/JamTookTheBait)
 * [joohoi](https://github.com/joohoi)

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -57,11 +57,7 @@ func (s *Stdoutput) Banner() error {
 	// Print wordlists
 	for _, provider := range s.config.InputProviders {
 		if provider.Name == "wordlist" {
-			wordlistValue := provider.Value
-			if provider.Keyword != "FUZZ" {
-				wordlistValue += ":" + provider.Keyword
-			}
-			printOption([]byte("Wordlist"), []byte(wordlistValue))
+			printOption([]byte("Wordlist"), []byte(provider.Keyword + ": " + provider.Value))
 		}
 	}
 

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -53,6 +53,18 @@ func (s *Stdoutput) Banner() error {
 	fmt.Printf("%s\n       v%s\n%s\n\n", BANNER_HEADER, ffuf.VERSION, BANNER_SEP)
 	printOption([]byte("Method"), []byte(s.config.Method))
 	printOption([]byte("URL"), []byte(s.config.Url))
+
+	// Print wordlists
+	for _, provider := range s.config.InputProviders {
+		if provider.Name == "wordlist" {
+			wordlistValue := provider.Value
+			if provider.Keyword != "FUZZ" {
+				wordlistValue += ":" + provider.Keyword
+			}
+			printOption([]byte("Wordlist"), []byte(wordlistValue))
+		}
+	}
+
 	// Print headers
 	if len(s.config.Headers) > 0 {
 		for k, v := range s.config.Headers {


### PR DESCRIPTION
This pull request tries to close #197 and adds the wordlists to the header information.

I tested this with two cases:

lenovo@lenovo-ThinkPad-T460s:~/ohjelmointi/ffuf/project3$ ./ffuf/ffuf -w data/ffuf/urlit.txt -v -u http://localhost:8080/FUZZ

        /'___\  /'___\           /'___\       
       /\ \__/ /\ \__/  __  __  /\ \__/       
       \ \ ,__\\ \ ,__\/\ \/\ \ \ \ ,__\      
        \ \ \_/ \ \ \_/\ \ \_\ \ \ \ \_/      
         \ \_\   \ \_\  \ \____/  \ \_\       
          \/_/    \/_/   \/___/    \/_/       

       v1.1.0-git
________________________________________________

 :: Method           : GET
 :: URL              : http://localhost:8080/FUZZ
 :: Wordlist         : data/ffuf/urlit.txt
 :: Follow redirects : false
 :: Calibration      : false
 :: Timeout          : 10
 :: Threads          : 40
 :: Matcher          : Response status: 200,204,301,302,307,401,403
________________________________________________

[Status: 200, Size: 25, Words: 3, Lines: 1]
| URL | http://localhost:8080/bbb
    * FUZZ: bbb

[Status: 200, Size: 25, Words: 3, Lines: 1]
| URL | http://localhost:8080/aaa
    * FUZZ: aaa

[Status: 200, Size: 25, Words: 3, Lines: 1]
| URL | http://localhost:8080/ccc
    * FUZZ: ccc

:: Progress: [3/3] :: Job [1/1] :: 0 req/sec :: Duration: [0:00:00] :: Errors: 0 ::


lenovo@lenovo-ThinkPad-T460s:~/ohjelmointi/ffuf/project3$ ./ffuf/ffuf -w data/ffuf/tun.txt:TUN -w data/ffuf/pw.txt:PW -v -u http://localhost:8080/ -X POST -H "Content-Type: application/json" -d '{"Username": "TUN", "Password": "PW"}'

        /'___\  /'___\           /'___\       
       /\ \__/ /\ \__/  __  __  /\ \__/       
       \ \ ,__\\ \ ,__\/\ \/\ \ \ \ ,__\      
        \ \ \_/ \ \ \_/\ \ \_\ \ \ \ \_/      
         \ \_\   \ \_\  \ \____/  \ \_\       
          \/_/    \/_/   \/___/    \/_/       

       v1.1.0-git
________________________________________________

 :: Method           : POST
 :: URL              : http://localhost:8080/
 :: Wordlist         : data/ffuf/tun.txt:TUN
 :: Wordlist         : data/ffuf/pw.txt:PW
 :: Header           : Content-Type: application/json
 :: Data             : {"Username": "TUN", "Password": "PW"}
 :: Follow redirects : false
 :: Calibration      : false
 :: Timeout          : 10
 :: Threads          : 40
 :: Matcher          : Response status: 200,204,301,302,307,401,403
________________________________________________

:: Progress: [16/16] :: Job [1/1] :: 0 req/sec :: Duration: [0:00:00] :: Errors: 0 ::