### PR TITLE
Increase default rows per page on html report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
   - Changed
     - Added tls renegotiation flag to fix #193 in http.Client
+    - Fixed HTML report to display select/combo-box for rows per page (and increased default from 10 to 250 rows).
 
 - v1.0.2
   - Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,9 +1,9 @@
 # Contributors
-
 * [bjhulst](https://github.com/bjhulst)
 * [ccsplit](https://github.com/ccsplit)
 * [codingo](https://github.com/codingo)
 * [Damian89](https://github.com/Damian89)
+* [Daviey](https://github.com/Daviey)
 * [delic](https://github.com/delic)
 * [eur0pa](https://github.com/eur0pa)
 * [fang0654](https://github.com/fang0654)
@@ -20,4 +20,3 @@
 * [seblw](https://github.com/seblw)
 * [Shaked](https://github.com/Shaked)
 * [SolomonSklash](https://github.com/SolomonSklash)
-* [Daviey](https://github.com/Daviey)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,3 +20,4 @@
 * [seblw](https://github.com/seblw)
 * [Shaked](https://github.com/Shaked)
 * [SolomonSklash](https://github.com/SolomonSklash)
+* [Daviey](https://github.com/Daviey)

--- a/pkg/output/file_html.go
+++ b/pkg/output/file_html.go
@@ -100,11 +100,19 @@ const (
 	<script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
     <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.js"></script>
-	<script>
-	$(document).ready( function () {
-		$('#ffufreport').DataTable();
-	} );
-	</script>
+    <script>
+    $(document).ready(function() {
+        $('#ffufreport').DataTable(
+            {
+                "aLengthMenu": [
+                    [250, 500, 1000, 2500, -1],
+                    [250, 500, 1000, 2500, "All"]
+                ]
+            }
+        )
+        $('select').formSelect();
+        });
+    </script>
     <style>
       body {
         display: flex;


### PR DESCRIPTION
Previously 10 results were displayed per-page, as the
default of DataTables.  This change increases the default to
250 results per page and also adds the option for 250, 500,
1000, 2500 and ALL results.

In addition, materialize css default was blocking the
viewing of the option to display alternative results
per-page.  This is resolved by calling .formSelect as per
https://stackoverflow.com/questions/28258106/materialize-css-select-doesnt-seem-to-render

Fixes ffuf/ffuf#216

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>