### PR TITLE
Fix recursive when URL contains explicit port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - Added tls renegotiation flag to fix #193 in http.Client
     - Fixed HTML report to display select/combo-box for rows per page (and increased default from 10 to 250 rows).
     - Added Host information to JSON output file
+    - Fixed recursive not adding jobs on discovered folders when user supplied url (-u) contains a port number.
 
 - v1.0.2
   - Changed

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -313,7 +314,7 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 
 //handleRecursionJob adds a new recursion job to the job queue if a new directory is found
 func (j *Job) handleRecursionJob(resp Response) {
-	if (resp.Request.Url + "/") != resp.GetRedirectLocation(true) {
+	if !(strings.HasSuffix(resp.GetRedirectLocation(true), "/")) {
 		// Not a directory, return early
 		return
 	}


### PR DESCRIPTION
Previously when handling recursive jobs, found folders were
not being added if the user supplied url (-u) contained a
port number (ie, http://example.com:80/FUZZ).

This is because the logic to determine if a redirect was a
folder was to compare if the redirected URL == the
request-url + "/".  (ie, is a trailing "/" added)

The issue is that GetRedirectLocation() strips the port,
which means the if statement is wrongly always false (as the
port is missing).

This change now checks if the redirection has a trailing
"/", which means we can imply the redirection is a folder,
as that is the real factor that needs testing.

The issue with this fix is that if a redirect goes to a
whole new url, then we have *potentially* implemented follow
redirects on recursive (ffuf/ffuf#192) which is probably not
desirable?

Fixes ffuf/ffuf#232

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>