### PR TITLE
support for base64 and urlencoding

### DIFF
--- a/help.go
+++ b/help.go
@@ -89,7 +89,7 @@ func Usage() {
 		Description:   "Options for input data for fuzzing. Wordlists and input generators.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"D", "ic", "input-cmd", "input-num", "mode", "request", "request-proto", "e", "w"},
+		ExpectedFlags: []string{"D", "ic", "input-cmd", "input-num", "mode", "request", "request-proto", "e", "w", "el", "ep"},
 	}
 	u_output := UsageSection{
 		Name:          "OUTPUT OPTIONS",

--- a/pkg/encoder/base64.go
+++ b/pkg/encoder/base64.go
@@ -1,0 +1,27 @@
+package encoder
+
+import (
+	"encoding/base64"
+)
+
+func b64(ep EncoderParameters, data []byte) ([]byte, error) {
+	encs := []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+	}
+	if val, ok := ep["b64_url"]; ok && val == "true" {
+		encs = []*base64.Encoding{
+			base64.URLEncoding,
+			base64.RawURLEncoding,
+		}
+	}
+
+	enc := encs[0]
+	if val, ok := ep["b64_nopad"]; ok && val == "true" {
+		enc = encs[1]
+	}
+
+	encoded := make([]byte, enc.EncodedLen(len(data)))
+	enc.Encode(encoded, data)
+	return encoded, nil
+}

--- a/pkg/encoder/encoder.go
+++ b/pkg/encoder/encoder.go
@@ -1,0 +1,91 @@
+package encoder
+
+import (
+	"fmt"
+)
+
+type EncoderParameters = map[string]string
+
+type encoder func(ep EncoderParameters, data []byte) ([]byte, error)
+
+type encoderRecord struct {
+	name           string
+	description    string
+	implementation encoder
+}
+
+type EncoderSpecs = *encoderRecord
+
+func (e EncoderSpecs) Name() string        { return e.name }
+func (e EncoderSpecs) Description() string { return e.description }
+
+func Encoders() []EncoderSpecs {
+	return []EncoderSpecs{
+		&encoderRecord{
+			name:           "urlenc",
+			description:    "Url encoding. Set 'urlenc_chars=...' to define encoded chars.",
+			implementation: urlencode,
+		},
+		&encoderRecord{
+			name:           "b64",
+			description:    "Base64. Set 'b64_url=true' for url variant and 'b64_nopad=true' to remove '=' padding.",
+			implementation: b64,
+		},
+	}
+}
+
+type encoderInstance struct {
+	Specification []string          `json:"encoders,omitempty"`
+	Parameters    EncoderParameters `json:"parameters,omitempty"`
+	encoder       `json:"-"`
+}
+
+type EncoderInstance = *encoderInstance
+
+func (e EncoderInstance) Encode(data []byte) ([]byte, error) {
+	return e.encoder(e.Parameters, data)
+}
+
+func id(ep EncoderParameters, data []byte) ([]byte, error) {
+	return data, nil
+}
+
+func Id() EncoderInstance {
+	return &encoderInstance{
+		Specification: nil,
+		Parameters:    nil,
+		encoder:       id,
+	}
+}
+
+func compose(e1, e2 encoder) encoder {
+	return func(ep EncoderParameters, data []byte) ([]byte, error) {
+		if x, err := e1(ep, data); err != nil {
+			return x, err
+		} else {
+			return e2(ep, x)
+		}
+	}
+}
+
+func Compile(encoders []string, ep EncoderParameters) (EncoderInstance, error) {
+	e := id
+	for i, enc := range encoders {
+		composed := false
+		for _, encspec := range Encoders() {
+			if encspec.name == enc {
+				e = compose(e, encspec.implementation)
+				composed = true
+				break
+			}
+		}
+		if !composed {
+			return nil, fmt.Errorf("Unknown encoder %s at position %d", enc, i)
+		}
+	}
+	return &encoderInstance{
+		Specification: encoders,
+		Parameters:    ep,
+		encoder:       e,
+	}, nil
+}

--- a/pkg/encoder/urlencode.go
+++ b/pkg/encoder/urlencode.go
@@ -1,0 +1,75 @@
+package encoder
+
+import (
+	"net/url"
+	"strings"
+)
+
+// urlencoding algorithm below is a slightly modified version found in
+// the standard library to allow for which chars to encode to be
+// parameterised: https://golang.org/src/net/url/url.go
+const upperhex = "0123456789ABCDEF"
+
+func escape(s string, encodeChars string) string {
+	spaceCount, hexCount := 0, 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if strings.Contains(encodeChars, string(c)) {
+			if c == ' ' {
+				spaceCount++
+			} else {
+				hexCount++
+			}
+		}
+	}
+
+	if spaceCount == 0 && hexCount == 0 {
+		return s
+	}
+
+	var buf [64]byte
+	var t []byte
+
+	required := len(s) + 2*hexCount
+	if required <= len(buf) {
+		t = buf[:required]
+	} else {
+		t = make([]byte, required)
+	}
+
+	if hexCount == 0 {
+		copy(t, s)
+		for i := 0; i < len(s); i++ {
+			if s[i] == ' ' {
+				t[i] = '+'
+			}
+		}
+		return string(t)
+	}
+
+	j := 0
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case c == ' ':
+			t[j] = '+'
+			j++
+		case strings.Contains(encodeChars, string(c)):
+			t[j] = '%'
+			t[j+1] = upperhex[c>>4]
+			t[j+2] = upperhex[c&15]
+			j += 3
+		default:
+			t[j] = s[i]
+			j++
+		}
+	}
+	return string(t)
+}
+
+func urlencode(ep EncoderParameters, data []byte) ([]byte, error) {
+	chars, ok := ep["urlencode_chars"]
+	if ok {
+		return []byte(escape(string(data), chars)), nil
+	}
+	return []byte(url.QueryEscape(string(data))), nil
+}

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -2,6 +2,8 @@ package ffuf
 
 import (
 	"context"
+
+	"github.com/ffuf/ffuf/pkg/encoder"
 )
 
 type Config struct {
@@ -46,9 +48,10 @@ type Config struct {
 }
 
 type InputProviderConfig struct {
-	Name    string `json:"name"`
-	Keyword string `json:"keyword"`
-	Value   string `json:"value"`
+	Name    string                  `json:"name"`
+	Keyword string                  `json:"keyword"`
+	Value   string                  `json:"value"`
+	Encoder encoder.EncoderInstance `json:"encoder"`
 }
 
 func NewConfig(ctx context.Context) Config {

--- a/pkg/input/encodedprovider.go
+++ b/pkg/input/encodedprovider.go
@@ -1,0 +1,33 @@
+package input
+
+import (
+	"log"
+
+	"github.com/ffuf/ffuf/pkg/encoder"
+	"github.com/ffuf/ffuf/pkg/ffuf"
+)
+
+type encodedInputProvider struct {
+	iip ffuf.InternalInputProvider
+	ei  encoder.EncoderInstance
+}
+
+func (eip *encodedInputProvider) Keyword() string    { return eip.iip.Keyword() }
+func (eip *encodedInputProvider) Next() bool         { return eip.iip.Next() }
+func (eip *encodedInputProvider) Position() int      { return eip.iip.Position() }
+func (eip *encodedInputProvider) ResetPosition()     { eip.iip.ResetPosition() }
+func (eip *encodedInputProvider) IncrementPosition() { eip.iip.IncrementPosition() }
+func (eip *encodedInputProvider) Total() int         { return eip.iip.Total() }
+
+func (eip *encodedInputProvider) Value() []byte {
+	data, err := eip.ei.Encode(eip.iip.Value())
+	log.Printf("wht is this \n")
+	if err == nil {
+		return data
+	}
+
+	log.Printf("Encoder error: %s: %s\n", eip.iip.Keyword(), err)
+
+	// not possible to return an error from this interface
+	return []byte{}
+}

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -29,14 +29,20 @@ func NewInputProvider(conf *ffuf.Config) (ffuf.InputProvider, error) {
 func (i *MainInputProvider) AddProvider(provider ffuf.InputProviderConfig) error {
 	if provider.Name == "command" {
 		newcomm, _ := NewCommandInput(provider.Keyword, provider.Value, i.Config)
-		i.Providers = append(i.Providers, newcomm)
+		i.Providers = append(i.Providers, &encodedInputProvider{
+			iip: newcomm,
+			ei:  provider.Encoder,
+		})
 	} else {
 		// Default to wordlist
 		newwl, err := NewWordlistInput(provider.Keyword, provider.Value, i.Config)
 		if err != nil {
 			return err
 		}
-		i.Providers = append(i.Providers, newwl)
+		i.Providers = append(i.Providers, &encodedInputProvider{
+			iip: newwl,
+			ei:  provider.Encoder,
+		})
 	}
 	return nil
 }


### PR DESCRIPTION
I often find myself needing to switch back to other tools as there is a lack of support for url encoding in ffuf. So I have put together this small PR in hopes its useful, and in line with what is discussed in #48.

* added two command line options `-el` encoding list, and `-ep` encoding parameters.
* the `-w` parameter now accepts encoders appended after the keyword (similar to `wfuzz`)

So now its possible to do something like the following and have the cookie automatically url encoded:

```
$ echo  '9lanBYqNH2wezQcQ5JiGl7070PzSIfSI' | ./bin/radamsa -m bf --count 100 | ffuf -u http://xx.xx.xx.xx/login.php -w -:FUZZ:urlenc -H 'Cookie: auth=FUZZ' -mr admin
```

I am sure this can easily be extended with other encoders if needed. Although at the moment I have just left it with the two I generally find useful.