### PR TITLE
Allow input shell option

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,6 +88,7 @@ func main() {
 	flag.BoolVar(&conf.Colors, "c", false, "Colorize output.")
 	flag.BoolVar(&ignored, "compressed", true, "Dummy flag for copy as curl functionality (ignored)")
 	flag.Var(&opts.inputcommands, "input-cmd", "Command producing the input. --input-num is required when using this input method. Overrides -w.")
+	flag.StringVar(&conf.InputShell, "input-shell", "", "Shell to be used for running command")
 	flag.IntVar(&conf.InputNum, "input-num", 100, "Number of inputs to test. Used in conjunction with --input-cmd.")
 	flag.StringVar(&conf.InputMode, "mode", "clusterbomb", "Multi-wordlist operation mode. Available modes: clusterbomb, pitchfork")
 	flag.BoolVar(&ignored, "i", true, "Dummy flag for copy as curl functionality (ignored)")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	CommandKeywords        []string                  `json:"-"`
 	InputNum               int                       `json:"cmd_inputnum"`
 	InputMode              string                    `json:"inputmode"`
+	InputShell             string                    `json:"inputshell"`
 	OutputDirectory        string                    `json:"outputdirectory"`
 	OutputFile             string                    `json:"outputfile"`
 	OutputFormat           string                    `json:"outputformat"`

--- a/pkg/input/command.go
+++ b/pkg/input/command.go
@@ -14,6 +14,7 @@ type CommandInput struct {
 	count   int
 	keyword string
 	command string
+	shell   string
 }
 
 func NewCommandInput(keyword string, value string, conf *ffuf.Config) (*CommandInput, error) {
@@ -22,6 +23,12 @@ func NewCommandInput(keyword string, value string, conf *ffuf.Config) (*CommandI
 	cmd.config = conf
 	cmd.count = 0
 	cmd.command = value
+	cmd.shell = SHELL_CMD
+
+	if cmd.config.InputShell != "" {
+		cmd.shell = cmd.config.InputShell
+	}
+
 	return &cmd, nil
 }
 
@@ -57,7 +64,7 @@ func (c *CommandInput) Next() bool {
 func (c *CommandInput) Value() []byte {
 	var stdout bytes.Buffer
 	os.Setenv("FFUF_NUM", strconv.Itoa(c.count))
-	cmd := exec.Command(SHELL_CMD, SHELL_ARG, c.command)
+	cmd := exec.Command(c.shell, SHELL_ARG, c.command)
 	cmd.Stdout = &stdout
 	err := cmd.Run()
 	if err != nil {


### PR DESCRIPTION
* Add flag to set the shell to be used for the the input command


This is in response to issue #141 
Adds support to set the shell to be used with `input-cmd`. Fixes some issues that happen when using the [default shell](https://github.com/ffuf/ffuf/blob/master/pkg/input/const.go#L6) (`/bin/sh`). But still defaults to current shell if not set.

For example:
`echo` does not support `-n` flag in `/bin/sh`

Being able to set `/bin/zsh` or `/bin/bash` would fix the issue.

Usage:
```
ffuf -v \
    -input-shell "/bin/zsh" \
    -input-cmd 'echo -n subscriptions' \
    -input-num 1 -u https://example.com/path1/FUZZ
```


