### PR TITLE
Comma separated -w flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
   - Changed
     - Pre-flight errors are now displayed also after the usage text to prevent the need to scroll through backlog.
+    - The `-w` flag now accepts comma delimited values in the form of `file1:W1,file2:W2`.
 
 - v1.1.0
   - New

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,5 @@
 # Contributors
+* [AverageSecurityGuy](https://github.com/averagesecurityguy)
 * [bjhulst](https://github.com/bjhulst)
 * [bsysop](https://twitter.com/bsysop)
 * [ccsplit](https://github.com/ccsplit)
@@ -23,4 +24,3 @@
 * [seblw](https://github.com/seblw)
 * [Shaked](https://github.com/Shaked)
 * [SolomonSklash](https://github.com/SolomonSklash)
-* [AverageSecurityGuy](https://github.com/averagesecurityguy)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,3 +23,4 @@
 * [seblw](https://github.com/seblw)
 * [Shaked](https://github.com/Shaked)
 * [SolomonSklash](https://github.com/SolomonSklash)
+* [AverageSecurityGuy](https://github.com/averagesecurityguy)

--- a/main.go
+++ b/main.go
@@ -58,7 +58,16 @@ func (m *multiStringFlag) String() string {
 }
 
 func (m *multiStringFlag) Set(value string) error {
-	*m = append(*m, value)
+	delimited := strings.Split(value, ",")
+
+	if len(delimited) > 1 {
+		*m = append(*m, delimited...)
+	} else {
+		*m = append(*m, value)
+	}
+
+	fmt.Printf("%v\n", *m)
+
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -66,8 +66,6 @@ func (m *multiStringFlag) Set(value string) error {
 		*m = append(*m, value)
 	}
 
-	fmt.Printf("%v\n", *m)
-
 	return nil
 }
 


### PR DESCRIPTION
This is to resolve https://github.com/ffuf/ffuf/issues/290. The request was for input like `-w file1.txt:W1, file2.txt:W2` unfortunately, that won't work because the `flag` module splits the input on whitespace so main.go never sees the rest of the comma delimited list. If you remove the space and instead use `-w file1.txt:W1,file2.txt:W2`, this code change will properly parse that.

```
% ./ffuf -u https://W2.io/W1 -w ./wordlist.txt:W1,./domains.txt:W2

        /'___\  /'___\           /'___\       
       /\ \__/ /\ \__/  __  __  /\ \__/       
       \ \ ,__\\ \ ,__\/\ \/\ \ \ \ ,__\      
        \ \ \_/ \ \ \_/\ \ \_\ \ \ \ \_/      
         \ \_\   \ \_\  \ \____/  \ \_\       
          \/_/    \/_/   \/___/    \/_/       

       v1.2.0-git
________________________________________________

 :: Method           : GET
 :: URL              : https://W2.io/W1
 :: Wordlist         : W1: ./wordlist.txt
 :: Wordlist         : W2: ./domains.txt
 :: Follow redirects : false
 :: Calibration      : false
 :: Timeout          : 10
 :: Threads          : 40
 :: Matcher          : Response status: 200,204,301,302,307,401,403
________________________________________________

:: Progress: [1/1] :: Job [1/1] :: 0 req/sec :: Duration: [0:00:00] :: Errors: 0[Status: 301, Size: 162, Words: 5, Lines: 8]
    * W1: admin
    * W2: codingo

:: Progress: [1/1] :: Job [1/1] :: 0 req/sec :: Duration: [0:00:00] :: Errors: 0:: Progress: [1/1] :: Job [1/1] :: 0 req/sec :: Duration: [0:00:00] :: Errors: 0 ::

```