### PR TITLE
[WIP] Adds request timings

### DIFF
--- a/pkg/ffuf/request.go
+++ b/pkg/ffuf/request.go
@@ -1,5 +1,7 @@
 package ffuf
 
+import "time"
+
 // Request holds the meaningful data that is passed for runner for making the query
 type Request struct {
 	Method   string
@@ -10,6 +12,7 @@ type Request struct {
 	Input    map[string][]byte
 	Position int
 	Raw      string
+	Start    time.Time
 }
 
 func NewRequest(conf *Config) Request {
@@ -17,5 +20,6 @@ func NewRequest(conf *Config) Request {
 	req.Method = conf.Method
 	req.Url = conf.Url
 	req.Headers = make(map[string]string)
+	req.Start = time.Now()
 	return req
 }

--- a/pkg/ffuf/response.go
+++ b/pkg/ffuf/response.go
@@ -3,6 +3,7 @@ package ffuf
 import (
 	"net/http"
 	"net/url"
+	"time"
 )
 
 // Response struct holds the meaningful data returned from request and is meant for passing to filters
@@ -17,6 +18,7 @@ type Response struct {
 	Request       *Request
 	Raw           string
 	ResultFile    string
+	Duration      time.Duration
 }
 
 // GetRedirectLocation returns the redirect location for a 3xx redirect HTTP response
@@ -54,5 +56,6 @@ func NewResponse(httpresp *http.Response, req *Request) Response {
 	resp.Cancelled = false
 	resp.Raw = ""
 	resp.ResultFile = ""
+	resp.Duration = time.Since(req.Start)
 	return resp
 }

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -41,6 +41,7 @@ type Result struct {
 	ResultFile       string            `json:"resultfile"`
 	Host             string            `json:"host"`
 	HTMLColor        string            `json:"-"`
+	Duration         time.Duration     `json:"duration"`
 }
 
 func NewStdoutput(conf *ffuf.Config) *Stdoutput {
@@ -51,7 +52,7 @@ func NewStdoutput(conf *ffuf.Config) *Stdoutput {
 }
 
 func (s *Stdoutput) Banner() error {
-	fmt.Fprintf(os.Stderr ,"%s\n       v%s\n%s\n\n", BANNER_HEADER, ffuf.VERSION, BANNER_SEP)
+	fmt.Fprintf(os.Stderr, "%s\n       v%s\n%s\n\n", BANNER_HEADER, ffuf.VERSION, BANNER_SEP)
 	printOption([]byte("Method"), []byte(s.config.Method))
 	printOption([]byte("URL"), []byte(s.config.Url))
 
@@ -304,6 +305,7 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 			Url:              resp.Request.Url,
 			ResultFile:       resp.ResultFile,
 			Host:             resp.Request.Host,
+			Duration:         resp.Duration,
 		}
 		s.Results = append(s.Results, sResult)
 	}
@@ -378,7 +380,7 @@ func (s *Stdoutput) resultQuiet(resp ffuf.Response) {
 func (s *Stdoutput) resultMultiline(resp ffuf.Response) {
 	var res_hdr, res_str string
 	res_str = "%s%s    * %s: %s\n"
-	res_hdr = fmt.Sprintf("%s[Status: %d, Size: %d, Words: %d, Lines: %d]", TERMINAL_CLEAR_LINE, resp.StatusCode, resp.ContentLength, resp.ContentWords, resp.ContentLines)
+	res_hdr = fmt.Sprintf("%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %s]", TERMINAL_CLEAR_LINE, resp.StatusCode, resp.ContentLength, resp.ContentWords, resp.ContentLines, resp.Duration.String())
 	res_hdr = s.colorize(res_hdr, resp.StatusCode)
 	reslines := ""
 	if s.config.Verbose {
@@ -405,7 +407,7 @@ func (s *Stdoutput) resultMultiline(resp ffuf.Response) {
 
 func (s *Stdoutput) resultNormal(resp ffuf.Response) {
 	var res_str string
-	res_str = fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(resp), s.colorize(fmt.Sprintf("%d", resp.StatusCode), resp.StatusCode), resp.ContentLength, resp.ContentWords, resp.ContentLines)
+	res_str = fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d, Duration: %s]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(resp), s.colorize(fmt.Sprintf("%d", resp.StatusCode), resp.StatusCode), resp.ContentLength, resp.ContentWords, resp.ContentLines, resp.Duration.String())
 	fmt.Println(res_str)
 }
 


### PR DESCRIPTION
I was attempting to do a timing based attack on a target and realized ffuf does not have this information.
This is the first stages of PR that would add that data. I'm opening it in the spirit of discussions.

Here's what it looks like on the command line:

```bash
ffuf on  master [!] via 🐹 v1.13.8 
❯ ./ffuf -w ~/Desktop/passwords.txt -u https://example.org/FUZZ -mc all -fs 42 -c -v 

        /'___\  /'___\           /'___\       
       /\ \__/ /\ \__/  __  __  /\ \__/       
       \ \ ,__\\ \ ,__\/\ \/\ \ \ \ ,__\      
        \ \ \_/ \ \ \_/\ \ \_\ \ \ \ \_/      
         \ \_\   \ \_\  \ \____/  \ \_\       
          \/_/    \/_/   \/___/    \/_/       

       v1.2.0-git
________________________________________________

 :: Method           : GET
 :: URL              : https://example.org/FUZZ
 :: Wordlist         : FUZZ: /home/zmackie/Desktop/passwords.txt
 :: Follow redirects : false
 :: Calibration      : false
 :: Timeout          : 10
 :: Threads          : 40
 :: Matcher          : Response status: all
 :: Filter           : Response size: 42
________________________________________________

[Status: 404, Size: 1256, Words: 298, Lines: 47, Duration: 207.566501ms] <------------------ NEW FIELD
| URL | https://example.org/1234
    * FUZZ: 1234

[Status: 404, Size: 1256, Words: 298, Lines: 47, Duration: 207.706648ms]
| URL | https://example.org/password
    * FUZZ: password

[Status: 404, Size: 1256, Words: 298, Lines: 47, Duration: 208.983548ms]
| URL | https://example.org/abc123
    * FUZZ: abc123

[Status: 404, Size: 1256, Words: 298, Lines: 47, Duration: 250.911374ms]
| URL | https://example.org/qazwsx
    * FUZZ: qazwsx

```