### PR TITLE
Fix example --input-cmd at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For this example, we'll fuzz JSON data that's sent over POST. [Radamsa](https://
 When `--input-cmd` is used, ffuf will display matches as their position. This same position value will be available for the callee as an environment variable `$FFUF_NUM`. We'll use this position value as the seed for the mutator. Files example1.txt and example2.txt contain valid JSON payloads. We are matching all the responses, but filtering out response code `400 - Bad request`:
 
 ```
-ffuf --input-cmd 'radamsa --seed $FFUF_NUM example1.txt example2.txt' -H "Content-Type: application/json" -X POST -u https://ffuf.io.fi/ -mc all -fc 400
+ffuf --input-cmd 'radamsa --seed $FFUF_NUM example1.txt example2.txt' -H "Content-Type: application/json" -X POST -u https://ffuf.io.fi/FUZZ -mc all -fc 400
 ```
 
 It of course isn't very efficient to call the mutator for each payload, so we can also pre-generate the payloads, still using [Radamsa](https://gitlab.com/akihe/radamsa) as an example:


### PR DESCRIPTION
People are running this example and gettings errors, just added "FUZZ" keyword to complete the example.