### PR TITLE
pkg: use {strings,bytes}.ReplaceAll when possible

### DIFF
--- a/pkg/filter/regex.go
+++ b/pkg/filter/regex.go
@@ -41,7 +41,7 @@ func (f *RegexpFilter) Filter(response *ffuf.Response) (bool, error) {
 	matchdata = append(matchdata, response.Data...)
 	pattern := f.valueRaw
 	for keyword, inputitem := range response.Request.Input {
-		pattern = strings.Replace(pattern, keyword, regexp.QuoteMeta(string(inputitem)), -1)
+		pattern = strings.ReplaceAll(pattern, keyword, regexp.QuoteMeta(string(inputitem)))
 	}
 	matched, err := regexp.Match(pattern, matchdata)
 	if err != nil {

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -77,15 +77,15 @@ func (r *SimpleRunner) Prepare(input map[string][]byte) (ffuf.Request, error) {
 	req.Data = []byte(r.config.Data)
 
 	for keyword, inputitem := range input {
-		req.Method = strings.Replace(req.Method, keyword, string(inputitem), -1)
+		req.Method = strings.ReplaceAll(req.Method, keyword, string(inputitem))
 		headers := make(map[string]string, 0)
 		for h, v := range req.Headers {
-			var CanonicalHeader string = textproto.CanonicalMIMEHeaderKey(strings.Replace(h, keyword, string(inputitem), -1))
-			headers[CanonicalHeader] = strings.Replace(v, keyword, string(inputitem), -1)
+			var CanonicalHeader string = textproto.CanonicalMIMEHeaderKey(strings.ReplaceAll(h, keyword, string(inputitem)))
+			headers[CanonicalHeader] = strings.ReplaceAll(v, keyword, string(inputitem))
 		}
 		req.Headers = headers
-		req.Url = strings.Replace(req.Url, keyword, string(inputitem), -1)
-		req.Data = []byte(strings.Replace(string(req.Data), keyword, string(inputitem), -1))
+		req.Url = strings.ReplaceAll(req.Url, keyword, string(inputitem))
+		req.Data = []byte(strings.ReplaceAll(string(req.Data), keyword, string(inputitem)))
 	}
 
 	req.Input = input


### PR DESCRIPTION
### What does this PR do?

Now that Go 1.13+ is required, this PR makes use of standard library helper methods in order to have a more readable code.

### Problem description

See #301 

Fixes #301