### PR TITLE
pkg: handle gosimple linter findings

### DIFF
--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -387,7 +387,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	// Do checks for recursion mode
 	if parseOpts.HTTP.Recursion {
 		if !strings.HasSuffix(conf.Url, "FUZZ") {
-			errmsg := fmt.Sprintf("When using -recursion the URL (-u) must end with FUZZ keyword.")
+			errmsg := "When using -recursion the URL (-u) must end with FUZZ keyword."
 			errs.Add(fmt.Errorf(errmsg))
 		}
 	}
@@ -460,20 +460,20 @@ func parseRawRequest(parseOpts *ConfigOptions, conf *Config) error {
 
 func keywordPresent(keyword string, conf *Config) bool {
 	//Search for keyword from HTTP method, URL and POST data too
-	if strings.Index(conf.Method, keyword) != -1 {
+	if strings.Contains(conf.Method, keyword) {
 		return true
 	}
-	if strings.Index(conf.Url, keyword) != -1 {
+	if strings.Contains(conf.Url, keyword) {
 		return true
 	}
-	if strings.Index(conf.Data, keyword) != -1 {
+	if strings.Contains(conf.Data, keyword) {
 		return true
 	}
 	for k, v := range conf.Headers {
-		if strings.Index(k, keyword) != -1 {
+		if strings.Contains(k, keyword) {
 			return true
 		}
-		if strings.Index(v, keyword) != -1 {
+		if strings.Contains(v, keyword) {
 			return true
 		}
 	}

--- a/pkg/ffuf/util.go
+++ b/pkg/ffuf/util.go
@@ -25,7 +25,7 @@ func UniqStringSlice(inslice []string) []string {
 		found[v] = true
 	}
 	ret := []string{}
-	for k, _ := range found {
+	for k := range found {
 		ret = append(ret, k)
 	}
 	return ret

--- a/pkg/filter/lines_test.go
+++ b/pkg/filter/lines_test.go
@@ -10,7 +10,7 @@ import (
 func TestNewLineFilter(t *testing.T) {
 	f, _ := NewLineFilter("200,301,400-410,500")
 	linesRepr := f.Repr()
-	if strings.Index(linesRepr, "200,301,400-410,500") == -1 {
+	if !strings.Contains(linesRepr, "200,301,400-410,500") {
 		t.Errorf("Word filter was expected to have 4 values")
 	}
 }

--- a/pkg/filter/regexp_test.go
+++ b/pkg/filter/regexp_test.go
@@ -10,7 +10,7 @@ import (
 func TestNewRegexpFilter(t *testing.T) {
 	f, _ := NewRegexpFilter("s([a-z]+)arch")
 	statusRepr := f.Repr()
-	if strings.Index(statusRepr, "s([a-z]+)arch") == -1 {
+	if !strings.Contains(statusRepr, "s([a-z]+)arch") {
 		t.Errorf("Status filter was expected to have a regexp value")
 	}
 }

--- a/pkg/filter/size_test.go
+++ b/pkg/filter/size_test.go
@@ -10,7 +10,7 @@ import (
 func TestNewSizeFilter(t *testing.T) {
 	f, _ := NewSizeFilter("1,2,3,444,5-90")
 	sizeRepr := f.Repr()
-	if strings.Index(sizeRepr, "1,2,3,444,5-90") == -1 {
+	if !strings.Contains(sizeRepr, "1,2,3,444,5-90") {
 		t.Errorf("Size filter was expected to have 5 values")
 	}
 }

--- a/pkg/filter/status_test.go
+++ b/pkg/filter/status_test.go
@@ -10,7 +10,7 @@ import (
 func TestNewStatusFilter(t *testing.T) {
 	f, _ := NewStatusFilter("200,301,400-410,500")
 	statusRepr := f.Repr()
-	if strings.Index(statusRepr, "200,301,400-410,500") == -1 {
+	if !strings.Contains(statusRepr, "200,301,400-410,500") {
 		t.Errorf("Status filter was expected to have 4 values")
 	}
 }

--- a/pkg/filter/words_test.go
+++ b/pkg/filter/words_test.go
@@ -10,7 +10,7 @@ import (
 func TestNewWordFilter(t *testing.T) {
 	f, _ := NewWordFilter("200,301,400-410,500")
 	wordsRepr := f.Repr()
-	if strings.Index(wordsRepr, "200,301,400-410,500") == -1 {
+	if !strings.Contains(wordsRepr, "200,301,400-410,500") {
 		t.Errorf("Word filter was expected to have 4 values")
 	}
 }

--- a/pkg/input/command.go
+++ b/pkg/input/command.go
@@ -47,10 +47,7 @@ func (c *CommandInput) IncrementPosition() {
 
 //Next will increment the cursor position, and return a boolean telling if there's iterations left
 func (c *CommandInput) Next() bool {
-	if c.count >= c.config.InputNum {
-		return false
-	}
-	return true
+	return c.count < c.config.InputNum
 }
 
 //Value returns the input from command stdoutput

--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -57,10 +57,7 @@ func (w *WordlistInput) Keyword() string {
 
 //Next will increment the cursor position, and return a boolean telling if there's words left in the list
 func (w *WordlistInput) Next() bool {
-	if w.position >= len(w.data) {
-		return false
-	}
-	return true
+	return w.position < len(w.data)
 }
 
 //IncrementPosition will increment the current position in the inputprovider data slice

--- a/pkg/output/file_csv.go
+++ b/pkg/output/file_csv.go
@@ -25,17 +25,14 @@ func writeCSV(config *ffuf.Config, res []Result, encode bool) error {
 	for _, inputprovider := range config.InputProviders {
 		header = append(header, inputprovider.Keyword)
 	}
-
-	for _, item := range staticheaders {
-		header = append(header, item)
-	}
+	header = append(header, staticheaders...)
 
 	if err := w.Write(header); err != nil {
 		return err
 	}
 	for _, r := range res {
 		if encode {
-			inputs := make(map[string][]byte, 0)
+			inputs := make(map[string][]byte, len(r.Input))
 			for k, v := range r.Input {
 				inputs[k] = []byte(base64encode(v))
 			}

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -107,12 +107,10 @@ func (s *Stdoutput) Banner() error {
 
 	// Proxies
 	if len(s.config.ProxyURL) > 0 {
-		proxy := fmt.Sprintf("%s", s.config.ProxyURL)
-		printOption([]byte("Proxy"), []byte(proxy))
+		printOption([]byte("Proxy"), []byte(s.config.ProxyURL))
 	}
 	if len(s.config.ReplayProxyURL) > 0 {
-		replayproxy := fmt.Sprintf("%s", s.config.ReplayProxyURL)
-		printOption([]byte("ReplayProxy"), []byte(replayproxy))
+		printOption([]byte("ReplayProxy"), []byte(s.config.ReplayProxyURL))
 	}
 
 	// Timeout
@@ -152,7 +150,7 @@ func (s *Stdoutput) Progress(status ffuf.Progress) {
 		return
 	}
 
-	dur := time.Now().Sub(status.StartedAt)
+	dur := time.Since(status.StartedAt)
 	runningSecs := int(dur / time.Second)
 	var reqRate int64
 	if runningSecs > 0 {
@@ -289,7 +287,7 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 	// Check if we need the data later
 	if s.config.OutputFile != "" {
 		// No need to store results if we're not going to use them later
-		inputs := make(map[string][]byte, 0)
+		inputs := make(map[string][]byte, len(resp.Request.Input))
 		for k, v := range resp.Request.Input {
 			inputs[k] = v
 		}
@@ -404,14 +402,13 @@ func (s *Stdoutput) resultMultiline(resp ffuf.Response) {
 }
 
 func (s *Stdoutput) resultNormal(resp ffuf.Response) {
-	var res_str string
-	res_str = fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(resp), s.colorize(fmt.Sprintf("%d", resp.StatusCode), resp.StatusCode), resp.ContentLength, resp.ContentWords, resp.ContentLines)
-	fmt.Println(res_str)
+	res := fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(resp), s.colorize(fmt.Sprintf("%d", resp.StatusCode), resp.StatusCode), resp.ContentLength, resp.ContentWords, resp.ContentLines)
+	fmt.Println(res)
 }
 
 func (s *Stdoutput) colorize(input string, status int64) string {
 	if !s.config.Colors {
-		return fmt.Sprintf("%s", input)
+		return input
 	}
 	colorCode := ANSI_CLEAR
 	if status >= 200 && status < 300 {

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -78,7 +78,7 @@ func (r *SimpleRunner) Prepare(input map[string][]byte) (ffuf.Request, error) {
 
 	for keyword, inputitem := range input {
 		req.Method = strings.ReplaceAll(req.Method, keyword, string(inputitem))
-		headers := make(map[string]string, 0)
+		headers := make(map[string]string, len(req.Headers))
 		for h, v := range req.Headers {
 			var CanonicalHeader string = textproto.CanonicalMIMEHeaderKey(strings.ReplaceAll(h, keyword, string(inputitem)))
 			headers[CanonicalHeader] = strings.ReplaceAll(v, keyword, string(inputitem))


### PR DESCRIPTION
### What does this PR do?

It attempts to handle [`gosimple`](https://github.com/dominikh/go-tools/tree/master/simple) linter findings.

This change is an attempt to handle gosimple linter finfings in order to make the code easier to follow. It includes the following changes:

- use [`strings.Contains`](https://pkg.go.dev/strings#Contains) instead of `strings.Index` `!= -1`. As you can see in its [implementation](https://github.com/golang/go/blob/go1.15.2/src/strings/strings.go#L61), there's no performance improvement/consequence.
- use [`time.Since`](https://github.com/golang/go/blob/go1.15.2/src/time/time.go#L866-L867) standard library helper.
- remove unneeded return statements at the end of methods
- preallocate maps when their capacity is known [1]
- avoid underscoring values when they can be omitted. See this [playground](https://play.golang.org/p/UkgTavZIov3).
- avoid `fmt.Sprintf()` calls when the only argument is already a string

[1] In regards of the maps preallocation, it isn't that important as long as the maps aren't too big. Go maps are allocated with a small capacity if no size is provided. Then, their capacity is doubled after a certain load factor is reached. Growing their capacity means that, often, number of buckets must be doubled and entries need to be redistributed across them.

More information on how they're implemented can be found at: https://dave.cheney.net/2018/05/29/how-the-go-runtime-implements-maps-efficiently-without-generics
More information on how the load factor is chosen can be found at: https://github.com/golang/go/blob/a3868028ac8470d1ab7782614707bb90925e7fe3/src/runtime/map.go#L19L36

### Why do we need it?

It's part of my efforts to make ffuf simpler. In my opinion all simplifications improve readability and make contributors experience better. Please, feel free to close this PR if you disagree.

Best,
Miguel