### PR TITLE
pkg/ffuf: fix panic in Windows when parsing wordlist flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     - Fixed the issue where the option -ac was overwriting existing filters. Now auto-calibration will add them where needed.
     - The `-w` flag now accepts comma delimited values in the form of `file1:W1,file2:W2`.
     - Links in the HTML report are now clickable
+    - Fixed panic during wordlist flag parsing in Windows systems.
 
 - v1.1.0
   - New

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -176,7 +176,11 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 				// The wordlist was supplied without a keyword parameter
 				wl = []string{v}
 			} else {
-				filepart := v[:strings.LastIndex(v, ":")]
+				filepart := v
+				if strings.Contains(filepart, ":") {
+					filepart = v[:strings.LastIndex(filepart, ":")]
+				}
+
 				if FileExists(filepart) {
 					wl = []string{filepart, v[strings.LastIndex(v, ":")+1:]}
 				} else {

--- a/pkg/ffuf/util.go
+++ b/pkg/ffuf/util.go
@@ -31,11 +31,13 @@ func UniqStringSlice(inslice []string) []string {
 	return ret
 }
 
-//FileExists checks if the filepath exists and is not a directory
+//FileExists checks if the filepath exists and is not a directory.
+//Returns false in case it's not possible to describe the named file.
 func FileExists(path string) bool {
 	md, err := os.Stat(path)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
+
 	return !md.IsDir()
 }


### PR DESCRIPTION
## Description

This change addresses two panics that happened while parsing the provided wordlist flag in Windows systems.

- [`pkg/ffuf/util.go:40`](https://github.com/ffuf/ffuf/blob/602c1c79e8399ccae5f6f7d645ab4f8e47e77118/pkg/ffuf/util.go#L34-L41): panic happened when the provided path was invalid. Example: `.\wordlist.txt:` as the `os.Stat` call returned an error different than `os.ErrNotExist`.

- [`pkg/ffuf/optionsparser.go:179`](https://github.com/ffuf/ffuf/blob/602c1c79e8399ccae5f6f7d645ab4f8e47e77118/pkg/ffuf/optionsparser.go#L179): panic happened when the provided value did not existed and did not contain a colon character. Example: `.\asdf.txt` when the local file `.\asdf.txt` did not exist. This panic happened due to `strings.LastIndex` returning `-1` when the provided substring does not appear. Therefore, `v[:-1]` panicking.

Fixes #333

## Additonally

- [x] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`. 
The file should be alphabetically ordered.
- [x] Add a short description of the fix to `CHANGELOG.md`

---

**Please, test this patch thoroughly using a Windows system before merging it**. I'd like to contribute unit tests for this patch too in order to avoid having a regression or incomplete fix. However, it would require a bigger refactor of the file rather than just 2 panic fixes.

**Note**: [`pkg/ffuf/optionsparser.go:181`](https://github.com/ffuf/ffuf/blob/602c1c79e8399ccae5f6f7d645ab4f8e47e77118/pkg/ffuf/optionsparser.go#L181) (L185 on my patch) does not panic as `strings.LastIndex` returning -1 will make the slice access to be `v[0:]`, preserving the complete `v`value. It would be nice to prevent this in a next patch, though.
