### PR TITLE
Allow input-shell option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - Ffuf now reads a default configuration file `$HOME/.ffufrc` upon startup. Options set in this file
     are overwritten by the ones provided on CLI.
     - Change banner logging to stderr instead of stdout.
+    - New CLI flag `-input-shell` to set the shell to be used by `input-cmd`
 
   - Changed
     - Pre-flight errors are now displayed also after the usage text to prevent the need to scroll through backlog.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
 * [JamTookTheBait](https://github.com/JamTookTheBait)
 * [jimen0](https://github.com/jimen0)
 * [joohoi](https://github.com/joohoi)
+* [jsgv](https://github.com/jsgv)
 * [jvesiluoma](https://github.com/jvesiluoma)
 * [Kiblyn11](https://github.com/Kiblyn11)
 * [lc](https://github.com/lc)

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.HTTP.URL, "u", opts.HTTP.URL, "Target URL")
 	flag.StringVar(&opts.Input.Extensions, "e", opts.Input.Extensions, "Comma separated list of extensions. Extends FUZZ keyword.")
 	flag.StringVar(&opts.Input.InputMode, "mode", opts.Input.InputMode, "Multi-wordlist operation mode. Available modes: clusterbomb, pitchfork")
+	flag.StringVar(&opts.Input.InputShell, "input-shell", opts.Input.InputShell, "Shell to be used for running command")
 	flag.StringVar(&opts.Input.Request, "request", opts.Input.Request, "File containing the raw http request")
 	flag.StringVar(&opts.Input.RequestProto, "request-proto", opts.Input.RequestProto, "Protocol to use along with raw request")
 	flag.StringVar(&opts.Matcher.Lines, "ml", opts.Matcher.Lines, "Match amount of lines in response")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	InputMode              string                    `json:"inputmode"`
 	InputNum               int                       `json:"cmd_inputnum"`
 	InputProviders         []InputProviderConfig     `json:"inputproviders"`
+	InputShell             string                    `json:"inputshell"`
 	Matchers               map[string]FilterProvider `json:"matchers"`
 	MaxTime                int                       `json:"maxtime"`
 	MaxTimeJob             int                       `json:"maxtime_job"`
@@ -70,6 +71,7 @@ func NewConfig(ctx context.Context, cancel context.CancelFunc) Config {
 	conf.IgnoreWordlistComments = false
 	conf.InputMode = "clusterbomb"
 	conf.InputNum = 0
+	conf.InputShell = ""
 	conf.InputProviders = make([]InputProviderConfig, 0)
 	conf.Matchers = make(map[string]FilterProvider)
 	conf.MaxTime = 0

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -64,6 +64,7 @@ type InputOptions struct {
 	IgnoreWordlistComments bool
 	InputMode              string
 	InputNum               int
+	InputShell             string
 	Inputcommands          []string
 	Request                string
 	RequestProto           string
@@ -372,6 +373,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	conf.Colors = parseOpts.General.Colors
 	conf.InputNum = parseOpts.Input.InputNum
 	conf.InputMode = parseOpts.Input.InputMode
+	conf.InputShell = parseOpts.Input.InputShell
 	conf.OutputFile = parseOpts.Output.OutputFile
 	conf.OutputDirectory = parseOpts.Output.OutputDirectory
 	conf.IgnoreBody = parseOpts.HTTP.IgnoreBody

--- a/pkg/input/command.go
+++ b/pkg/input/command.go
@@ -14,6 +14,7 @@ type CommandInput struct {
 	count   int
 	keyword string
 	command string
+	shell   string
 }
 
 func NewCommandInput(keyword string, value string, conf *ffuf.Config) (*CommandInput, error) {
@@ -22,6 +23,12 @@ func NewCommandInput(keyword string, value string, conf *ffuf.Config) (*CommandI
 	cmd.config = conf
 	cmd.count = 0
 	cmd.command = value
+	cmd.shell = SHELL_CMD
+
+	if cmd.config.InputShell != "" {
+		cmd.shell = cmd.config.InputShell
+	}
+
 	return &cmd, nil
 }
 
@@ -54,7 +61,7 @@ func (c *CommandInput) Next() bool {
 func (c *CommandInput) Value() []byte {
 	var stdout bytes.Buffer
 	os.Setenv("FFUF_NUM", strconv.Itoa(c.count))
-	cmd := exec.Command(SHELL_CMD, SHELL_ARG, c.command)
+	cmd := exec.Command(c.shell, SHELL_ARG, c.command)
 	cmd.Stdout = &stdout
 	err := cmd.Run()
 	if err != nil {


### PR DESCRIPTION
**This is a new pull request that replaces original [pull request](https://github.com/ffuf/ffuf/pull/293)**

* Add flag to set the shell to be used for the the input command


This is in response to issue #141 
Adds support to set the shell to be used with `input-cmd`. Fixes some issues that happen when using the [default shell](https://github.com/ffuf/ffuf/blob/master/pkg/input/const.go#L6) (`/bin/sh`). But still defaults to current shell if not set.

For example:
`echo` does not support `-n` flag in `/bin/sh`

Being able to set `/bin/zsh` or `/bin/bash` would fix the issue.

Usage:
```
ffuf -v \
    -input-shell "/bin/zsh" \
    -input-cmd 'echo -n subscriptions' \
    -input-num 1 -u https://example.com/path1/FUZZ
```


