### PR TITLE
Release 1.2.1

### DIFF
--- a/help.go
+++ b/help.go
@@ -89,7 +89,7 @@ func Usage() {
 		Description:   "Options for input data for fuzzing. Wordlists and input generators.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"D", "ic", "input-cmd", "input-num", "mode", "request", "request-proto", "e", "w"},
+		ExpectedFlags: []string{"D", "ic", "input-cmd", "input-num", "input-shell", "mode", "request", "request-proto", "e", "w"},
 	}
 	u_output := UsageSection{
 		Name:          "OUTPUT OPTIONS",

--- a/pkg/ffuf/const.go
+++ b/pkg/ffuf/const.go
@@ -2,5 +2,5 @@ package ffuf
 
 const (
 	//VERSION holds the current version number
-	VERSION = "1.3.0-git"
+	VERSION = "1.2.1"
 )


### PR DESCRIPTION
Point release to fix issues with the help text in `input-shell` param.