### PR TITLE
Trim slash prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 - master
   - New
   - Changed
-  
+
+- v1.2.2
+  - New
+    - New CLI Flag `-sp` to automatically trim prefixed slashes in a wordlist
+ 
 - v1.2.1
   - Changed
     - Fixed a build breaking bug in `input-shell` parameter

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,5 @@
 # Contributors
+* [3lpsy](https://github.com/3lpsy)
 * [AverageSecurityGuy](https://github.com/averagesecurityguy)
 * [bp0](https://github.com/bp0lr)
 * [bjhulst](https://github.com/bjhulst)

--- a/help.go
+++ b/help.go
@@ -61,7 +61,7 @@ func Usage() {
 		Description:   "",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"ac", "acc", "c", "config", "maxtime", "maxtime-job", "p", "rate", "s", "sa", "se", "sf", "t", "v", "V"},
+		ExpectedFlags: []string{"ac", "acc", "c", "config", "maxtime", "maxtime-job", "p", "rate", "s", "sa", "se", "sf", "sp", "t", "v", "V"},
 	}
 	u_compat := UsageSection{
 		Name:          "COMPATIBILITY OPTIONS",

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.BoolVar(&opts.General.StopOn403, "sf", opts.General.StopOn403, "Stop when > 95% of responses return 403 Forbidden")
 	flag.BoolVar(&opts.General.StopOnAll, "sa", opts.General.StopOnAll, "Stop on all error cases. Implies -sf and -se.")
 	flag.BoolVar(&opts.General.StopOnErrors, "se", opts.General.StopOnErrors, "Stop on spurious errors")
+	flag.BoolVar(&opts.General.StripSlash, "sp", opts.General.StripSlash, "Strip preceeding slash on wordlist item (if exists).")
 	flag.BoolVar(&opts.General.Verbose, "v", opts.General.Verbose, "Verbose output, printing full URL and redirect location (if any) with the results.")
 	flag.BoolVar(&opts.HTTP.FollowRedirects, "r", opts.HTTP.FollowRedirects, "Follow redirects")
 	flag.BoolVar(&opts.HTTP.IgnoreBody, "ignore-body", opts.HTTP.IgnoreBody, "Do not fetch the response content.")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	OutputDirectory        string                    `json:"outputdirectory"`
 	OutputFile             string                    `json:"outputfile"`
 	OutputFormat           string                    `json:"outputformat"`
-	OutputCreateEmptyFile  bool	                     `json:"OutputCreateEmptyFile"`
+	OutputCreateEmptyFile  bool                      `json:"OutputCreateEmptyFile"`
 	ProgressFrequency      int                       `json:"-"`
 	ProxyURL               string                    `json:"proxyurl"`
 	Quiet                  bool                      `json:"quiet"`
@@ -44,6 +44,7 @@ type Config struct {
 	StopOn403              bool                      `json:"stop_403"`
 	StopOnAll              bool                      `json:"stop_all"`
 	StopOnErrors           bool                      `json:"stop_errors"`
+	StripSlash             bool                      `json:"strip_slash"`
 	Threads                int                       `json:"threads"`
 	Timeout                int                       `json:"timeout"`
 	Url                    string                    `json:"url"`
@@ -87,6 +88,7 @@ func NewConfig(ctx context.Context, cancel context.CancelFunc) Config {
 	conf.StopOn403 = false
 	conf.StopOnAll = false
 	conf.StopOnErrors = false
+	conf.StripSlash = false
 	conf.Timeout = 10
 	conf.Url = ""
 	conf.Verbose = false

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -54,6 +54,7 @@ type GeneralOptions struct {
 	StopOn403              bool
 	StopOnAll              bool
 	StopOnErrors           bool
+	StripSlash             bool
 	Threads                int
 	Verbose                bool
 }
@@ -114,6 +115,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.General.StopOn403 = false
 	c.General.StopOnAll = false
 	c.General.StopOnErrors = false
+	c.General.StripSlash = false
 	c.General.Threads = 40
 	c.General.Verbose = false
 	c.HTTP.Data = ""
@@ -384,6 +386,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	conf.StopOn403 = parseOpts.General.StopOn403
 	conf.StopOnAll = parseOpts.General.StopOnAll
 	conf.StopOnErrors = parseOpts.General.StopOnErrors
+	conf.StripSlash = parseOpts.General.StripSlash
 	conf.FollowRedirects = parseOpts.HTTP.FollowRedirects
 	conf.Recursion = parseOpts.HTTP.Recursion
 	conf.RecursionDepth = parseOpts.HTTP.RecursionDepth

--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -109,7 +109,11 @@ func (w *WordlistInput) readFile(path string) error {
 	re := regexp.MustCompile(`(?i)%ext%`)
 	for reader.Scan() {
 		if w.config.DirSearchCompat && len(w.config.Extensions) > 0 {
-			text := []byte(reader.Text())
+			raw := reader.Text()
+			if w.config.StripSlash {
+				raw = strings.TrimPrefix(raw, "/")
+			}
+			text := []byte(raw)
 			if re.Match(text) {
 				for _, ext := range w.config.Extensions {
 					contnt := re.ReplaceAll(text, []byte(ext))
@@ -128,7 +132,9 @@ func (w *WordlistInput) readFile(path string) error {
 			}
 		} else {
 			text := reader.Text()
-
+			if w.config.StripSlash {
+				text = strings.TrimPrefix(text, "/")
+			}
 			if w.config.IgnoreWordlistComments {
 				text, ok = stripComments(text)
 				if !ok {


### PR DESCRIPTION
# Description

This PR adds the option to automatically trim prefixes preceeding slashes from a wordlist. For example, if a wordlist contains:

```
/x.txt
profile
/admin
```
ffuf would make the following requests for `ffuf -u http://acme.com/FUZZ -w lists.txt -sp`:

```
/x.txt => http://acme.com/x.txt
profile => http://acme.com/profile
/admin => http://acme.com/admin
```

## Rationale

Typically, I would say that the wordlist should be prepared for the tool and context where the wordlist will be used. However, I have found myself creating countless duplicates of wordlists with the appendix "somelist-noslash.txt". I thought this would be a nice quality of life addition and save people time when switching to fresh VMs without having to load/prep custom wordlists.
