### PR TITLE
Fix Job - Recursion [Bug]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - New
      - All output file formats now include the `Content-Type`.
   - Changed
+    - Fix impossible condition in starting a recursion job
     - Fix a badchar in progress output
   
 - v1.2.1

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -108,7 +108,7 @@ func (j *Job) Start() {
 	for j.jobsInQueue() {
 		j.prepareQueueJob()
 
-		if j.queuepos > 1 && !j.RunningJob {
+		if j.queuepos > 1 {
 			// Print info for queued recursive jobs
 			j.Output.Info(fmt.Sprintf("Scanning: %s", j.Config.Url))
 		}


### PR DESCRIPTION
Fix impossible condition in starting a recursion job
It now prints "[INFO] Scanning: http://URL/FUZZ" after the first job as intended.