### PR TITLE
Add flag for automatic naming of output files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Changelog
 - master
   - New
-     - All output file formats now include the `Content-Type`.
+    - All output file formats now include the `Content-Type`.
+    - Added a flag for automatic naming of output files. The name depends on the value of the URL.
   - Changed
     - Fix a badchar in progress output
   

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@
 * [jsgv](https://github.com/jsgv)
 * [jvesiluoma](https://github.com/jvesiluoma)
 * [Kiblyn11](https://github.com/Kiblyn11)
+* [KwnyPwny](https://github.com/KwnyPwny)
 * [lc](https://github.com/lc)
 * [nnwakelam](https://twitter.com/nnwakelam)
 * [noraj](https://pwn.by/noraj)

--- a/help.go
+++ b/help.go
@@ -96,7 +96,7 @@ func Usage() {
 		Description:   "Options for output. Output file formats, file names and debug file locations.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"debug-log", "o", "of", "od", "or"},
+		ExpectedFlags: []string{"debug-log", "o", "of", "od", "or", "oa"},
 	}
 	sections := []UsageSection{u_http, u_general, u_compat, u_matcher, u_filter, u_input, u_output}
 

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.BoolVar(&opts.HTTP.IgnoreBody, "ignore-body", opts.HTTP.IgnoreBody, "Do not fetch the response content.")
 	flag.BoolVar(&opts.HTTP.Recursion, "recursion", opts.HTTP.Recursion, "Scan recursively. Only FUZZ keyword is supported, and URL (-u) has to end in it.")
 	flag.BoolVar(&opts.Input.DirSearchCompat, "D", opts.Input.DirSearchCompat, "DirSearch wordlist compatibility mode. Used in conjunction with -e flag.")
+	flag.BoolVar(&opts.Output.AutoName, "oa", opts.Output.AutoName, "Automatic naming of output file depending on URL.")
 	flag.BoolVar(&opts.Input.IgnoreWordlistComments, "ic", opts.Input.IgnoreWordlistComments, "Ignore wordlist comments")
 	flag.IntVar(&opts.General.MaxTime, "maxtime", opts.General.MaxTime, "Maximum running time in seconds for entire process.")
 	flag.IntVar(&opts.General.MaxTimeJob, "maxtime-job", opts.General.MaxTimeJob, "Maximum running time in seconds per job.")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	OutputFile             string                    `json:"outputfile"`
 	OutputFormat           string                    `json:"outputformat"`
 	OutputCreateEmptyFile  bool	                     `json:"OutputCreateEmptyFile"`
+	AutoName               bool                      `json:"AutoName"`
 	ProgressFrequency      int                       `json:"-"`
 	ProxyURL               string                    `json:"proxyurl"`
 	Quiet                  bool                      `json:"quiet"`

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"regexp"
 
 	"github.com/pelletier/go-toml"
 )
@@ -77,6 +78,7 @@ type OutputOptions struct {
 	OutputFile      string
 	OutputFormat    string
 	OutputCreateEmptyFile	bool
+	AutoName	bool
 }
 
 type FilterOptions struct {
@@ -143,6 +145,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.Output.OutputFile = ""
 	c.Output.OutputFormat = "json"
 	c.Output.OutputCreateEmptyFile = false
+	c.Output.AutoName = false
 	return c
 }
 
@@ -317,6 +320,18 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 		}
 	}
 
+	//Prefer Outputfile if it was defined
+	if parseOpts.Output.OutputFile != "" {
+		conf.OutputFile = parseOpts.Output.OutputFile
+	} else {
+		if parseOpts.Output.AutoName {
+			specialChars := regexp.MustCompile(`[:/\?\=\&]+`)
+			autoName := specialChars.ReplaceAllString(conf.Url, "-")
+			parseOpts.Output.OutputFile = autoName
+			conf.OutputFile = autoName
+		}
+	}
+
 	//Check the output file format option
 	if parseOpts.Output.OutputFile != "" {
 		//No need to check / error out if output file isn't defined
@@ -376,9 +391,9 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	conf.InputNum = parseOpts.Input.InputNum
 	conf.InputMode = parseOpts.Input.InputMode
 	conf.InputShell = parseOpts.Input.InputShell
-	conf.OutputFile = parseOpts.Output.OutputFile
 	conf.OutputDirectory = parseOpts.Output.OutputDirectory
 	conf.OutputCreateEmptyFile = parseOpts.Output.OutputCreateEmptyFile
+	conf.AutoName = parseOpts.Output.AutoName
 	conf.IgnoreBody = parseOpts.HTTP.IgnoreBody
 	conf.Quiet = parseOpts.General.Quiet
 	conf.StopOn403 = parseOpts.General.StopOn403

--- a/pkg/output/file_csv.go
+++ b/pkg/output/file_csv.go
@@ -12,13 +12,17 @@ import (
 var staticheaders = []string{"url", "redirectlocation", "position", "status_code", "content_length", "content_words", "content_lines", "content_type", "resultfile"}
 
 func writeCSV(config *ffuf.Config, res []Result, encode bool) error {
-	
+
 	if(config.OutputCreateEmptyFile && (len(res) == 0)){
 		return nil
 	}
-	
+
 	header := make([]string, 0)
-	f, err := os.Create(config.OutputFile)
+	extension := ".csv"
+	if encode {
+		extension = ".ecsv"
+	}
+	f, err := os.Create(config.OutputFile + extension)
 	if err != nil {
 		return err
 	}

--- a/pkg/output/file_html.go
+++ b/pkg/output/file_html.go
@@ -36,12 +36,12 @@ const (
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"
 	/>
-	<link 
-	  rel="stylesheet" 
-	  type="text/css" 
+	<link
+	  rel="stylesheet"
+	  type="text/css"
 	  href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.css"
 	/>
-  
+
   </head>
 
   <body>
@@ -181,7 +181,7 @@ func writeHTML(config *ffuf.Config, results []Result) error {
   if(config.OutputCreateEmptyFile && (len(results) == 0)){
 		return nil
   }
-  
+
 	results = colorizeResults(results)
 
 	ti := time.Now()
@@ -198,7 +198,7 @@ func writeHTML(config *ffuf.Config, results []Result) error {
 		Keys:        keywords,
 	}
 
-	f, err := os.Create(config.OutputFile)
+	f, err := os.Create(config.OutputFile + ".html")
 	if err != nil {
 		return err
 	}

--- a/pkg/output/file_json.go
+++ b/pkg/output/file_json.go
@@ -37,11 +37,11 @@ type jsonFileOutput struct {
 }
 
 func writeEJSON(config *ffuf.Config, res []Result) error {
-	
+
 	if(config.OutputCreateEmptyFile && (len(res) == 0)){
 		return nil
 	}
-	
+
 	t := time.Now()
 	outJSON := ejsonFileOutput{
 		CommandLine: config.CommandLine,
@@ -53,7 +53,7 @@ func writeEJSON(config *ffuf.Config, res []Result) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(config.OutputFile, outBytes, 0644)
+	err = ioutil.WriteFile(config.OutputFile + ".ejson", outBytes, 0644)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func writeJSON(config *ffuf.Config, res []Result) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(config.OutputFile, outBytes, 0644)
+	err = ioutil.WriteFile(config.OutputFile + ".json", outBytes, 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/output/file_md.go
+++ b/pkg/output/file_md.go
@@ -40,7 +40,7 @@ func writeMarkdown(config *ffuf.Config, res []Result) error {
 		Keys:        keywords,
 	}
 
-	f, err := os.Create(config.OutputFile)
+	f, err := os.Create(config.OutputFile + ".md")
 	if err != nil {
 		return err
 	}

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -14,12 +14,12 @@ import (
 
 const (
 	BANNER_HEADER = `
-        /'___\  /'___\           /'___\       
-       /\ \__/ /\ \__/  __  __  /\ \__/       
-       \ \ ,__\\ \ ,__\/\ \/\ \ \ \ ,__\      
-        \ \ \_/ \ \ \_/\ \ \_\ \ \ \ \_/      
-         \ \_\   \ \_\  \ \____/  \ \_\       
-          \/_/    \/_/   \/___/    \/_/       
+        /'___\  /'___\           /'___\
+       /\ \__/ /\ \__/  __  __  /\ \__/
+       \ \ ,__\\ \ ,__\/\ \/\ \ \ \ ,__\
+        \ \ \_/ \ \ \_/\ \ \_\ \ \ \ \_/
+         \ \_\   \ \_\  \ \____/  \ \_\
+          \/_/    \/_/   \/___/    \/_/
 `
 	BANNER_SEP = "________________________________________________"
 )
@@ -206,7 +206,6 @@ func (s *Stdoutput) Warning(warnstring string) {
 
 func (s *Stdoutput) writeToAll(config *ffuf.Config, res []Result) error {
 	var err error
-	var BaseFilename string = s.config.OutputFile
 
 	// Go through each type of write, adding
 	// the suffix to each output file.
@@ -215,37 +214,31 @@ func (s *Stdoutput) writeToAll(config *ffuf.Config, res []Result) error {
 		return nil
   	}
 
-	s.config.OutputFile = BaseFilename + ".json"
 	err = writeJSON(s.config, s.Results)
 	if err != nil {
 		s.Error(err.Error())
 	}
 
-	s.config.OutputFile = BaseFilename + ".ejson"
 	err = writeEJSON(s.config, s.Results)
 	if err != nil {
 		s.Error(err.Error())
 	}
 
-	s.config.OutputFile = BaseFilename + ".html"
 	err = writeHTML(s.config, s.Results)
 	if err != nil {
 		s.Error(err.Error())
 	}
 
-	s.config.OutputFile = BaseFilename + ".md"
 	err = writeMarkdown(s.config, s.Results)
 	if err != nil {
 		s.Error(err.Error())
 	}
 
-	s.config.OutputFile = BaseFilename + ".csv"
 	err = writeCSV(s.config, s.Results, false)
 	if err != nil {
 		s.Error(err.Error())
 	}
 
-	s.config.OutputFile = BaseFilename + ".ecsv"
 	err = writeCSV(s.config, s.Results, true)
 	if err != nil {
 		s.Error(err.Error())


### PR DESCRIPTION
# Description

This pull requests adds a flag `-oa` for automatic naming of output files.
The name depends on the URL given.
This can be shown most easily with an **example**:
Cmd: `ffuf -u 'https://www.google.com:443/FUZZ?a=1&b=2' -w words -oa -of md`
Output file name: `https-www.google.com-443-FUZZ-a-1-b-2.md`
 
Note how special characters are replaced with `-` such that file names are valid.

The other naming flags still work like before. `-o` overwrites `-oa`.
However, in order to append extensions to automatic file names, I had to change the output writers to always append the respective extension.

This changes the behavior of ffuf as follows:
**Before:**
Cmd: `ffuf -u https://www.google.com/FUZZ -w words -of md -o output`
Output file name: `output`

**After:**
Cmd: `ffuf -u https://www.google.com/FUZZ -w words -of md -o output`
Output file name: `output.md`

Personally, I think this is more consistent, also regarding that the `-of all` always added extensions to file names.

I'm happy about feedback :)