### PR TITLE
Fix: Create output directory recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
      - All output file formats now include the `Content-Type`.
   - Changed
     - Fix a badchar in progress output
+    - Fixed output writing so it doesn't silently fail if it needs to create directories recursively
   
 - v1.2.1
   - Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@
 * [jvesiluoma](https://github.com/jvesiluoma)
 * [Kiblyn11](https://github.com/Kiblyn11)
 * [lc](https://github.com/lc)
+* [mprencipe](https://github.com/mprencipe)
 * [nnwakelam](https://twitter.com/nnwakelam)
 * [noraj](https://pwn.by/noraj)
 * [oh6hay](https://github.com/oh6hay)

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -318,7 +318,7 @@ func (s *Stdoutput) writeResultToFile(resp ffuf.Response) string {
 	var fileContent, fileName, filePath string
 	// Create directory if needed
 	if s.config.OutputDirectory != "" {
-		err := os.Mkdir(s.config.OutputDirectory, 0750)
+		err := os.MkdirAll(s.config.OutputDirectory, 0750)
 		if err != nil {
 			if !os.IsExist(err) {
 				s.Error(err.Error())


### PR DESCRIPTION
# Description

Output directory is now created recursively if the given directory path doesn't exist. Previously the output writing would silently fail in this case.

Fixes: #395 

## Additionally

- [x] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`. 
The file should be alphabetically ordered.
- [x] Add a short description of the fix to `CHANGELOG.md`