### PR TITLE
add recursion-on-code flag

### DIFF
--- a/help.go
+++ b/help.go
@@ -54,7 +54,7 @@ func Usage() {
 		Description:   "Options controlling the HTTP request and its parts.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"H", "X", "b", "d", "r", "u", "recursion", "recursion-depth", "replay-proxy", "timeout", "ignore-body", "x"},
+		ExpectedFlags: []string{"H", "X", "b", "d", "r", "u", "recursion", "recursion-depth", "recursion-on-code", "replay-proxy", "timeout", "ignore-body", "x"},
 	}
 	u_general := UsageSection{
 		Name:          "GENERAL OPTIONS",

--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.HTTP.Method, "X", opts.HTTP.Method, "HTTP method to use")
 	flag.StringVar(&opts.HTTP.ProxyURL, "x", opts.HTTP.ProxyURL, "HTTP Proxy URL")
 	flag.StringVar(&opts.HTTP.ReplayProxyURL, "replay-proxy", opts.HTTP.ReplayProxyURL, "Replay matched requests using this proxy.")
+	flag.StringVar(&opts.HTTP.RecursionOnCode, "recursion-on-code", opts.HTTP.RecursionOnCode, "Recursion only on matched HTTP status code, comma separated list of codes and ranges")
 	flag.StringVar(&opts.HTTP.URL, "u", opts.HTTP.URL, "Target URL")
 	flag.StringVar(&opts.Input.Extensions, "e", opts.Input.Extensions, "Comma separated list of extensions. Extends FUZZ keyword.")
 	flag.StringVar(&opts.Input.InputMode, "mode", opts.Input.InputMode, "Multi-wordlist operation mode. Available modes: clusterbomb, pitchfork")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Rate                   int64                     `json:"rate"`
 	Recursion              bool                      `json:"recursion"`
 	RecursionDepth         int                       `json:"recursion_depth"`
+	RecursionOnCode        []ValueRange              `json:"recursion_on_code"`
 	ReplayProxyURL         string                    `json:"replayproxyurl"`
 	StopOn403              bool                      `json:"stop_403"`
 	StopOnAll              bool                      `json:"stop_all"`
@@ -84,6 +85,7 @@ func NewConfig(ctx context.Context, cancel context.CancelFunc) Config {
 	conf.Rate = 0
 	conf.Recursion = false
 	conf.RecursionDepth = 0
+	conf.RecursionOnCode = make([]ValueRange, 0)
 	conf.StopOn403 = false
 	conf.StopOnAll = false
 	conf.StopOnErrors = false

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -322,10 +322,21 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 	}
 }
 
+
+func (j *Job) matchedRecursionCode(resp Response) bool {
+    for _, iv := range j.Config.RecursionOnCode {
+        if iv.Min <= resp.StatusCode && resp.StatusCode <= iv.Max {
+            return true
+        }
+    }
+    return false
+}
+
+
 //handleRecursionJob adds a new recursion job to the job queue if a new directory is found
 func (j *Job) handleRecursionJob(resp Response) {
-	if (resp.Request.Url + "/") != resp.GetRedirectLocation(true) {
-		// Not a directory, return early
+	if (resp.Request.Url + "/") != resp.GetRedirectLocation(true) || !j.matchedRecursionCode(resp) {
+		// Not a directory or status code not wanted, return early
 		return
 	}
 	if j.Config.RecursionDepth == 0 || j.currentDepth < j.Config.RecursionDepth {

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -35,6 +35,7 @@ type HTTPOptions struct {
 	ProxyURL        string
 	Recursion       bool
 	RecursionDepth  int
+	RecursionOnCode string
 	ReplayProxyURL  string
 	Timeout         int
 	URL             string
@@ -123,6 +124,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.HTTP.ProxyURL = ""
 	c.HTTP.Recursion = false
 	c.HTTP.RecursionDepth = 0
+	c.HTTP.RecursionOnCode = ""
 	c.HTTP.ReplayProxyURL = ""
 	c.HTTP.Timeout = 10
 	c.HTTP.URL = ""
@@ -368,6 +370,17 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 		// populating it through raw request in the first iteration
 		conf.Data = parseOpts.HTTP.Data
 	}
+
+    if parseOpts.HTTP.RecursionOnCode != "" {
+        for _, sv := range strings.Split(parseOpts.HTTP.RecursionOnCode, ",") {
+            vr, err := ValueRangeFromString(sv)
+            if err != nil {
+                errs.Add(fmt.Errorf("Recursion on status code (-recursion-on-code): invalid value %s", sv))
+            } else {
+                conf.RecursionOnCode = append(conf.RecursionOnCode, vr)
+            }
+        }
+    }
 
 	// Common stuff
 	conf.IgnoreWordlistComments = parseOpts.Input.IgnoreWordlistComments


### PR DESCRIPTION
# Description

I think I added the feature requested in #259.
It adds a flag `-recursion-on-code` expecting comma separated HTTP status codes or ranges. Then the recursion will only take place on directories returning status codes matching those `-recursion-on-code` codes.

Fixes: #259 

## Additonally

- [ ] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`. 
The file should be alphabetically ordered.
- [ ] Add a short description of the fix to `CHANGELOG.md`

Thanks for contributing to ffuf :)
