### PR TITLE
Add flag to ignore certain words from wordlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - master
   - New
      - All output file formats now include the `Content-Type`.
+     - New CLI flag `-iw` to provide a list of substrings, which, if present within a words from the wordlist (`-w`), exclude this word from the tests. 
   - Changed
     - Fix a badchar in progress output
   

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@
 * [jsgv](https://github.com/jsgv)
 * [jvesiluoma](https://github.com/jvesiluoma)
 * [Kiblyn11](https://github.com/Kiblyn11)
+* [KwnyPwny](https://github.com/KwnyPwny)
 * [lc](https://github.com/lc)
 * [nnwakelam](https://twitter.com/nnwakelam)
 * [noraj](https://pwn.by/noraj)

--- a/help.go
+++ b/help.go
@@ -89,7 +89,7 @@ func Usage() {
 		Description:   "Options for input data for fuzzing. Wordlists and input generators.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"D", "ic", "input-cmd", "input-num", "input-shell", "mode", "request", "request-proto", "e", "w"},
+		ExpectedFlags: []string{"D", "ic", "input-cmd", "input-num", "input-shell", "iw", "mode", "request", "request-proto", "e", "w"},
 	}
 	u_output := UsageSection{
 		Name:          "OUTPUT OPTIONS",

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.HTTP.ReplayProxyURL, "replay-proxy", opts.HTTP.ReplayProxyURL, "Replay matched requests using this proxy.")
 	flag.StringVar(&opts.HTTP.URL, "u", opts.HTTP.URL, "Target URL")
 	flag.StringVar(&opts.Input.Extensions, "e", opts.Input.Extensions, "Comma separated list of extensions. Extends FUZZ keyword.")
+	flag.StringVar(&opts.Input.IgnoreWords, "iw", opts.Input.IgnoreWords, "Comma separated list of substrings to ignore from wordlists. If a word contains one of the substrings, it is excluded from the wordlist.")
 	flag.StringVar(&opts.Input.InputMode, "mode", opts.Input.InputMode, "Multi-wordlist operation mode. Available modes: clusterbomb, pitchfork")
 	flag.StringVar(&opts.Input.InputShell, "input-shell", opts.Input.InputShell, "Shell to be used for running command")
 	flag.StringVar(&opts.Input.Request, "request", opts.Input.Request, "File containing the raw http request")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Headers                map[string]string         `json:"headers"`
 	IgnoreBody             bool                      `json:"ignorebody"`
 	IgnoreWordlistComments bool                      `json:"ignore_wordlist_comments"`
+	IgnoreWords            []string                  `json:"ignore_words"`
 	InputMode              string                    `json:"inputmode"`
 	InputNum               int                       `json:"cmd_inputnum"`
 	InputProviders         []InputProviderConfig     `json:"inputproviders"`
@@ -33,7 +34,7 @@ type Config struct {
 	OutputDirectory        string                    `json:"outputdirectory"`
 	OutputFile             string                    `json:"outputfile"`
 	OutputFormat           string                    `json:"outputformat"`
-	OutputCreateEmptyFile  bool	                     `json:"OutputCreateEmptyFile"`
+	OutputCreateEmptyFile  bool                      `json:"OutputCreateEmptyFile"`
 	ProgressFrequency      int                       `json:"-"`
 	ProxyURL               string                    `json:"proxyurl"`
 	Quiet                  bool                      `json:"quiet"`
@@ -70,6 +71,7 @@ func NewConfig(ctx context.Context, cancel context.CancelFunc) Config {
 	conf.FollowRedirects = false
 	conf.Headers = make(map[string]string)
 	conf.IgnoreWordlistComments = false
+	conf.IgnoreWords = make([]string, 0)
 	conf.InputMode = "clusterbomb"
 	conf.InputNum = 0
 	conf.InputShell = ""

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	OutputDirectory        string                    `json:"outputdirectory"`
 	OutputFile             string                    `json:"outputfile"`
 	OutputFormat           string                    `json:"outputformat"`
-	OutputCreateEmptyFile  bool                      `json:"OutputCreateEmptyFile"`
+	OutputCreateEmptyFile  bool	                     `json:"OutputCreateEmptyFile"`
 	ProgressFrequency      int                       `json:"-"`
 	ProxyURL               string                    `json:"proxyurl"`
 	Quiet                  bool                      `json:"quiet"`

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -62,6 +62,7 @@ type InputOptions struct {
 	DirSearchCompat        bool
 	Extensions             string
 	IgnoreWordlistComments bool
+	IgnoreWords            string
 	InputMode              string
 	InputNum               int
 	InputShell             string
@@ -72,11 +73,11 @@ type InputOptions struct {
 }
 
 type OutputOptions struct {
-	DebugLog        string
-	OutputDirectory string
-	OutputFile      string
-	OutputFormat    string
-	OutputCreateEmptyFile	bool
+	DebugLog              string
+	OutputDirectory       string
+	OutputFile            string
+	OutputFormat          string
+	OutputCreateEmptyFile bool
 }
 
 type FilterOptions struct {
@@ -129,6 +130,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.Input.DirSearchCompat = false
 	c.Input.Extensions = ""
 	c.Input.IgnoreWordlistComments = false
+	c.Input.IgnoreWords = ""
 	c.Input.InputMode = "clusterbomb"
 	c.Input.InputNum = 100
 	c.Input.Request = ""
@@ -163,6 +165,12 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	if parseOpts.Input.Extensions != "" {
 		extensions := strings.Split(parseOpts.Input.Extensions, ",")
 		conf.Extensions = extensions
+	}
+
+	// prepare ignored words
+	if parseOpts.Input.IgnoreWords != "" {
+		ignore_words := strings.Split(parseOpts.Input.IgnoreWords, ",")
+		conf.IgnoreWords = ignore_words
 	}
 
 	// Convert cookies to a header

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -73,11 +73,11 @@ type InputOptions struct {
 }
 
 type OutputOptions struct {
-	DebugLog              string
-	OutputDirectory       string
-	OutputFile            string
-	OutputFormat          string
-	OutputCreateEmptyFile bool
+	DebugLog        string
+	OutputDirectory string
+	OutputFile      string
+	OutputFormat    string
+	OutputCreateEmptyFile	bool
 }
 
 type FilterOptions struct {

--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -102,7 +102,6 @@ func (w *WordlistInput) readFile(path string) error {
 		}
 	}
 	defer file.Close()
-
 	var data [][]byte
 	var ok bool
 	reader := bufio.NewScanner(file)
@@ -110,6 +109,9 @@ func (w *WordlistInput) readFile(path string) error {
 	for reader.Scan() {
 		if w.config.DirSearchCompat && len(w.config.Extensions) > 0 {
 			text := []byte(reader.Text())
+			if len(w.config.IgnoreWords) > 0 && ignoreWords(string(text), w.config.IgnoreWords) {
+				continue
+			}
 			if re.Match(text) {
 				for _, ext := range w.config.Extensions {
 					contnt := re.ReplaceAll(text, []byte(ext))
@@ -128,6 +130,9 @@ func (w *WordlistInput) readFile(path string) error {
 			}
 		} else {
 			text := reader.Text()
+			if len(w.config.IgnoreWords) > 0 && ignoreWords(text, w.config.IgnoreWords) {
+				continue
+			}
 
 			if w.config.IgnoreWordlistComments {
 				text, ok = stripComments(text)
@@ -162,4 +167,15 @@ func stripComments(text string) (string, bool) {
 		return text, true
 	}
 	return text[:index], true
+}
+
+// Check if a word contains substrings of a substring array.
+// Returns true if there was a match.
+func ignoreWords(word string, substrings []string) bool {
+	for _, sub := range substrings {
+		if strings.Contains(word, sub) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -102,6 +102,7 @@ func (w *WordlistInput) readFile(path string) error {
 		}
 	}
 	defer file.Close()
+
 	var data [][]byte
 	var ok bool
 	reader := bufio.NewScanner(file)


### PR DESCRIPTION
# Description

This pull requests adds the flag `-iw`.
The flag accepts a list of comma separated values, like the extension flag `-e`.
When loading a wordlist, it is checked for every word if it contains a value from the `-iw` flag.
This can be shown most easily with an **example**:
File `words`:
```
dologout
logarithm
login
logout
logoutnow
logs
```

Cmd: `ffuf -u 'https://www.google.com:443/FUZZ?a=1&b=2' -w words -iw logout`

Words that are loaded:
```
logarithm
login
logs
```

## Why is this useful?

As the example above demonstrates it is, for example, possible to remove the word "logout" from wordlists.
This has the advantage, that when doing authenticated fuzzing, you are not logged out because the `/logout` endpoint is not called.
This is currently only possible by copying the wordlist and removing the unwanted words, which I find inconvenient.

I'm happy about feedback :)