### PR TITLE
Response time logging and filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 - master
   - New
+    - Added response time logging and filtering
   - Changed
     - Fixed output writing so it doesn't silently fail if it needs to create directories recursively
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 * [Damian89](https://github.com/Damian89)
 * [Daviey](https://github.com/Daviey)
 * [delic](https://github.com/delic)
+* [denandz](https://github.com/denandz)
 * [eur0pa](https://github.com/eur0pa)
 * [fabiobauer](https://github.com/fabiobauer)
 * [fang0654](https://github.com/fang0654)

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ MATCHER OPTIONS:
   -ml              Match amount of lines in response
   -mr              Match regexp
   -ms              Match HTTP response size
+  -mt              Match how many milliseconds to the first response byte, either greater or less than. EG: >100 or <100
   -mw              Match amount of words in response
 
 FILTER OPTIONS:
@@ -204,6 +205,7 @@ FILTER OPTIONS:
   -fl              Filter by amount of lines in response. Comma separated list of line counts and ranges
   -fr              Filter regexp
   -fs              Filter HTTP response size. Comma separated list of sizes and ranges
+  -ft              Filter by number of milliseconds to the first response byte, either greater or less than. EG: >100 or <100
   -fw              Filter by amount of words in response. Comma separated list of word counts and ranges
 
 INPUT OPTIONS:

--- a/ffufrc.example
+++ b/ffufrc.example
@@ -68,6 +68,7 @@
     regexp = ""
     size = ""
     status = ""
+    time = ""
     words = ""
 
 [matcher]
@@ -75,4 +76,5 @@
     regexp = ""
     size = ""
     status = "200,204,301,302,307,401,403,405"
+    time = ""
     words = ""

--- a/help.go
+++ b/help.go
@@ -75,14 +75,14 @@ func Usage() {
 		Description:   "Matchers for the response filtering.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"mc", "ml", "mr", "ms", "mw"},
+		ExpectedFlags: []string{"mc", "ml", "mr", "ms", "mt", "mw"},
 	}
 	u_filter := UsageSection{
 		Name:          "FILTER OPTIONS",
 		Description:   "Filters for the response filtering.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"fc", "fl", "fr", "fs", "fw"},
+		ExpectedFlags: []string{"fc", "fl", "fr", "fs", "ft", "fw"},
 	}
 	u_input := UsageSection{
 		Name:          "INPUT OPTIONS",

--- a/main.go
+++ b/main.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
 	"github.com/ffuf/ffuf/pkg/ffuf"
 	"github.com/ffuf/ffuf/pkg/filter"
 	"github.com/ffuf/ffuf/pkg/input"
 	"github.com/ffuf/ffuf/pkg/interactive"
 	"github.com/ffuf/ffuf/pkg/output"
 	"github.com/ffuf/ffuf/pkg/runner"
-	"io/ioutil"
-	"log"
-	"os"
-	"strings"
 )
 
 type multiStringFlag []string
@@ -84,6 +85,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.Filter.Regexp, "fr", opts.Filter.Regexp, "Filter regexp")
 	flag.StringVar(&opts.Filter.Size, "fs", opts.Filter.Size, "Filter HTTP response size. Comma separated list of sizes and ranges")
 	flag.StringVar(&opts.Filter.Status, "fc", opts.Filter.Status, "Filter HTTP status codes from response. Comma separated list of codes and ranges")
+	flag.StringVar(&opts.Filter.Time, "ft", opts.Filter.Time, "Filter by number of milliseconds to the first response byte, either greater or less than. EG: >100 or <100")
 	flag.StringVar(&opts.Filter.Words, "fw", opts.Filter.Words, "Filter by amount of words in response. Comma separated list of word counts and ranges")
 	flag.StringVar(&opts.General.Delay, "p", opts.General.Delay, "Seconds of `delay` between requests, or a range of random delay. For example \"0.1\" or \"0.1-2.0\"")
 	flag.StringVar(&opts.HTTP.Data, "d", opts.HTTP.Data, "POST data")
@@ -104,6 +106,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.Matcher.Regexp, "mr", opts.Matcher.Regexp, "Match regexp")
 	flag.StringVar(&opts.Matcher.Size, "ms", opts.Matcher.Size, "Match HTTP response size")
 	flag.StringVar(&opts.Matcher.Status, "mc", opts.Matcher.Status, "Match HTTP status codes, or \"all\" for everything.")
+	flag.StringVar(&opts.Matcher.Time, "mt", opts.Matcher.Time, "Match how many milliseconds to the first response byte, either greater or less than. EG: >100 or <100")
 	flag.StringVar(&opts.Matcher.Words, "mw", opts.Matcher.Words, "Match amount of words in response")
 	flag.StringVar(&opts.Output.DebugLog, "debug-log", opts.Output.DebugLog, "Write all of the internal logging to the specified file.")
 	flag.StringVar(&opts.Output.OutputDirectory, "od", opts.Output.OutputDirectory, "Directory path to store matched results to.")

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -1,5 +1,7 @@
 package ffuf
 
+import "time"
+
 //FilterProvider is a generic interface for both Matchers and Filters
 type FilterProvider interface {
 	Filter(response *Response) (bool, error)
@@ -61,6 +63,7 @@ type Result struct {
 	ContentType      string            `json:"content-type"`
 	RedirectLocation string            `json:"redirectlocation"`
 	Url              string            `json:"url"`
+	Duration         time.Duration     `json:"duration"`
 	ResultFile       string            `json:"resultfile"`
 	Host             string            `json:"host"`
 	HTMLColor        string            `json:"-"`

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -85,6 +85,7 @@ type FilterOptions struct {
 	Regexp string
 	Size   string
 	Status string
+	Time   string
 	Words  string
 }
 
@@ -93,6 +94,7 @@ type MatcherOptions struct {
 	Regexp string
 	Size   string
 	Status string
+	Time   string
 	Words  string
 }
 
@@ -103,6 +105,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.Filter.Regexp = ""
 	c.Filter.Size = ""
 	c.Filter.Status = ""
+	c.Filter.Time = ""
 	c.Filter.Words = ""
 	c.General.AutoCalibration = false
 	c.General.Colors = false
@@ -139,6 +142,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.Matcher.Regexp = ""
 	c.Matcher.Size = ""
 	c.Matcher.Status = "200,204,301,302,307,401,403,405"
+	c.Matcher.Time = ""
 	c.Matcher.Words = ""
 	c.Output.DebugLog = ""
 	c.Output.OutputDirectory = ""

--- a/pkg/ffuf/response.go
+++ b/pkg/ffuf/response.go
@@ -3,6 +3,7 @@ package ffuf
 import (
 	"net/http"
 	"net/url"
+	"time"
 )
 
 // Response struct holds the meaningful data returned from request and is meant for passing to filters
@@ -18,6 +19,7 @@ type Response struct {
 	Request       *Request
 	Raw           string
 	ResultFile    string
+	Time          time.Duration
 }
 
 // GetRedirectLocation returns the redirect location for a 3xx redirect HTTP response

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -25,6 +25,9 @@ func NewFilterByName(name string, value string) (ffuf.FilterProvider, error) {
 	if name == "regexp" {
 		return NewRegexpFilter(value)
 	}
+	if name == "time" {
+		return NewTimeFilter(value)
+	}
 	return nil, fmt.Errorf("Could not create filter with name %s", name)
 }
 
@@ -143,6 +146,9 @@ func SetupFilters(parseOpts *ffuf.ConfigOptions, conf *ffuf.Config) error {
 		if f.Name == "mr" {
 			matcherSet = true
 		}
+		if f.Name == "mt" {
+			matcherSet = true
+		}
 		if f.Name == "mw" {
 			matcherSet = true
 			warningIgnoreBody = true
@@ -182,6 +188,11 @@ func SetupFilters(parseOpts *ffuf.ConfigOptions, conf *ffuf.Config) error {
 			errs.Add(err)
 		}
 	}
+	if parseOpts.Filter.Time != "" {
+		if err := AddFilter(conf, "time", parseOpts.Filter.Time); err != nil {
+			errs.Add(err)
+		}
+	}
 	if parseOpts.Matcher.Size != "" {
 		if err := AddMatcher(conf, "size", parseOpts.Matcher.Size); err != nil {
 			errs.Add(err)
@@ -199,6 +210,11 @@ func SetupFilters(parseOpts *ffuf.ConfigOptions, conf *ffuf.Config) error {
 	}
 	if parseOpts.Matcher.Lines != "" {
 		if err := AddMatcher(conf, "line", parseOpts.Matcher.Lines); err != nil {
+			errs.Add(err)
+		}
+	}
+	if parseOpts.Matcher.Time != "" {
+		if err := AddFilter(conf, "time", parseOpts.Matcher.Time); err != nil {
 			errs.Add(err)
 		}
 	}

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -29,6 +29,11 @@ func TestNewFilterByName(t *testing.T) {
 	if _, ok := ref.(*RegexpFilter); !ok {
 		t.Errorf("Was expecting regexpfilter")
 	}
+
+	tf, _ := NewFilterByName("time", "200")
+	if _, ok := tf.(*TimeFilter); !ok {
+		t.Errorf("Was expecting timefilter")
+	}
 }
 
 func TestNewFilterByNameError(t *testing.T) {

--- a/pkg/filter/time.go
+++ b/pkg/filter/time.go
@@ -1,0 +1,66 @@
+package filter
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ffuf/ffuf/pkg/ffuf"
+)
+
+type TimeFilter struct {
+	ms       int64 // milliseconds since first response byte
+	gt       bool  // filter if response time is greater than
+	lt       bool  // filter if response time is less than
+	valueRaw string
+}
+
+func NewTimeFilter(value string) (ffuf.FilterProvider, error) {
+	var milliseconds int64
+	gt, lt := false, false
+
+	gt = strings.HasPrefix(value, ">")
+	lt = strings.HasPrefix(value, "<")
+
+	if (!lt && !gt) || (lt && gt) {
+		return &TimeFilter{}, fmt.Errorf("Time filter or matcher (-ft / -mt): invalid value: %s", value)
+	}
+
+	milliseconds, err := strconv.ParseInt(value[1:], 10, 64)
+	if err != nil {
+		return &TimeFilter{}, fmt.Errorf("Time filter or matcher (-ft / -mt): invalid value: %s", value)
+	}
+	return &TimeFilter{ms: milliseconds, gt: gt, lt: lt, valueRaw: value}, nil
+}
+
+func (f *TimeFilter) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Value string `json:"value"`
+	}{
+		Value: f.valueRaw,
+	})
+}
+
+func (f *TimeFilter) Filter(response *ffuf.Response) (bool, error) {
+	if f.gt {
+		if response.Time.Milliseconds() > f.ms {
+			return true, nil
+		}
+
+	} else if f.lt {
+		if response.Time.Milliseconds() < f.ms {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (f *TimeFilter) Repr() string {
+	return f.valueRaw
+}
+
+func (f *TimeFilter) ReprVerbose() string {
+	return fmt.Sprintf("Response time: %s", f.Repr())
+}

--- a/pkg/filter/time_test.go
+++ b/pkg/filter/time_test.go
@@ -1,0 +1,54 @@
+package filter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ffuf/ffuf/pkg/ffuf"
+)
+
+func TestNewTimeFilter(t *testing.T) {
+	fp, _ := NewTimeFilter(">100")
+
+	f := fp.(*TimeFilter)
+
+	if !f.gt || f.lt {
+		t.Errorf("Time filter was expected to have greater-than")
+	}
+
+	if f.ms != 100 {
+		t.Errorf("Time filter was expected to have ms == 100")
+	}
+}
+
+func TestNewTimeFilterError(t *testing.T) {
+	_, err := NewTimeFilter("100>")
+	if err == nil {
+		t.Errorf("Was expecting an error from errenous input data")
+	}
+}
+
+func TestTimeFiltering(t *testing.T) {
+	f, _ := NewTimeFilter(">100")
+
+	for i, test := range []struct {
+		input  int64
+		output bool
+	}{
+		{1342, true},
+		{2000, true},
+		{35000, true},
+		{1458700, true},
+		{99, false},
+		{2, false},
+	} {
+		resp := ffuf.Response{
+			Data: []byte("dahhhhhtaaaaa"),
+			Time: time.Duration(test.input * int64(time.Millisecond)),
+		}
+		filterReturn, _ := f.Filter(&resp)
+		if filterReturn != test.output {
+			t.Errorf("Filter test %d: Was expecing filter return value of %t but got %t", i, test.output, filterReturn)
+		}
+	}
+}

--- a/pkg/interactive/termhandler.go
+++ b/pkg/interactive/termhandler.go
@@ -3,11 +3,12 @@ package interactive
 import (
 	"bufio"
 	"fmt"
-	"github.com/ffuf/ffuf/pkg/ffuf"
-	"github.com/ffuf/ffuf/pkg/filter"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/pkg/filter"
 )
 
 type interactive struct {
@@ -110,6 +111,15 @@ func (i *interactive) handleInput(in []byte) {
 				i.updateFilter("size", args[1])
 				i.Job.Output.Info("New response size filter value set")
 			}
+		case "ft":
+			if len(args) < 2 {
+				i.Job.Output.Error("Please define a value for response time filter, or \"none\" for removing it")
+			} else if len(args) > 2 {
+				i.Job.Output.Error("Too many arguments for \"ft\"")
+			} else {
+				i.updateFilter("time", args[1])
+				i.Job.Output.Info("New response time filter value set")
+			}
 		case "queueshow":
 			i.printQueue()
 		case "queuedel":
@@ -205,7 +215,7 @@ func (i *interactive) printPrompt() {
 }
 
 func (i *interactive) printHelp() {
-	var fc, fl, fs, fw string
+	var fc, fl, fs, ft, fw string
 	for name, filter := range i.Job.Config.Filters {
 		switch name {
 		case "status":
@@ -216,6 +226,8 @@ func (i *interactive) printHelp() {
 			fw = "(active: " + filter.Repr() + ")"
 		case "size":
 			fs = "(active: " + filter.Repr() + ")"
+		case "time":
+			ft = "(active: " + filter.Repr() + ")"
 		}
 	}
 	help := `
@@ -224,6 +236,7 @@ available commands:
  fl [value]             - (re)configure line count filter %s
  fw [value]             - (re)configure word count filter %s
  fs [value]             - (re)configure size filter %s
+ ft [value]				- (re)configure time filter %s
  queueshow              - show recursive job queue
  queuedel [number]      - delete a recursion job in the queue
  queueskip              - advance to the next queued recursion job
@@ -233,5 +246,5 @@ available commands:
  savejson [filename]    - save current matches to a file
  help                   - you are looking at it
 `
-	i.Job.Output.Raw(fmt.Sprintf(help, fc, fl, fw, fs))
+	i.Job.Output.Raw(fmt.Sprintf(help, fc, fl, fw, fs, ft))
 }

--- a/pkg/output/file_csv.go
+++ b/pkg/output/file_csv.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ffuf/ffuf/pkg/ffuf"
 )
 
-var staticheaders = []string{"url", "redirectlocation", "position", "status_code", "content_length", "content_words", "content_lines", "content_type", "resultfile"}
+var staticheaders = []string{"url", "redirectlocation", "position", "status_code", "content_length", "content_words", "content_lines", "content_type", "duration", "resultfile"}
 
 func writeCSV(filename string, config *ffuf.Config, res []ffuf.Result, encode bool) error {
 
@@ -69,6 +69,7 @@ func toCSV(r ffuf.Result) []string {
 	res = append(res, strconv.FormatInt(r.ContentWords, 10))
 	res = append(res, strconv.FormatInt(r.ContentLines, 10))
 	res = append(res, r.ContentType)
+	res = append(res, r.Duration.String())
 	res = append(res, r.ResultFile)
 	return res
 }

--- a/pkg/output/file_html.go
+++ b/pkg/output/file_html.go
@@ -78,6 +78,7 @@ const (
               <th>Words</th>
 			  <th>Lines</th>
 			  <th>Type</th>
+        <th>Duration</th>
 			  <th>Resultfile</th>
           </tr>
         </thead>
@@ -99,6 +100,7 @@ const (
                     <td>{{ $result.ContentWords }}</td>
 					<td>{{ $result.ContentLines }}</td>
 					<td>{{ $result.ContentType }}</td>
+          <td>{{ $result.Duration }}</td>
                     <td>{{ $result.ResultFile }}</td>
                 </tr>
             {{ end }}

--- a/pkg/output/file_json.go
+++ b/pkg/output/file_json.go
@@ -24,6 +24,7 @@ type JsonResult struct {
 	ContentLines     int64             `json:"lines"`
 	ContentType      string            `json:"content-type"`
 	RedirectLocation string            `json:"redirectlocation"`
+	Duration         time.Duration     `json:"duration"`
 	ResultFile       string            `json:"resultfile"`
 	Url              string            `json:"url"`
 	Host             string            `json:"host"`
@@ -77,6 +78,7 @@ func writeJSON(filename string, config *ffuf.Config, res []ffuf.Result) error {
 			ContentLines:     r.ContentLines,
 			ContentType:      r.ContentType,
 			RedirectLocation: r.RedirectLocation,
+			Duration:         r.Duration,
 			ResultFile:       r.ResultFile,
 			Url:              r.Url,
 			Host:             r.Host,

--- a/pkg/output/file_md.go
+++ b/pkg/output/file_md.go
@@ -14,9 +14,9 @@ const (
   Command line : ` + "`{{.CommandLine}}`" + `
   Time: ` + "{{ .Time }}" + `
 
-  {{ range .Keys }}| {{ . }} {{ end }}| URL | Redirectlocation | Position | Status Code | Content Length | Content Words | Content Lines | Content Type | ResultFile |
+  {{ range .Keys }}| {{ . }} {{ end }}| URL | Redirectlocation | Position | Status Code | Content Length | Content Words | Content Lines | Content Type | Duration | ResultFile |
   {{ range .Keys }}| :- {{ end }}| :-- | :--------------- | :---- | :------- | :---------- | :------------- | :------------ | :--------- | :----------- |
-  {{range .Results}}{{ range $keyword, $value := .Input }}| {{ $value | printf "%s" }} {{ end }}| {{ .Url }} | {{ .RedirectLocation }} | {{ .Position }} | {{ .StatusCode }} | {{ .ContentLength }} | {{ .ContentWords }} | {{ .ContentLines }} | {{ .ContentType }} | {{ .ResultFile }} |
+  {{range .Results}}{{ range $keyword, $value := .Input }}| {{ $value | printf "%s" }} {{ end }}| {{ .Url }} | {{ .RedirectLocation }} | {{ .Position }} | {{ .StatusCode }} | {{ .ContentLength }} | {{ .ContentWords }} | {{ .ContentLines }} | {{ .ContentType }} | {{ .Duration}} | {{ .ResultFile }} |
   {{end}}` // The template format is not pretty but follows the markdown guide
 )
 

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -394,7 +394,7 @@ func (s *Stdoutput) resultQuiet(res ffuf.Result) {
 func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 	var res_hdr, res_str string
 	res_str = "%s%s    * %s: %s\n"
-	res_hdr = fmt.Sprintf("%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Round(time.Millisecond))
+	res_hdr = fmt.Sprintf("%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]", TERMINAL_CLEAR_LINE, res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds())
 	res_hdr = s.colorize(res_hdr, res.StatusCode)
 	reslines := ""
 	if s.config.Verbose {
@@ -420,7 +420,7 @@ func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 }
 
 func (s *Stdoutput) resultNormal(res ffuf.Result) {
-	resnormal := fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(res), s.colorize(fmt.Sprintf("%d", res.StatusCode), res.StatusCode), res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Round(time.Millisecond))
+	resnormal := fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d, Duration: %dms]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(res), s.colorize(fmt.Sprintf("%d", res.StatusCode), res.StatusCode), res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds())
 	fmt.Println(resnormal)
 }
 

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -316,6 +316,7 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 		ContentType:      resp.ContentType,
 		RedirectLocation: resp.GetRedirectLocation(false),
 		Url:              resp.Request.Url,
+		Duration:         resp.Time,
 		ResultFile:       resp.ResultFile,
 		Host:             resp.Request.Host,
 	}
@@ -393,7 +394,7 @@ func (s *Stdoutput) resultQuiet(res ffuf.Result) {
 func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 	var res_hdr, res_str string
 	res_str = "%s%s    * %s: %s\n"
-	res_hdr = fmt.Sprintf("%s[Status: %d, Size: %d, Words: %d, Lines: %d]", TERMINAL_CLEAR_LINE, res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines)
+	res_hdr = fmt.Sprintf("%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration)
 	res_hdr = s.colorize(res_hdr, res.StatusCode)
 	reslines := ""
 	if s.config.Verbose {
@@ -419,7 +420,7 @@ func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 }
 
 func (s *Stdoutput) resultNormal(res ffuf.Result) {
-	resnormal := fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(res), s.colorize(fmt.Sprintf("%d", res.StatusCode), res.StatusCode), res.ContentLength, res.ContentWords, res.ContentLines)
+	resnormal := fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(res), s.colorize(fmt.Sprintf("%d", res.StatusCode), res.StatusCode), res.ContentLength, res.ContentWords, res.ContentLines, res.Duration)
 	fmt.Println(resnormal)
 }
 

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -394,7 +394,7 @@ func (s *Stdoutput) resultQuiet(res ffuf.Result) {
 func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 	var res_hdr, res_str string
 	res_str = "%s%s    * %s: %s\n"
-	res_hdr = fmt.Sprintf("%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration)
+	res_hdr = fmt.Sprintf("%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Round(time.Millisecond))
 	res_hdr = s.colorize(res_hdr, res.StatusCode)
 	reslines := ""
 	if s.config.Verbose {
@@ -420,7 +420,7 @@ func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 }
 
 func (s *Stdoutput) resultNormal(res ffuf.Result) {
-	resnormal := fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(res), s.colorize(fmt.Sprintf("%d", res.StatusCode), res.StatusCode), res.ContentLength, res.ContentWords, res.ContentLines, res.Duration)
+	resnormal := fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(res), s.colorize(fmt.Sprintf("%d", res.StatusCode), res.StatusCode), res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Round(time.Millisecond))
 	fmt.Println(resnormal)
 }
 

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -394,7 +394,7 @@ func (s *Stdoutput) resultQuiet(res ffuf.Result) {
 func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 	var res_hdr, res_str string
 	res_str = "%s%s    * %s: %s\n"
-	res_hdr = fmt.Sprintf("%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds())
+	res_hdr = fmt.Sprintf("%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Round(time.Millisecond))
 	res_hdr = s.colorize(res_hdr, res.StatusCode)
 	reslines := ""
 	if s.config.Verbose {
@@ -420,7 +420,7 @@ func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 }
 
 func (s *Stdoutput) resultNormal(res ffuf.Result) {
-	resnormal := fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(res), s.colorize(fmt.Sprintf("%d", res.StatusCode), res.StatusCode), res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds())
+	resnormal := fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(res), s.colorize(fmt.Sprintf("%d", res.StatusCode), res.StatusCode), res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Round(time.Millisecond))
 	fmt.Println(resnormal)
 }
 

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -394,7 +394,7 @@ func (s *Stdoutput) resultQuiet(res ffuf.Result) {
 func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 	var res_hdr, res_str string
 	res_str = "%s%s    * %s: %s\n"
-	res_hdr = fmt.Sprintf("%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Round(time.Millisecond))
+	res_hdr = fmt.Sprintf("%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds())
 	res_hdr = s.colorize(res_hdr, res.StatusCode)
 	reslines := ""
 	if s.config.Verbose {
@@ -420,7 +420,7 @@ func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 }
 
 func (s *Stdoutput) resultNormal(res ffuf.Result) {
-	resnormal := fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(res), s.colorize(fmt.Sprintf("%d", res.StatusCode), res.StatusCode), res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Round(time.Millisecond))
+	resnormal := fmt.Sprintf("%s%-23s [Status: %s, Size: %d, Words: %d, Lines: %d, Duration: %v]", TERMINAL_CLEAR_LINE, s.prepareInputsOneLine(res), s.colorize(fmt.Sprintf("%d", res.StatusCode), res.StatusCode), res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds())
 	fmt.Println(resnormal)
 }
 

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -128,7 +128,7 @@ func (r *SimpleRunner) Execute(req *ffuf.Request) (ffuf.Response, error) {
 	}
 
 	req.Host = httpreq.Host
-	httpreq = httpreq.WithContext(httptrace.WithClientTrace(httpreq.Context(), trace))
+	httpreq = httpreq.WithContext(httptrace.WithClientTrace(r.config.Context, trace))
 	for k, v := range req.Headers {
 		httpreq.Header.Set(k, v)
 	}

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"net/http/httputil"
 	"net/textproto"
 	"net/url"
@@ -97,7 +98,21 @@ func (r *SimpleRunner) Execute(req *ffuf.Request) (ffuf.Response, error) {
 	var err error
 	var rawreq []byte
 	data := bytes.NewReader(req.Data)
+
+	var start time.Time
+	var firstByteTime time.Duration
+
+	trace := &httptrace.ClientTrace{
+		WroteRequest: func(wri httptrace.WroteRequestInfo) {
+			start = time.Now() // begin the timer after the request is fully written
+		},
+		GotFirstResponseByte: func() {
+			firstByteTime = time.Since(start) // record when the first byte of the response was received
+		},
+	}
+
 	httpreq, err = http.NewRequestWithContext(r.config.Context, req.Method, req.Url, data)
+
 	if err != nil {
 		return ffuf.Response{}, err
 	}
@@ -113,7 +128,7 @@ func (r *SimpleRunner) Execute(req *ffuf.Request) (ffuf.Response, error) {
 	}
 
 	req.Host = httpreq.Host
-	httpreq = httpreq.WithContext(r.config.Context)
+	httpreq = httpreq.WithContext(httptrace.WithClientTrace(httpreq.Context(), trace))
 	for k, v := range req.Headers {
 		httpreq.Header.Set(k, v)
 	}
@@ -155,6 +170,7 @@ func (r *SimpleRunner) Execute(req *ffuf.Request) (ffuf.Response, error) {
 	linesSize := len(strings.Split(string(resp.Data), "\n"))
 	resp.ContentWords = int64(wordsSize)
 	resp.ContentLines = int64(linesSize)
+	resp.Time = firstByteTime
 
 	return resp, nil
 }


### PR DESCRIPTION
# Description

This pull request implements response time logging and filtering. Timing is performed using Golang's HTTP Tracing, so the logged time is the duration between the request being fully written (so we avoid logging overhead from DNS and TLS connection setup) and the first byte of the response being received. 

Matchers and filters have been implemented with `-mt` and `-ft`. This is particularly useful when fuzzing things and looking for time discrepancies. The idea is to let the user tweak these parameters and see responses that fall outside of the expected response time.

Here is an example of using this to find blind sqli in the OWASP DVWA (using the SQLI Blind fuzzing list from Seclists)

```
$ ./ffuf -timeout 30 -t 1 -w ./urlsqli -u "http://172.17.0.1.nip.io:8088/vulnerabilities/sqli_blind/?id=FUZZ&Submit=Submit" -H 'Cookie: PHPSESSID=cd02gr40qdcrifs0g52paofqv1; security=low' -mc all -ft "<1000"

        /'___\  /'___\           /'___\       
       /\ \__/ /\ \__/  __  __  /\ \__/       
       \ \ ,__\\ \ ,__\/\ \/\ \ \ \ ,__\      
        \ \ \_/ \ \ \_/\ \ \_\ \ \ \ \_/      
         \ \_\   \ \_\  \ \____/  \ \_\       
          \/_/    \/_/   \/___/    \/_/       

       v1.3.0-dev
________________________________________________

 :: Method           : GET
 :: URL              : http://172.17.0.1.nip.io:8088/vulnerabilities/sqli_blind/?id=FUZZ&Submit=Submit
 :: Wordlist         : FUZZ: ./urlsqli
 :: Header           : Cookie: PHPSESSID=cd02gr40qdcrifs0g52paofqv1; security=low
 :: Follow redirects : false
 :: Calibration      : false
 :: Timeout          : 30
 :: Threads          : 1
 :: Matcher          : Response status: all
 :: Filter           : Response time: <1000
________________________________________________

%27+or+sleep%282%29%23  [Status: 404, Size: 4567, Words: 179, Lines: 111, Duration: 10.004019898s]
%27+or+sleep%282%29%3D%27 [Status: 200, Size: 4561, Words: 178, Lines: 111, Duration: 10.011460493s]
%27+or+benchmark%2810000000%2CMD5%281%29%29%23 [Status: 404, Size: 4567, Words: 179, Lines: 111, Duration: 6.763547328s]
:: Progress: [42/42] :: Job [1/1] :: 754 req/sec :: Duration: [0:00:26] :: Errors: 0 ::
```

And another example of finding SSRF based on timing discrepancy (using the https://owasp-skf.gitbook.io/asvs-write-ups/kbid-262-server-side-request-forgery container as the target)

```
$ ./ffuf -w fuzzlist -t 10 -timeout 30 -u 'http://127.0.0.1:5000/check_existence' -request request -mc all -ft '<2000'

        /'___\  /'___\           /'___\       
       /\ \__/ /\ \__/  __  __  /\ \__/       
       \ \ ,__\\ \ ,__\/\ \/\ \ \ \ ,__\      
        \ \ \_/ \ \ \_/\ \ \_\ \ \ \ \_/      
         \ \_\   \ \_\  \ \____/  \ \_\       
          \/_/    \/_/   \/___/    \/_/       

       v1.3.0-dev
________________________________________________

 :: Method           : POST
 :: URL              : http://127.0.0.1:5000/check_existence
 :: Wordlist         : FUZZ: fuzzlist
 :: Header           : Host: 127.0.0.1:5000
 :: Header           : Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
 :: Header           : Dnt: 1
 :: Header           : Accept-Encoding: deflate, gzip
 :: Header           : Accept-Language: en-US,en;q=0.9
 :: Header           : Referer: http://127.0.0.1:5000/check_existence
 :: Header           : Sec-Fetch-Site: same-origin
 :: Header           : Origin: http://127.0.0.1:5000
 :: Header           : Proxy-Connection: Keep-Alive
 :: Header           : Upgrade-Insecure-Requests: 1
 :: Header           : User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.72 Safari/537.36
 :: Header           : Cache-Control: max-age=0
 :: Header           : Connection: keep-alive
 :: Header           : Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryBteNwndvo1K1kAc3
 :: Header           : Sec-Ch-Ua: " Not A;Brand";v="99", "Chromium";v="90", "Google Chrome";v="90"
 :: Header           : Sec-Ch-Ua-Mobile: ?0
 :: Header           : Sec-Fetch-Dest: document
 :: Header           : Sec-Fetch-Mode: navigate
 :: Header           : Sec-Fetch-User: ?1
 :: Data             : ------WebKitFormBoundaryBteNwndvo1K1kAc3
Content-Disposition: form-data; name="url"

FUZZ
------WebKitFormBoundaryBteNwndvo1K1kAc3--

 :: Follow redirects : false
 :: Calibration      : false
 :: Timeout          : 30
 :: Threads          : 10
 :: Matcher          : Response status: all
 :: Filter           : Response time: <2000
________________________________________________

https://httpstat.us/200?sleep=5000 [Status: 200, Size: 4178, Words: 1185, Lines: 95, Duration: 2.323751622s]
http://www.google.com   [Status: 200, Size: 4162, Words: 1183, Lines: 95, Duration: 2.49734596s]
https://www.google.com/  [Status: 200, Size: 4162, Words: 1183, Lines: 95, Duration: 2.67432851s]
http://www.google.com:80/search?q=wingus [Status: 200, Size: 4162, Words: 1183, Lines: 95, Duration: 3.294715376s]
https://www.google.com/search?q=dingus [Status: 200, Size: 4162, Words: 1183, Lines: 95, Duration: 3.702227468s]
```

Fixes: #196