### PR TITLE
Add TLS SNI Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 - master
   - New
+    - Added a CLI flag to specify TLS SNI value
   - Changed
 
 - v1.3.1

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 * [Damian89](https://github.com/Damian89)
 * [Daviey](https://github.com/Daviey)
 * [delic](https://github.com/delic)
+* [erbbysam](https://github.com/erbbysam)
 * [eur0pa](https://github.com/eur0pa)
 * [fabiobauer](https://github.com/fabiobauer)
 * [fang0654](https://github.com/fang0654)

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ HTTP OPTIONS:
   -recursion-depth    Maximum recursion depth. (default: 0)
   -recursion-strategy Recursion strategy: "default" for a redirect based, and "greedy" to recurse on all matches (default: default)
   -replay-proxy       Replay matched requests using this proxy.
+  -sni                Target TLS SNI, does not support FUZZ keyword
   -timeout            HTTP request timeout in seconds. (default: 10)
   -u                  Target URL
   -x                  Proxy URL (SOCKS5 or HTTP). For example: http://127.0.0.1:8080 or socks5://127.0.0.1:8080

--- a/help.go
+++ b/help.go
@@ -54,7 +54,7 @@ func Usage() {
 		Description:   "Options controlling the HTTP request and its parts.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"H", "X", "b", "d", "r", "u", "recursion", "recursion-depth", "recursion-strategy", "replay-proxy", "timeout", "ignore-body", "x"},
+		ExpectedFlags: []string{"H", "X", "b", "d", "r", "u", "recursion", "recursion-depth", "recursion-strategy", "replay-proxy", "timeout", "ignore-body", "x", "sni"},
 	}
 	u_general := UsageSection{
 		Name:          "GENERAL OPTIONS",

--- a/main.go
+++ b/main.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
 	"github.com/ffuf/ffuf/pkg/ffuf"
 	"github.com/ffuf/ffuf/pkg/filter"
 	"github.com/ffuf/ffuf/pkg/input"
 	"github.com/ffuf/ffuf/pkg/interactive"
 	"github.com/ffuf/ffuf/pkg/output"
 	"github.com/ffuf/ffuf/pkg/runner"
-	"io/ioutil"
-	"log"
-	"os"
-	"strings"
 )
 
 type multiStringFlag []string
@@ -96,6 +97,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.HTTP.ReplayProxyURL, "replay-proxy", opts.HTTP.ReplayProxyURL, "Replay matched requests using this proxy.")
 	flag.StringVar(&opts.HTTP.RecursionStrategy, "recursion-strategy", opts.HTTP.RecursionStrategy, "Recursion strategy: \"default\" for a redirect based, and \"greedy\" to recurse on all matches")
 	flag.StringVar(&opts.HTTP.URL, "u", opts.HTTP.URL, "Target URL")
+	flag.StringVar(&opts.HTTP.SNI, "sni", opts.HTTP.SNI, "Target TLS SNI, does not support FUZZ keyword")
 	flag.StringVar(&opts.Input.Extensions, "e", opts.Input.Extensions, "Comma separated list of extensions. Extends FUZZ keyword.")
 	flag.StringVar(&opts.Input.InputMode, "mode", opts.Input.InputMode, "Multi-wordlist operation mode. Available modes: clusterbomb, pitchfork")
 	flag.StringVar(&opts.Input.InputShell, "input-shell", opts.Input.InputShell, "Shell to be used for running command")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	RecursionDepth         int                       `json:"recursion_depth"`
 	RecursionStrategy      string                    `json:"recursion_strategy"`
 	ReplayProxyURL         string                    `json:"replayproxyurl"`
+	SNI                    string                    `json:"sni"`
 	StopOn403              bool                      `json:"stop_403"`
 	StopOnAll              bool                      `json:"stop_all"`
 	StopOnErrors           bool                      `json:"stop_errors"`
@@ -88,6 +89,7 @@ func NewConfig(ctx context.Context, cancel context.CancelFunc) Config {
 	conf.Recursion = false
 	conf.RecursionDepth = 0
 	conf.RecursionStrategy = "default"
+	conf.SNI = ""
 	conf.StopOn403 = false
 	conf.StopOnAll = false
 	conf.StopOnErrors = false

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -513,9 +513,6 @@ func keywordPresent(keyword string, conf *Config) bool {
 	if strings.Contains(conf.Url, keyword) {
 		return true
 	}
-	if strings.Contains(conf.SNI, keyword) {
-		return true
-	}
 	if strings.Contains(conf.Data, keyword) {
 		return true
 	}

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -37,6 +37,7 @@ type HTTPOptions struct {
 	RecursionDepth    int
 	RecursionStrategy string
 	ReplayProxyURL    string
+	SNI               string
 	Timeout           int
 	URL               string
 }
@@ -129,6 +130,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.HTTP.RecursionStrategy = "default"
 	c.HTTP.ReplayProxyURL = ""
 	c.HTTP.Timeout = 10
+	c.HTTP.SNI = ""
 	c.HTTP.URL = ""
 	c.Input.DirSearchCompat = false
 	c.Input.Extensions = ""
@@ -247,6 +249,11 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	//Prepare URL
 	if parseOpts.HTTP.URL != "" {
 		conf.Url = parseOpts.HTTP.URL
+	}
+
+	// Prepare SNI
+	if parseOpts.HTTP.SNI != "" {
+		conf.SNI = parseOpts.HTTP.SNI
 	}
 
 	//Prepare headers and make canonical
@@ -504,6 +511,9 @@ func keywordPresent(keyword string, conf *Config) bool {
 		return true
 	}
 	if strings.Contains(conf.Url, keyword) {
+		return true
+	}
+	if strings.Contains(conf.SNI, keyword) {
 		return true
 	}
 	if strings.Contains(conf.Data, keyword) {

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -58,6 +58,7 @@ func NewSimpleRunner(conf *ffuf.Config, replay bool) ffuf.RunnerProvider {
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 				Renegotiation:      tls.RenegotiateOnceAsClient,
+				ServerName:         conf.SNI,
 			},
 		}}
 


### PR DESCRIPTION
# Description

Add TLS SNI support to ffuf.

I opted not to include support for the `FUZZ` target here as each new request would require a full new TLS connection which introduces significant overhead. There might be some value in adding support for this later for VHOST discovery using TLS SNI.

Fixes: #440

For background: https://tools.ietf.org/html/rfc6066#section-3

## Example:
```
./ffuf -H "Host: www.erbbysam.com" -u https://104.154.120.133:443/FUZZ -sni www.erbbysam.com -w ~/wordlist.txt 
```

## Tests:
 - I have confirmed this new field works.
 - I have confirmed this new code does not impact existing SNI values when run without the `-sni` flag using.
 - I have confirmed this new field can be specified via configuration file.

(all tests were done using using tcpdump+wireshark -- example: `tcpdump port 443 -w ~/output.pcap`)

## Additonally

- [X] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`. 
The file should be alphabetically ordered.
- [X] Add a short description of the fix to `CHANGELOG.md`

Thanks for contributing to ffuf :)
