### PR TITLE
Print results found during interactive mode after exiting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Added a CLI flag to specify TLS SNI value
   - Changed
     - Fixed an issue where output file was created regardless of `-or`
+    - Fixed an issue where output (often a lot of it) would be printed after entering interactive mode
 
 - v1.3.1
   - New

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -356,6 +356,7 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 			j.inc429()
 		}
 	}
+	j.pauseWg.Wait()
 	if j.isMatch(resp) {
 		// Re-send request through replay-proxy if needed
 		if j.ReplayRunner != nil {
@@ -370,6 +371,7 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 			}
 		}
 		j.Output.Result(resp)
+
 		// Refresh the progress indicator as we printed something out
 		j.updateProgress()
 		if j.Config.Recursion && j.Config.RecursionStrategy == "greedy" {


### PR DESCRIPTION
Results found in background threads after entering interactive mode are now printed (and re-evaluated, as filters / matchers can be changed during it) only after exiting interactive mode.