### PR TITLE
Removing `Re-parse the cli options` in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -172,7 +172,8 @@ func main() {
 		// Reset the flag package state
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 		// Re-parse the cli options
-		opts = ParseFlags(opts)
+		// Why ?
+		// opts = ParseFlags(opts)
 	}
 
 	// Prepare context and set up Config struct


### PR DESCRIPTION
It set `opts.Input.Wordlists` to `[]`. and caused such errors:
Wordlist args missing when referenced from config file. #484
wordlists not readable in ffufrc #357

Fixes: #357 #484 