### PR TITLE
Deleted Re-parse the cli options from main.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Changed
     - Fixed an issue where output file was created regardless of `-or`
     - Fixed an issue where output (often a lot of it) would be printed after entering interactive mode
+    - Fixed an issue where caused Wordlist args missing when referenced from config file
 
 - v1.3.1
   - New

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,3 +35,4 @@
 * [SolomonSklash](https://github.com/SolomonSklash)
 * [l4yton](https://github.com/l4yton)
 * [xfgusta](https://github.com/xfgusta)
+* [xaoirse](https://github.com/xaoirse)

--- a/main.go
+++ b/main.go
@@ -172,7 +172,8 @@ func main() {
 		// Reset the flag package state
 		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 		// Re-parse the cli options
-		opts = ParseFlags(opts)
+		// Why?
+		// opts = ParseFlags(opts)
 	}
 
 	// Prepare context and set up Config struct


### PR DESCRIPTION
It set opts.Input.Wordlists to []. and caused such errors:
Wordlist args missing when referenced from config file. #484
wordlists not readable in ffufrc #357

Fixes: #357 #484