### PR TITLE
added the '-stfu' flag to Show The Full URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 - master
   - New
+    - Added the '-stfu' flag to Show The Full URL
     - Added response time logging and filtering
     - Added a CLI flag to specify TLS SNI value
     - Added full line colors

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,6 +32,7 @@
 * [SakiiR](https://github.com/SakiiR)
 * [seblw](https://github.com/seblw)
 * [Shaked](https://github.com/Shaked)
+* [shyft](https://github.com/ShyftXero)
 * [SolomonSklash](https://github.com/SolomonSklash)
 * [l4yton](https://github.com/l4yton)
 * [xfgusta](https://github.com/xfgusta)

--- a/help.go
+++ b/help.go
@@ -96,7 +96,7 @@ func Usage() {
 		Description:   "Options for output. Output file formats, file names and debug file locations.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"debug-log", "o", "of", "od", "or"},
+		ExpectedFlags: []string{"debug-log", "o", "of", "od", "or", "stfu"},
 	}
 	sections := []UsageSection{u_http, u_general, u_compat, u_matcher, u_filter, u_input, u_output}
 

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.Output.OutputDirectory, "od", opts.Output.OutputDirectory, "Directory path to store matched results to.")
 	flag.StringVar(&opts.Output.OutputFile, "o", opts.Output.OutputFile, "Write output to file")
 	flag.StringVar(&opts.Output.OutputFormat, "of", opts.Output.OutputFormat, "Output file format. Available formats: json, ejson, html, md, csv, ecsv (or, 'all' for all formats)")
+	flag.BoolVar(&opts.Output.ShowFullURL, "stfu", opts.Output.ShowFullURL, "Show the full URL in normal output")
 	flag.Var(&autocalibrationstrings, "acc", "Custom auto-calibration string. Can be used multiple times. Implies -ac")
 	flag.Var(&cookies, "b", "Cookie data `\"NAME1=VALUE1; NAME2=VALUE2\"` for copy as curl functionality.")
 	flag.Var(&cookies, "cookie", "Cookie data (alias of -b)")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	Timeout                int                       `json:"timeout"`
 	Url                    string                    `json:"url"`
 	Verbose                bool                      `json:"verbose"`
+	ShowFullURL			   bool						 `json:"show_full_url"`
 }
 
 type InputProviderConfig struct {
@@ -96,6 +97,7 @@ func NewConfig(ctx context.Context, cancel context.CancelFunc) Config {
 	conf.Timeout = 10
 	conf.Url = ""
 	conf.Verbose = false
+	conf.ShowFullURL = false
 	return conf
 }
 

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -80,6 +80,7 @@ type OutputOptions struct {
 	OutputFile          string
 	OutputFormat        string
 	OutputSkipEmptyFile bool
+	ShowFullURL         bool
 }
 
 type FilterOptions struct {
@@ -153,6 +154,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.Output.OutputFile = ""
 	c.Output.OutputFormat = "json"
 	c.Output.OutputSkipEmptyFile = false
+	c.Output.ShowFullURL = false
 	return c
 }
 
@@ -410,6 +412,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	conf.MaxTimeJob = parseOpts.General.MaxTimeJob
 	conf.Noninteractive = parseOpts.General.Noninteractive
 	conf.Verbose = parseOpts.General.Verbose
+	conf.ShowFullURL = parseOpts.Output.ShowFullURL
 
 	// Handle copy as curl situation where POST method is implied by --data flag. If method is set to anything but GET, NOOP
 	if len(conf.Data) > 0 &&

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -427,7 +427,15 @@ func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 }
 
 func (s *Stdoutput) resultNormal(res ffuf.Result) {
-	resnormal := fmt.Sprintf("%s%s%-23s [Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, s.colorize(res.StatusCode), s.prepareInputsOneLine(res), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), ANSI_CLEAR)
+	resnormal := ""
+	
+	fmt.Println(s.config.ShowFullURL)
+
+	if s.config.ShowFullURL {
+		resnormal = fmt.Sprintf("%s%s%-23s [Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, s.colorize(res.StatusCode), res.Url, res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), ANSI_CLEAR)
+	}else {
+		resnormal = fmt.Sprintf("%s%s%-23s [Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, s.colorize(res.StatusCode), s.prepareInputsOneLine(res), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), ANSI_CLEAR)
+	}
 	fmt.Println(resnormal)
 }
 


### PR DESCRIPTION
# Description
Added option to show the full URL (`-stfu`) in output rather than just the word from the wordlist. 

The default behavior is unmodified
```
00001.salesforce-communities.cdn.t [Status: 200, Size: 9194, Words: 710, Lines: 202]
00000000000000000000    [Status: 200, Size: 9193, Words: 709, Lines: 202]
0000aaaa                [Status: 200, Size: 9194, Words: 710, Lines: 202]
0000ax                  [Status: 200, Size: 9193, Words: 709, Lines: 202]
0  
```
with `-stfu`
```
https://test.com/00001.salesforce-communities.cdn.t [Status: 200, Size: 9194, Words: 710, Lines: 202]
https://test.com/00000000000000000000    [Status: 200, Size: 9193, Words: 709, Lines: 202]
https://test.com/0000aaaa                [Status: 200, Size: 9194, Words: 710, Lines: 202]
https://test.com/0000ax                  [Status: 200, Size: 9193, Words: 709, Lines: 202]
https://test.com/0                       [Status: 200, Size: 9193, Words: 709, Lines: 202]
```


Fixes: #(issue number)

https://github.com/ffuf/ffuf/issues/421

## Additonally

- [x] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`. 
The file should be alphabetically ordered.
- [x] Add a short description of the fix to `CHANGELOG.md`

Thanks for contributing to ffuf :)
