### PR TITLE
Fix a recursion bug (#377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     - Fixed an issue where output (often a lot of it) would be printed after entering interactive mode
     - Fixed an issue when reading wordlist files from ffufrc
     - Fixed an issue where `-of all` option only creates one output file (instead of all formats) 
+    - Fixed an issue where redirection to the same domain in recursive mode dropped port info from URL
     - Added HTTP2 support
 
 - v1.3.1

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@
 * [fang0654](https://github.com/fang0654)
 * [Hazegard](https://github.com/Hazegard)
 * [helpermika](https://github.com/helpermika)
+* [h1x](https://github.com/h1x-lnx)
 * [Ice3man543](https://github.com/Ice3man543)
 * [JamTookTheBait](https://github.com/JamTookTheBait)
 * [jimen0](https://github.com/jimen0)

--- a/pkg/ffuf/response.go
+++ b/pkg/ffuf/response.go
@@ -43,10 +43,38 @@ func (resp *Response) GetRedirectLocation(absolute bool) string {
 		if err != nil {
 			return redirectLocation
 		}
-		redirectLocation = baseUrl.ResolveReference(redirectUrl).String()
+		if redirectUrl.IsAbs() && UrlEqual(redirectUrl, baseUrl) {
+			redirectLocation = redirectUrl.Scheme + "://" +
+				baseUrl.Host + redirectUrl.Path
+		} else {
+			redirectLocation = baseUrl.ResolveReference(redirectUrl).String()
+		}
 	}
 
 	return redirectLocation
+}
+
+func UrlEqual(url1, url2 *url.URL) bool {
+	if url1.Hostname() != url2.Hostname() {
+		return false
+	}
+	if url1.Scheme != url2.Scheme {
+		return false
+	}
+	p1, p2 := getUrlPort(url1), getUrlPort(url2)
+	return p1 == p2
+}
+
+func getUrlPort(url *url.URL) string {
+	var portMap = map[string]string{
+		"http":  "80",
+		"https": "443",
+	}
+	p := url.Port()
+	if p == "" {
+		p = portMap[url.Scheme]
+	}
+	return p
 }
 
 func NewResponse(httpresp *http.Response, req *Request) Response {


### PR DESCRIPTION
Recursion does not work when the user provides port information in the URL and the site returns redirection status code (3xx) with a `Location` header containing absolute URL path. Bug (#377).

Line responsible: https://github.com/ffuf/ffuf/blob/965f282c0b77b620ed418a5905d10a171f627448/pkg/ffuf/response.go#L46

This line drops the port info when `redirectUrl` is an absolute path and is the same as `baseUrl`.
This PR fixes the bug by making sure that the above situation is handled differently than when the `redirectUrl` contains a relative path.
