### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ ffuf -w /path/to/values.txt -u https://target/script.php?valid_name=FUZZ -fc 401
 This is a very straightforward operation, again by using the `FUZZ` keyword. This example is fuzzing only part of the POST request. We're again filtering out the 401 responses.
 
 ```
-ffuf -w /path/to/postdata.txt -X POST -d "username=admin\&password=FUZZ" -u https://target/login.php -fc 401
+ffuf -w /path/to/postdata.txt -X POST -d "username=admin&password=FUZZ" -u https://target/login.php -fc 401
 ```
 
 ### Maximum execution time


### PR DESCRIPTION
# Description

As pointed by @zesty in https://github.com/ffuf/ffuf/issues/543, the POST data must no escape **&**.

Tested in a OOB server.

**From:**
`-d "username=admin\&password=FUZZ"`

**To:**
`-d "username=admin&password=FUZZ"`

Fixes: #543

## Additonally

- [x] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`. 
The file should be alphabetically ordered.
- [ ] Add a short description of the fix to `CHANGELOG.md`

Thanks for contributing to ffuf :)
