### PR TITLE
Remove unused param from writeToAll function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - master
   - New
   - Changed
+    - Removed unused filename parameter from writeToAll function.
   
 - v1.5.0
   - New

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,6 +32,7 @@
 * [lc](https://github.com/lc)
 * [mprencipe](https://github.com/mprencipe)
 * [nnwakelam](https://twitter.com/nnwakelam)
+* [NomanAli181](https://twitter.com/nomanAli181)
 * [noraj](https://pwn.by/noraj)
 * [oh6hay](https://github.com/oh6hay)
 * [penguinxoxo](https://github.com/penguinxoxo)

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -219,7 +219,7 @@ func (s *Stdoutput) Raw(output string) {
 	fmt.Fprintf(os.Stderr, "%s%s", TERMINAL_CLEAR_LINE, output)
 }
 
-func (s *Stdoutput) writeToAll(filename string, config *ffuf.Config, res []ffuf.Result) error {
+func (s *Stdoutput) writeToAll(config *ffuf.Config, res []ffuf.Result) error {
 	var err error
 	var BaseFilename string = s.config.OutputFile
 
@@ -275,7 +275,7 @@ func (s *Stdoutput) SaveFile(filename, format string) error {
 	}
 	switch format {
 	case "all":
-		err = s.writeToAll(filename, s.config, append(s.Results, s.CurrentResults...))
+		err = s.writeToAll(s.config, append(s.Results, s.CurrentResults...))
 	case "json":
 		err = writeJSON(filename, s.config, append(s.Results, s.CurrentResults...))
 	case "ejson":


### PR DESCRIPTION
Hello :)

# Description

I noticed that the function `writeToAll` at https://github.com/ffuf/ffuf/blob/master/pkg/output/stdout.go#L222 is taking the `filename` parameter but that isn't being used as the output filename is being created using `s.config.OutputFile` value.

Hence it is better to remove the parameter from the function and do the same while calling it.


--
Regards,
Noman

