### PR TITLE
Upgraded dependencies and go version to v1.18

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,7 @@
 * [justinsteven](https://github.com/justinsteven)
 * [jvesiluoma](https://github.com/jvesiluoma)
 * [Kiblyn11](https://github.com/Kiblyn11)
+* [kkaosninja](https://github.com/kkaosninja)
 * [lc](https://github.com/lc)
 * [mprencipe](https://github.com/mprencipe)
 * [nnwakelam](https://twitter.com/nnwakelam)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/ffuf/ffuf
 
-go 1.13
+go 1.18
 
-require github.com/pelletier/go-toml v1.8.1
+require github.com/pelletier/go-toml v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,2 @@
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
-github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=


### PR DESCRIPTION
# Description

Changes to `go.mod`
- Upgraded go version to v1.18
- Upgraded dependency `github.com/pelletier/go-toml` version to v1.19.5(latest)
