### PR TITLE
Added additional proxy URL verification

### DIFF
--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -364,9 +364,9 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 
 	// Verify proxy url format
 	if len(parseOpts.HTTP.ProxyURL) > 0 {
-		_, err := url.Parse(parseOpts.HTTP.ProxyURL)
-		if err != nil {
-			errs.Add(fmt.Errorf("Bad proxy url (-x) format: %s", err))
+		u, err := url.Parse(parseOpts.HTTP.ProxyURL)
+		if err != nil || u.Opaque != "" || (u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "socks5") {
+			errs.Add(fmt.Errorf("Bad proxy url (-x) format. Expected http, https or socks5 url"))
 		} else {
 			conf.ProxyURL = parseOpts.HTTP.ProxyURL
 		}
@@ -374,9 +374,9 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 
 	// Verify replayproxy url format
 	if len(parseOpts.HTTP.ReplayProxyURL) > 0 {
-		_, err := url.Parse(parseOpts.HTTP.ReplayProxyURL)
-		if err != nil {
-			errs.Add(fmt.Errorf("Bad replay-proxy url (-replay-proxy) format: %s", err))
+		u, err := url.Parse(parseOpts.HTTP.ReplayProxyURL)
+		if err != nil || u.Opaque != "" || (u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "socks5") {
+			errs.Add(fmt.Errorf("Bad replay-proxy url (-replay-proxy) format. Expected http, https or socks5 url"))
 		} else {
 			conf.ReplayProxyURL = parseOpts.HTTP.ReplayProxyURL
 		}

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -375,7 +375,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	// Verify replayproxy url format
 	if len(parseOpts.HTTP.ReplayProxyURL) > 0 {
 		u, err := url.Parse(parseOpts.HTTP.ReplayProxyURL)
-		if err != nil || u.Opaque != "" || (u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "socks5") {
+		if err != nil || u.Opaque != "" || (u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "socks5" && u.Scheme != "socks5h") {
 			errs.Add(fmt.Errorf("Bad replay-proxy url (-replay-proxy) format. Expected http, https or socks5 url"))
 		} else {
 			conf.ReplayProxyURL = parseOpts.HTTP.ReplayProxyURL

--- a/pkg/ffuf/optionsparser_test.go
+++ b/pkg/ffuf/optionsparser_test.go
@@ -1,6 +1,7 @@
 package ffuf
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -81,5 +82,99 @@ func TestTemplatePresent(t *testing.T) {
 
 	if templatePresent(template, &badConfHeaderKey) {
 		t.Errorf("Expected-bad config (Header key) failed validation")
+	}
+}
+
+func TestProxyParsing(t *testing.T) {
+	configOptions := NewConfigOptions()
+	errorString := "Bad proxy url (-x) format. Expected http, https or socks5 url"
+
+	// http should work
+	configOptions.HTTP.ProxyURL = "http://127.0.0.1:8080"
+	_, err := ConfigFromOptions(configOptions, nil, nil)
+	if strings.Contains(err.Error(), errorString) {
+		t.Errorf("Expected http proxy string to work")
+	}
+
+	// https should work
+	configOptions.HTTP.ProxyURL = "https://127.0.0.1"
+	_, err = ConfigFromOptions(configOptions, nil, nil)
+	if strings.Contains(err.Error(), errorString) {
+		t.Errorf("Expected https proxy string to work")
+	}
+
+	// socks5 should work
+	configOptions.HTTP.ProxyURL = "socks5://127.0.0.1"
+	_, err = ConfigFromOptions(configOptions, nil, nil)
+	if strings.Contains(err.Error(), errorString) {
+		t.Errorf("Expected socks5 proxy string to work")
+	}
+
+	// garbage data should FAIL
+	configOptions.HTTP.ProxyURL = "Y0 y0 it's GREASE"
+	_, err = ConfigFromOptions(configOptions, nil, nil)
+	if !strings.Contains(err.Error(), errorString) {
+		t.Errorf("Expected garbage proxy string to fail")
+	}
+
+	// Opaque URLs with the right scheme should FAIL
+	configOptions.HTTP.ProxyURL = "http:sixhours@dungeon"
+	_, err = ConfigFromOptions(configOptions, nil, nil)
+	if !strings.Contains(err.Error(), errorString) {
+		t.Errorf("Expected opaque proxy string to fail")
+	}
+
+	// Unsupported protocols should FAIL
+	configOptions.HTTP.ProxyURL = "imap://127.0.0.1"
+	_, err = ConfigFromOptions(configOptions, nil, nil)
+	if !strings.Contains(err.Error(), errorString) {
+		t.Errorf("Expected proxy string with unsupported protocol to fail")
+	}
+}
+
+func TestReplayProxyParsing(t *testing.T) {
+	configOptions := NewConfigOptions()
+	errorString := "Bad replay-proxy url (-replay-proxy) format. Expected http, https or socks5 url"
+
+	// http should work
+	configOptions.HTTP.ReplayProxyURL = "http://127.0.0.1:8080"
+	_, err := ConfigFromOptions(configOptions, nil, nil)
+	if strings.Contains(err.Error(), errorString) {
+		t.Errorf("Expected http replay proxy string to work")
+	}
+
+	// https should work
+	configOptions.HTTP.ReplayProxyURL = "https://127.0.0.1"
+	_, err = ConfigFromOptions(configOptions, nil, nil)
+	if strings.Contains(err.Error(), errorString) {
+		t.Errorf("Expected https proxy string to work")
+	}
+
+	// socks5 should work
+	configOptions.HTTP.ReplayProxyURL = "socks5://127.0.0.1"
+	_, err = ConfigFromOptions(configOptions, nil, nil)
+	if strings.Contains(err.Error(), errorString) {
+		t.Errorf("Expected socks5 proxy string to work")
+	}
+
+	// garbage data should FAIL
+	configOptions.HTTP.ReplayProxyURL = "Y0 y0 it's GREASE"
+	_, err = ConfigFromOptions(configOptions, nil, nil)
+	if !strings.Contains(err.Error(), errorString) {
+		t.Errorf("Expected garbage proxy string to fail")
+	}
+
+	// Opaque URLs with the right scheme should FAIL
+	configOptions.HTTP.ReplayProxyURL = "http:sixhours@dungeon"
+	_, err = ConfigFromOptions(configOptions, nil, nil)
+	if !strings.Contains(err.Error(), errorString) {
+		t.Errorf("Expected opaque proxy string to fail")
+	}
+
+	// Unsupported protocols should FAIL
+	configOptions.HTTP.ReplayProxyURL = "imap://127.0.0.1"
+	_, err = ConfigFromOptions(configOptions, nil, nil)
+	if !strings.Contains(err.Error(), errorString) {
+		t.Errorf("Expected proxy string with unsupported protocol to fail")
 	}
 }


### PR DESCRIPTION
# Description

This pull request adds additional checking for proxy and replay-proxy parameters, as well as adding some tests to make sure the parser is working how it's expected to.  Go's `url.parse` alone does not provide enough verification to determine whether a given URL matches the requirements for a proxy passed to a HTTP transport.

Fixes: #573