### PR TITLE
Sniper template parsing - fixes #579

### DIFF
--- a/pkg/ffuf/request.go
+++ b/pkg/ffuf/request.go
@@ -172,10 +172,12 @@ func injectKeyword(input string, keyword string, startOffset int, endOffset int)
 	prefix := inputslice[:startOffset]
 	suffix := inputslice[endOffset+1:]
 
-	inputslice = append(prefix, keywordslice...)
-	inputslice = append(inputslice, suffix...)
+	var outputslice []rune
+	outputslice = append(outputslice, prefix...)
+	outputslice = append(outputslice, keywordslice...)
+	outputslice = append(outputslice, suffix...)
 
-	return string(inputslice)
+	return string(outputslice)
 }
 
 // scrubTemplates removes all template (§) strings from the request struct

--- a/pkg/ffuf/request_test.go
+++ b/pkg/ffuf/request_test.go
@@ -215,6 +215,23 @@ func TestInjectKeyword(t *testing.T) {
 		t.Errorf("injectKeyword offset validation failed")
 	}
 
+	input = "id=§a§&sort=desc"
+	offsetTuple = templateLocations("§", input)
+	expected = "id=FUZZ&sort=desc"
+
+	result = injectKeyword(input, "FUZZ", offsetTuple[0], offsetTuple[1])
+	if result != expected {
+		t.Errorf("injectKeyword returned unexpected result: " + result)
+	}
+
+	input = "feature=aaa&thingie=bbb&array[§0§]=baz"
+	offsetTuple = templateLocations("§", input)
+	expected = "feature=aaa&thingie=bbb&array[FUZZ]=baz"
+
+	result = injectKeyword(input, "FUZZ", offsetTuple[0], offsetTuple[1])
+	if result != expected {
+		t.Errorf("injectKeyword returned unexpected result: " + result)
+	}
 }
 
 func TestScrubTemplates(t *testing.T) {


### PR DESCRIPTION
This PR fixes the sniper template parsing issues, which was caused due to bug in the `injectKeyword` method where if the data between the section-signs was a single character, the resulting string would be incorrect.

Have added additional test cases to catch this.

Fixes: #579