### PR TITLE
Fix the v2 tagging for go install

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
     gcflags:
       - all=-trimpath={{.Env.GOPATH}}
     ldflags: |
-      -s -w -X github.com/ffuf/ffuf/pkg/ffuf.VERSION_APPENDIX= -extldflags '-static'
+      -s -w -X github.com/ffuf/ffuf/v2/pkg/ffuf.VERSION_APPENDIX= -extldflags '-static'
     goos:
       - linux
       - windows

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A fast web fuzzer written in Go.
 - If you are on macOS with [homebrew](https://brew.sh), ffuf can be installed with: `brew install ffuf`
   
   _or_
-- If you have recent go compiler installed: `go install github.com/ffuf/ffuf@latest` (the same command works for updating)
+- If you have recent go compiler installed: `go install github.com/ffuf/ffuf/v2@latest` (the same command works for updating)
   
   _or_
 - `git clone https://github.com/ffuf/ffuf ; cd ffuf ; go get ; go build`

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,16 @@
-module github.com/ffuf/ffuf
+module github.com/ffuf/ffuf/v2
 
 go 1.17
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0
 	github.com/adrg/xdg v0.4.0
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pelletier/go-toml v1.9.5
+)
+
+require (
+	github.com/andybalholm/cascadia v1.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	golang.org/x/net v0.5.0 // indirect
+	golang.org/x/sys v0.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -47,7 +47,6 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/help.go
+++ b/help.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type UsageSection struct {

--- a/main.go
+++ b/main.go
@@ -10,13 +10,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
-	"github.com/ffuf/ffuf/pkg/filter"
-	"github.com/ffuf/ffuf/pkg/input"
-	"github.com/ffuf/ffuf/pkg/interactive"
-	"github.com/ffuf/ffuf/pkg/output"
-	"github.com/ffuf/ffuf/pkg/runner"
-	"github.com/ffuf/ffuf/pkg/scraper"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/filter"
+	"github.com/ffuf/ffuf/v2/pkg/input"
+	"github.com/ffuf/ffuf/v2/pkg/interactive"
+	"github.com/ffuf/ffuf/v2/pkg/output"
+	"github.com/ffuf/ffuf/v2/pkg/runner"
+	"github.com/ffuf/ffuf/v2/pkg/scraper"
 )
 
 type multiStringFlag []string

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -2,8 +2,9 @@ package filter
 
 import (
 	"fmt"
-	"github.com/ffuf/ffuf/pkg/ffuf"
 	"sync"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 // MatcherManager handles both filters and matchers.

--- a/pkg/filter/lines.go
+++ b/pkg/filter/lines.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type LineFilter struct {

--- a/pkg/filter/lines_test.go
+++ b/pkg/filter/lines_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 func TestNewLineFilter(t *testing.T) {

--- a/pkg/filter/regex.go
+++ b/pkg/filter/regex.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type RegexpFilter struct {

--- a/pkg/filter/regexp_test.go
+++ b/pkg/filter/regexp_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 func TestNewRegexpFilter(t *testing.T) {

--- a/pkg/filter/size.go
+++ b/pkg/filter/size.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type SizeFilter struct {

--- a/pkg/filter/size_test.go
+++ b/pkg/filter/size_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 func TestNewSizeFilter(t *testing.T) {

--- a/pkg/filter/status.go
+++ b/pkg/filter/status.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 const AllStatuses = 0

--- a/pkg/filter/status_test.go
+++ b/pkg/filter/status_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 func TestNewStatusFilter(t *testing.T) {

--- a/pkg/filter/time.go
+++ b/pkg/filter/time.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type TimeFilter struct {

--- a/pkg/filter/time_test.go
+++ b/pkg/filter/time_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 func TestNewTimeFilter(t *testing.T) {

--- a/pkg/filter/words.go
+++ b/pkg/filter/words.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type WordFilter struct {

--- a/pkg/filter/words_test.go
+++ b/pkg/filter/words_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 func TestNewWordFilter(t *testing.T) {

--- a/pkg/input/command.go
+++ b/pkg/input/command.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"strconv"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type CommandInput struct {

--- a/pkg/input/input.go
+++ b/pkg/input/input.go
@@ -3,7 +3,7 @@ package input
 import (
 	"fmt"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type MainInputProvider struct {

--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type WordlistInput struct {

--- a/pkg/interactive/termhandler.go
+++ b/pkg/interactive/termhandler.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type interactive struct {

--- a/pkg/output/file_csv.go
+++ b/pkg/output/file_csv.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 var staticheaders = []string{"url", "redirectlocation", "position", "status_code", "content_length", "content_words", "content_lines", "content_type", "duration", "resultfile"}

--- a/pkg/output/file_csv_test.go
+++ b/pkg/output/file_csv_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 func TestToCSV(t *testing.T) {

--- a/pkg/output/file_html.go
+++ b/pkg/output/file_html.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type htmlResult struct {

--- a/pkg/output/file_json.go
+++ b/pkg/output/file_json.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type ejsonFileOutput struct {

--- a/pkg/output/file_md.go
+++ b/pkg/output/file_md.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 const (

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,7 +1,7 @@
 package output
 
 import (
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 func NewOutputProviderByName(name string, conf *ffuf.Config) ffuf.OutputProvider {

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 const (

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -1,7 +1,7 @@
 package runner
 
 import (
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 func NewRunnerByName(name string, conf *ffuf.Config, replay bool) ffuf.RunnerProvider {

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 // Download results < 5MB

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 
 	"github.com/PuerkitoBio/goquery"
 )

--- a/pkg/scraper/util.go
+++ b/pkg/scraper/util.go
@@ -2,7 +2,7 @@ package scraper
 
 import (
 	"fmt"
-	"github.com/ffuf/ffuf/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 	"strings"
 )
 


### PR DESCRIPTION
In order for `go install .... ` to work with v2 we need to change the pathspec.