### PR TITLE
allow unused wordlist in config file

### DIFF
--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -526,19 +526,25 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 
 	conf.CommandLine = strings.Join(os.Args, " ")
 
+	newInputProviders := []InputProviderConfig{}
 	for _, provider := range conf.InputProviders {
 		if provider.Template != "" {
 			if !templatePresent(provider.Template, &conf) {
 				errmsg := fmt.Sprintf("Template %s defined, but not found in pairs in headers, method, URL or POST data.", provider.Template)
 				errs.Add(fmt.Errorf(errmsg))
+			} else {
+				newInputProviders = append(newInputProviders, provider)
 			}
 		} else {
 			if !keywordPresent(provider.Keyword, &conf) {
 				errmsg := fmt.Sprintf("Keyword %s defined, but not found in headers, method, URL or POST data.", provider.Keyword)
-				errs.Add(fmt.Errorf(errmsg))
+				_, _ = fmt.Fprintf(os.Stderr, "%s\n", fmt.Errorf(errmsg))
+			} else {
+				newInputProviders = append(newInputProviders, provider)
 			}
 		}
 	}
+	conf.InputProviders = newInputProviders
 
 	// Do checks for recursion mode
 	if parseOpts.HTTP.Recursion {


### PR DESCRIPTION
This is an attempt to fix issue #572.

The current fix just print the error message to `stderr` instead of adding it to the `Multierror` defined.
I am open to better alternatives :grin: 

I also had to remove unused worldlist in the `Config.InputProviders`. Otherwise, unused wordlists are still considered as used (in the reports for instance).