### PR TITLE
[Fix] Fixed multiline output when using only one fuzz variable (issue #645)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,7 @@
 * [noraj](https://pwn.by/noraj)
 * [oh6hay](https://github.com/oh6hay)
 * [penguinxoxo](https://github.com/penguinxoxo)
+* [p0dalirius](https://github.com/p0dalirius)
 * [putsi](https://github.com/putsi)
 * [SakiiR](https://github.com/SakiiR)
 * [seblw](https://github.com/seblw)

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -382,7 +382,7 @@ func (s *Stdoutput) PrintResult(res ffuf.Result) {
 
 func (s *Stdoutput) prepareInputsOneLine(res ffuf.Result) string {
 	inputs := ""
-	if len(res.Input) > 1 {
+	if len(s.fuzzkeywords) > 1 {
 		for _, k := range s.fuzzkeywords {
 		    if ffuf.StrInSlice(k, s.config.CommandKeywords) {
 				// If we're using external command for input, display the position instead of input

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -372,7 +372,7 @@ func (s *Stdoutput) PrintResult(res ffuf.Result) {
 		s.resultJson(res)
 	case s.config.Quiet:
 		s.resultQuiet(res)
-	case len(res.Input) > 1 || s.config.Verbose || len(s.config.OutputDirectory) > 0 || len(res.ScraperData) > 0:
+	case len(s.fuzzkeywords) > 1 || s.config.Verbose || len(s.config.OutputDirectory) > 0 || len(res.ScraperData) > 0:
 		// Print a multi-line result (when using multiple input keywords and wordlists)
 		s.resultMultiline(res)
 	default:

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -383,21 +383,21 @@ func (s *Stdoutput) PrintResult(res ffuf.Result) {
 func (s *Stdoutput) prepareInputsOneLine(res ffuf.Result) string {
 	inputs := ""
 	if len(res.Input) > 1 {
-		for k, v := range res.Input {
-			if ffuf.StrInSlice(k, s.config.CommandKeywords) {
+		for _, k := range s.fuzzkeywords {
+		    if ffuf.StrInSlice(k, s.config.CommandKeywords) {
 				// If we're using external command for input, display the position instead of input
 				inputs = fmt.Sprintf("%s%s : %s ", inputs, k, strconv.Itoa(res.Position))
 			} else {
-				inputs = fmt.Sprintf("%s%s : %s ", inputs, k, v)
+				inputs = fmt.Sprintf("%s%s : %s ", inputs, k, res.Input[k])
 			}
 		}
 	} else {
-		for k, v := range res.Input {
-			if ffuf.StrInSlice(k, s.config.CommandKeywords) {
+        for _, k := range s.fuzzkeywords {
+		    if ffuf.StrInSlice(k, s.config.CommandKeywords) {
 				// If we're using external command for input, display the position instead of input
 				inputs = strconv.Itoa(res.Position)
 			} else {
-				inputs = string(v)
+				inputs = string(res.Input[k])
 			}
 		}
 	}


### PR DESCRIPTION
# Description

Fixed multi-line output when using only one fuzz variable (issue #645)

Fixes: #645

---

## Bug source

In version 2.0 of fuff, `FFUFHASH` was added. 

https://github.com/ffuf/ffuf/blob/b2c1f9471f5bc275912c9c8194e88593d2636597/CHANGELOG.md?plain=1#L8

This variable is set in the `Input` map of the result structure:

https://github.com/ffuf/ffuf/blob/b2c1f9471f5bc275912c9c8194e88593d2636597/main.go#L397

This triggers two bugs

### Bug 1

Because of this, the size of `res.Input` is now at least 2. Therefore all output modes will be multi-lines since the condition `len(res.Input) > 1` is never met in the function [`PrintResult()`](https://github.com/p0dalirius/ffuf/blob/master/pkg/output/stdout.go#L369) in `pkg/output/stdout.go`.

https://github.com/p0dalirius/ffuf/blob/b2c1f9471f5bc275912c9c8194e88593d2636597/pkg/output/stdout.go#L375-L377

Changing the condition `len(res.Input) > 1` to `len(s.fuzzkeywords) > 1` fixes this bug.

### Bug 2

Another bug then occurs when only one fuzz variable is passed and results are printed. When `prepareInputsOneLine()` in `pkg/output/stdout.go` gets called, the function iterates on res.Input, therefore printing `FFUFHASH` too.

https://github.com/p0dalirius/ffuf/blob/master/pkg/output/stdout.go#L386

https://github.com/p0dalirius/ffuf/blob/master/pkg/output/stdout.go#L395

Changing the iteration on `res.Input` to an iteration on `s.fuzzkeywords` fixes this bug.

---

## New behavior

When fuzzing only one variable:

![image](https://user-images.githubusercontent.com/79218792/222801343-7a9d2ed3-3d0e-4204-a29c-bf40b35c15af.png)

When fuzzing two and more variables:

![image](https://user-images.githubusercontent.com/79218792/222801153-94f0e468-ae1a-430b-93ee-33db2a11c563.png)

Best regards,

