### PR TITLE
Add additional check for keywords when using sniper mode

### DIFF
--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -540,6 +540,13 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 		}
 	}
 
+	// If sniper mode, ensure there is no FUZZ keyword
+	if conf.InputMode == "sniper" {
+		if keywordPresent("FUZZ", &conf) {
+			errs.Add(fmt.Errorf("FUZZ keyword defined, but we are using sniper mode."))
+		}
+	}
+
 	// Do checks for recursion mode
 	if parseOpts.HTTP.Recursion {
 		if !strings.HasSuffix(conf.Url, "FUZZ") {


### PR DESCRIPTION
# Description

Adds an additional check when using Sniper mode. If a user specifies template characters, as well as a FUZZ keyword, then the sniper logic ends up injecting the payload into both the template character location as well as the FUZZ keyword.

Fixes: #655