### PR TITLE
Support older versions of TLS regardless of Go defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - master
   - New
   - Changed
+    - Explicitly allow TLS1.0 
   
 - v2.0.0
   - New

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -59,6 +59,7 @@ func NewSimpleRunner(conf *ffuf.Config, replay bool) ffuf.RunnerProvider {
 			TLSHandshakeTimeout: time.Duration(time.Duration(conf.Timeout) * time.Second),
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS10,
 				Renegotiation:      tls.RenegotiateOnceAsClient,
 				ServerName:         conf.SNI,
 			},


### PR DESCRIPTION
Fixes: #664