### PR TITLE
Don't write a finishing newline in silent mode

### DIFF
--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -307,7 +307,9 @@ func (s *Stdoutput) Finalize() error {
 			s.Error(err.Error())
 		}
 	}
-	fmt.Fprintf(os.Stderr, "\n")
+	if !s.config.Quiet {
+		fmt.Fprintf(os.Stderr, "\n")
+	}
 	return nil
 }
 
@@ -384,7 +386,7 @@ func (s *Stdoutput) prepareInputsOneLine(res ffuf.Result) string {
 	inputs := ""
 	if len(s.fuzzkeywords) > 1 {
 		for _, k := range s.fuzzkeywords {
-		    if ffuf.StrInSlice(k, s.config.CommandKeywords) {
+			if ffuf.StrInSlice(k, s.config.CommandKeywords) {
 				// If we're using external command for input, display the position instead of input
 				inputs = fmt.Sprintf("%s%s : %s ", inputs, k, strconv.Itoa(res.Position))
 			} else {
@@ -392,8 +394,8 @@ func (s *Stdoutput) prepareInputsOneLine(res ffuf.Result) string {
 			}
 		}
 	} else {
-        for _, k := range s.fuzzkeywords {
-		    if ffuf.StrInSlice(k, s.config.CommandKeywords) {
+		for _, k := range s.fuzzkeywords {
+			if ffuf.StrInSlice(k, s.config.CommandKeywords) {
 				// If we're using external command for input, display the position instead of input
 				inputs = strconv.Itoa(res.Position)
 			} else {


### PR DESCRIPTION
# Description
When running ffuf in silent mode, a new line is still written on every line at the end of a run of ffuf.
While this looks fine if there are any matches, it will just spam empty new lines whenever:

- No matches are found
- If you redirect stdout but keep stderr on console

Piping ffuf multiple times with different targets, this approx. looks like this:

https://github.com/ffuf/ffuf/assets/26608194/6194f5ec-8e51-496a-9149-68b04cc87658

Thus, let's remove printing the new line when in silent mode.

## Additonally

- [ ] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`. 
The file should be alphabetically ordered.
- [ ] Add a short description of the fix to `CHANGELOG.md`

-> I skipped since I thought this change is too insignificant.

