### PR TITLE
replace hardcoded 100000 with const for increased performance in `RateThrottle && `ChangeRate`

### DIFF
--- a/pkg/ffuf/rate.go
+++ b/pkg/ffuf/rate.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const Million = 1000000 // pre-compute the value for improved performance
+
 type RateThrottle struct {
 	rateCounter    *ring.Ring
 	Config         *Config
@@ -25,7 +27,7 @@ func NewRateThrottle(conf *Config) *RateThrottle {
 		r.rateCounter = ring.New(conf.Threads * 5)
 	}
 	if conf.Rate > 0 {
-		ratemicros := 1000000 / conf.Rate
+		ratemicros := Million / conf.Rate
 		r.RateLimiter = time.NewTicker(time.Microsecond * time.Duration(ratemicros))
 	} else {
 		//Million rps is probably a decent hardcoded upper speedlimit
@@ -65,7 +67,7 @@ func (r *RateThrottle) CurrentRate() int64 {
 }
 
 func (r *RateThrottle) ChangeRate(rate int) {
-	ratemicros := 1000000 / rate
+	ratemicros := Million / rate
 	r.RateLimiter.Stop()
 	r.RateLimiter = time.NewTicker(time.Microsecond * time.Duration(ratemicros))
 	r.Config.Rate = int64(rate)


### PR DESCRIPTION
implements a straightforward performance optimization for the `RateThrottle` and `ChangeRate` functions by replacing the rate calculation with a constant value.