### PR TITLE
Recursion status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 - master
   - New
+    - New command line parameter for recursive autocalibration on every path `-acp`
     - New command line parameter for controlling recursion status code `-recursion-status`
   - Changed
     - Explicitly allow TLS1.0 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 - master
   - New
+    - New command line parameter for controlling recursion status code `-recursion-status`
   - Changed
     - Explicitly allow TLS1.0 
     - Fix markdown output file format

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,7 @@
 
 * [adamtlangley](https://github.com/adamtlangley)
 * [adilsoybali](https://github.com/adilsoybali)
+* [aristosMiliaressis](https://github.com/aristosMiliaressis)
 * [AverageSecurityGuy](https://github.com/averagesecurityguy)
 * [bp0](https://github.com/bp0lr)
 * [bjhulst](https://github.com/bjhulst)

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ HTTP OPTIONS:
   -recursion          Scan recursively. Only FUZZ keyword is supported, and URL (-u) has to end in it. (default: false)
   -recursion-depth    Maximum recursion depth. (default: 0)
   -recursion-strategy Recursion strategy: "default" for a redirect based, and "greedy" to recurse on all matches (default: default)
+  -recursion-status   Recurses on responses with the given status (default: 301,302,303,307,308)
   -replay-proxy       Replay matched requests using this proxy.
   -sni                Target TLS SNI, does not support FUZZ keyword
   -timeout            HTTP request timeout in seconds. (default: 10)
@@ -174,6 +175,7 @@ GENERAL OPTIONS:
   -ac                 Automatically calibrate filtering options (default: false)
   -acc                Custom auto-calibration string. Can be used multiple times. Implies -ac
   -ach                Per host autocalibration (default: false)
+  -acp                Per path autocalibration (default: false)
   -ack                Autocalibration keyword (default: FUZZ)
   -acs                Autocalibration strategy: "basic" or "advanced" (default: basic)
   -c                  Colorize output. (default: false)

--- a/help.go
+++ b/help.go
@@ -54,7 +54,7 @@ func Usage() {
 		Description:   "Options controlling the HTTP request and its parts.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"H", "X", "b", "d", "r", "u", "recursion", "recursion-depth", "recursion-strategy", "replay-proxy", "timeout", "ignore-body", "x", "sni", "http2"},
+		ExpectedFlags: []string{"H", "X", "b", "d", "r", "u", "recursion", "recursion-depth", "recursion-strategy", "recursion-status", "replay-proxy", "timeout", "ignore-body", "x", "sni", "http2"},
 	}
 	u_general := UsageSection{
 		Name:          "GENERAL OPTIONS",

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,9 +21,14 @@ import (
 )
 
 type multiStringFlag []string
+type multiIntFlag []int
 type wordlistFlag []string
 
 func (m *multiStringFlag) String() string {
+	return ""
+}
+
+func (m *multiIntFlag) String() string {
 	return ""
 }
 
@@ -32,6 +38,22 @@ func (m *wordlistFlag) String() string {
 
 func (m *multiStringFlag) Set(value string) error {
 	*m = append(*m, value)
+	return nil
+}
+
+func (m *multiIntFlag) Set(value string) error {
+	nums := strings.Split(value, ",")
+	for _, n := range nums {
+		num, err := strconv.Atoi(n)
+		if err != nil {
+			errmsg := fmt.Errorf("multiIntFlag int conversion error")
+			fmt.Fprintf(os.Stderr, "Encountered error(s): %s\n", errmsg)
+			Usage()
+			fmt.Fprintf(os.Stderr, "Encountered error(s): %s\n", errmsg)
+			os.Exit(1)
+		}
+		*m = append(*m, num)
+	}
 	return nil
 }
 
@@ -51,6 +73,7 @@ func (m *wordlistFlag) Set(value string) error {
 func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	var ignored bool
 	var cookies, autocalibrationstrings, headers, inputcommands multiStringFlag
+	var recursionStatus multiIntFlag
 	var wordlists wordlistFlag
 
 	cookies = opts.HTTP.Cookies
@@ -127,6 +150,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.Output.OutputDirectory, "od", opts.Output.OutputDirectory, "Directory path to store matched results to.")
 	flag.StringVar(&opts.Output.OutputFile, "o", opts.Output.OutputFile, "Write output to file")
 	flag.StringVar(&opts.Output.OutputFormat, "of", opts.Output.OutputFormat, "Output file format. Available formats: json, ejson, html, md, csv, ecsv (or, 'all' for all formats)")
+	flag.Var(&recursionStatus, "recursion-status", "Recurses on responses with the given status (default: 301,302,303,307,308)")
 	flag.Var(&autocalibrationstrings, "acc", "Custom auto-calibration string. Can be used multiple times. Implies -ac")
 	flag.Var(&cookies, "b", "Cookie data `\"NAME1=VALUE1; NAME2=VALUE2\"` for copy as curl functionality.")
 	flag.Var(&cookies, "cookie", "Cookie data (alias of -b)")
@@ -139,6 +163,9 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	opts.General.AutoCalibrationStrings = autocalibrationstrings
 	opts.HTTP.Cookies = cookies
 	opts.HTTP.Headers = headers
+	if len(recursionStatus) != 0 {
+		opts.HTTP.RecursionStatus = recursionStatus
+	}
 	opts.Input.Inputcommands = inputcommands
 	opts.Input.Wordlists = wordlists
 	return opts

--- a/main.go
+++ b/main.go
@@ -88,6 +88,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.BoolVar(&opts.Output.OutputSkipEmptyFile, "or", opts.Output.OutputSkipEmptyFile, "Don't create the output file if we don't have results")
 	flag.BoolVar(&opts.General.AutoCalibration, "ac", opts.General.AutoCalibration, "Automatically calibrate filtering options")
 	flag.BoolVar(&opts.General.AutoCalibrationPerHost, "ach", opts.General.AutoCalibration, "Per host autocalibration")
+	flag.BoolVar(&opts.General.AutoCalibrationPerPath, "acp", false, "Recursive autocalibration on every path")
 	flag.BoolVar(&opts.General.Colors, "c", opts.General.Colors, "Colorize output.")
 	flag.BoolVar(&opts.General.Json, "json", opts.General.Json, "JSON output, printing newline-delimited JSON records")
 	flag.BoolVar(&opts.General.Noninteractive, "noninteractive", opts.General.Noninteractive, "Disable the interactive console functionality")

--- a/pkg/ffuf/autocalibration.go
+++ b/pkg/ffuf/autocalibration.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net/url"
 	"strconv"
 	"time"
 )
@@ -76,13 +77,45 @@ func (j *Job) CalibrateForHost(host string, baseinput map[string][]byte) error {
 				continue
 			}
 			responses = append(responses, resp)
-			err = j.calibrateFilters(responses, true)
+			err = j.calibrateFilters(responses, true, j.Config.AutoCalibrationPerPath)
 			if err != nil {
 				j.Output.Error(fmt.Sprintf("%s", err))
 			}
 		}
 	}
 	j.Config.MatcherManager.SetCalibratedForHost(host, true)
+	return nil
+}
+
+// CalibrateForPath runs autocalibration for a specific path
+func (j *Job) CalibrateForPath(path string, baseinput map[string][]byte) error {
+	if j.Config.MatcherManager.CalibratedForPath(path) {
+		return nil
+	}
+	if baseinput[j.Config.AutoCalibrationKeyword] == nil {
+		return fmt.Errorf("Autocalibration keyword \"%s\" not found in the request.", j.Config.AutoCalibrationKeyword)
+	}
+	cStrings := j.autoCalibrationStrings()
+	input := make(map[string][]byte)
+	for k, v := range baseinput {
+		input[k] = v
+	}
+	for _, v := range cStrings {
+		responses := make([]Response, 0)
+		for _, cs := range v {
+			input[j.Config.AutoCalibrationKeyword] = []byte(cs)
+			resp, err := j.calibrationRequest(input)
+			if err != nil {
+				continue
+			}
+			responses = append(responses, resp)
+			err = j.calibrateFilters(responses, true, j.Config.AutoCalibrationPerPath)
+			if err != nil {
+				j.Output.Error(fmt.Sprintf("%s", err))
+			}
+		}
+	}
+	j.Config.MatcherManager.SetCalibratedForPath(path, true)
 	return nil
 }
 
@@ -103,7 +136,7 @@ func (j *Job) Calibrate(input map[string][]byte) error {
 			}
 			responses = append(responses, resp)
 		}
-		_ = j.calibrateFilters(responses, false)
+		_ = j.calibrateFilters(responses, false, j.Config.AutoCalibrationPerPath)
 	}
 	j.Config.MatcherManager.SetCalibrated(true)
 	return nil
@@ -112,11 +145,14 @@ func (j *Job) Calibrate(input map[string][]byte) error {
 // CalibrateIfNeeded runs a self-calibration task for filtering options (if needed) by requesting random resources and
 //
 //	configuring the filters accordingly
-func (j *Job) CalibrateIfNeeded(host string, input map[string][]byte) error {
+func (j *Job) CalibrateIfNeeded(host string, path string, input map[string][]byte) error {
 	j.calibMutex.Lock()
 	defer j.calibMutex.Unlock()
 	if !j.Config.AutoCalibration {
 		return nil
+	}
+	if j.Config.AutoCalibrationPerPath {
+		return j.CalibrateForPath(path, input)
 	}
 	if j.Config.AutoCalibrationPerHost {
 		return j.CalibrateForHost(host, input)
@@ -124,7 +160,7 @@ func (j *Job) CalibrateIfNeeded(host string, input map[string][]byte) error {
 	return j.Calibrate(input)
 }
 
-func (j *Job) calibrateFilters(responses []Response, perHost bool) error {
+func (j *Job) calibrateFilters(responses []Response, perHost bool, perPath bool) error {
 	// Work down from the most specific common denominator
 	if len(responses) > 0 {
 		// Content length
@@ -136,7 +172,19 @@ func (j *Job) calibrateFilters(responses []Response, perHost bool) error {
 			}
 		}
 		if sizeMatch {
-			if perHost {
+			if perPath {
+				parsed, _ := url.Parse(responses[0].Request.Url)
+				// Check if already filtered
+				for _, f := range j.Config.MatcherManager.FiltersForPath(parsed.Path) {
+					match, _ := f.Filter(&responses[0])
+					if match {
+						// Already filtered
+						return nil
+					}
+				}
+				_ = j.Config.MatcherManager.AddPerPathFilter(parsed.Path, "size", strconv.FormatInt(baselineSize, 10))
+				return nil
+			} else if perHost {
 				// Check if already filtered
 				for _, f := range j.Config.MatcherManager.FiltersForDomain(HostURLFromRequest(*responses[0].Request)) {
 					match, _ := f.Filter(&responses[0])
@@ -170,7 +218,19 @@ func (j *Job) calibrateFilters(responses []Response, perHost bool) error {
 			}
 		}
 		if wordsMatch {
-			if perHost {
+			if perPath {
+				parsed, _ := url.Parse(responses[0].Request.Url)
+				// Check if already filtered
+				for _, f := range j.Config.MatcherManager.FiltersForPath(parsed.Path) {
+					match, _ := f.Filter(&responses[0])
+					if match {
+						// Already filtered
+						return nil
+					}
+				}
+				_ = j.Config.MatcherManager.AddPerPathFilter(parsed.Path, "word", strconv.FormatInt(baselineWords, 10))
+				return nil
+			} else if perHost {
 				// Check if already filtered
 				for _, f := range j.Config.MatcherManager.FiltersForDomain(HostURLFromRequest(*responses[0].Request)) {
 					match, _ := f.Filter(&responses[0])
@@ -204,7 +264,19 @@ func (j *Job) calibrateFilters(responses []Response, perHost bool) error {
 			}
 		}
 		if linesMatch {
-			if perHost {
+			if perPath {
+				parsed, _ := url.Parse(responses[0].Request.Url)
+				// Check if already filtered
+				for _, f := range j.Config.MatcherManager.FiltersForPath(parsed.Path) {
+					match, _ := f.Filter(&responses[0])
+					if match {
+						// Already filtered
+						return nil
+					}
+				}
+				_ = j.Config.MatcherManager.AddPerPathFilter(parsed.Path, "line", strconv.FormatInt(baselineLines, 10))
+				return nil
+			} else if perHost {
 				// Check if already filtered
 				for _, f := range j.Config.MatcherManager.FiltersForDomain(HostURLFromRequest(*responses[0].Request)) {
 					match, _ := f.Filter(&responses[0])

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	AutoCalibration         bool                  `json:"autocalibration"`
 	AutoCalibrationKeyword  string                `json:"autocalibration_keyword"`
 	AutoCalibrationPerHost  bool                  `json:"autocalibration_perhost"`
+	AutoCalibrationPerPath  bool                  `json:"autocalibration_perpath"`
 	AutoCalibrationStrategy string                `json:"autocalibration_strategy"`
 	AutoCalibrationStrings  []string              `json:"autocalibration_strings"`
 	Cancel                  context.CancelFunc    `json:"-"`

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	Rate                    int64                 `json:"rate"`
 	Recursion               bool                  `json:"recursion"`
 	RecursionDepth          int                   `json:"recursion_depth"`
+	RecursionStatus         []int                 `json:"recursion_status"`
 	RecursionStrategy       string                `json:"recursion_strategy"`
 	ReplayProxyURL          string                `json:"replayproxyurl"`
 	RequestFile             string                `json:"requestfile"`
@@ -106,6 +107,7 @@ func NewConfig(ctx context.Context, cancel context.CancelFunc) Config {
 	conf.Recursion = false
 	conf.RecursionDepth = 0
 	conf.RecursionStrategy = "default"
+	conf.RecursionStatus = []int{301, 302, 303, 307, 308}
 	conf.RequestFile = ""
 	conf.RequestProto = "https"
 	conf.SNI = ""

--- a/pkg/ffuf/configmarshaller.go
+++ b/pkg/ffuf/configmarshaller.go
@@ -31,6 +31,7 @@ func (c *Config) ToOptions() ConfigOptions {
 	o.General.AutoCalibration = c.AutoCalibration
 	o.General.AutoCalibrationKeyword = c.AutoCalibrationKeyword
 	o.General.AutoCalibrationPerHost = c.AutoCalibrationPerHost
+	o.General.AutoCalibrationPerPath = c.AutoCalibrationPerPath
 	o.General.AutoCalibrationStrategy = c.AutoCalibrationStrategy
 	o.General.AutoCalibrationStrings = c.AutoCalibrationStrings
 	o.General.Colors = c.Colors

--- a/pkg/ffuf/configmarshaller.go
+++ b/pkg/ffuf/configmarshaller.go
@@ -21,6 +21,7 @@ func (c *Config) ToOptions() ConfigOptions {
 	o.HTTP.Recursion = c.Recursion
 	o.HTTP.RecursionDepth = c.RecursionDepth
 	o.HTTP.RecursionStrategy = c.RecursionStrategy
+	o.HTTP.RecursionStatus = c.RecursionStatus
 	o.HTTP.ReplayProxyURL = c.ReplayProxyURL
 	o.HTTP.SNI = c.SNI
 	o.HTTP.Timeout = c.Timeout

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -8,14 +8,18 @@ import (
 type MatcherManager interface {
 	SetCalibrated(calibrated bool)
 	SetCalibratedForHost(host string, calibrated bool)
+	SetCalibratedForPath(host string, calibrated bool)
 	AddFilter(name string, option string, replace bool) error
 	AddPerDomainFilter(domain string, name string, option string) error
+	AddPerPathFilter(path string, name string, option string) error
 	RemoveFilter(name string)
 	AddMatcher(name string, option string) error
 	GetFilters() map[string]FilterProvider
 	GetMatchers() map[string]FilterProvider
 	FiltersForDomain(domain string) map[string]FilterProvider
+	FiltersForPath(path string) map[string]FilterProvider
 	CalibratedForDomain(domain string) bool
+	CalibratedForPath(path string) bool
 	Calibrated() bool
 }
 

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -468,7 +468,7 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 		}
 	}
 
-	if j.Config.Recursion && j.Config.RecursionStrategy == "default" && len(resp.GetRedirectLocation(false)) > 0 {
+	if j.Config.Recursion && j.Config.RecursionStrategy == "default" && intSliceContains(j.Config.RecursionStatus, int(resp.StatusCode)) {
 		j.handleDefaultRecursionJob(resp)
 	}
 }
@@ -499,7 +499,7 @@ func (j *Job) handleGreedyRecursionJob(resp Response) {
 // not been reached
 func (j *Job) handleDefaultRecursionJob(resp Response) {
 	recUrl := resp.Request.Url + "/" + "FUZZ"
-	if (resp.Request.Url + "/") != resp.GetRedirectLocation(true) {
+	if (resp.Request.Url+"/") != resp.GetRedirectLocation(true) && resp.StatusCode >= 300 && resp.StatusCode < 400 {
 		// Not a directory, return early
 		return
 	}
@@ -570,4 +570,13 @@ func (j *Job) Stop() {
 // Stop current, resume to next
 func (j *Job) Next() {
 	j.RunningJob = false
+}
+
+func intSliceContains(sslice []int, num int) bool {
+	for _, v := range sslice {
+		if v == num {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net/url"
 	"os"
 	"os/signal"
 	"sync"
@@ -334,7 +335,10 @@ func (j *Job) isMatch(resp Response) bool {
 	matched := false
 	var matchers map[string]FilterProvider
 	var filters map[string]FilterProvider
-	if j.Config.AutoCalibrationPerHost {
+	if j.Config.AutoCalibrationPerPath {
+		parsed, _ := url.Parse(resp.Request.Url)
+		filters = j.Config.MatcherManager.FiltersForPath(parsed.Path)
+	} else if j.Config.AutoCalibrationPerHost {
 		filters = j.Config.MatcherManager.FiltersForDomain(HostURLFromRequest(*resp.Request))
 	} else {
 		filters = j.Config.MatcherManager.GetFilters()
@@ -431,7 +435,8 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 	j.pauseWg.Wait()
 
 	// Handle autocalibration, must be done after the actual request to ensure sane value in req.Host
-	_ = j.CalibrateIfNeeded(HostURLFromRequest(req), input)
+	parsed, _ := url.Parse(req.Url)
+	_ = j.CalibrateIfNeeded(HostURLFromRequest(req), parsed.Path, input)
 
 	// Handle scraper actions
 	if j.Scraper != nil {
@@ -461,15 +466,16 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 		if j.Config.Recursion && j.Config.RecursionStrategy == "greedy" {
 			j.handleGreedyRecursionJob(resp)
 		}
-	} else {
-		if len(resp.ScraperData) > 0 {
-			// print the result anyway, as scraper found something
-			j.Output.Result(resp)
+		if j.Config.Recursion && j.Config.RecursionStrategy == "default" && intSliceContains(j.Config.RecursionStatus, int(resp.StatusCode)) {
+			j.handleDefaultRecursionJob(resp)
 		}
+
+		return
 	}
 
-	if j.Config.Recursion && j.Config.RecursionStrategy == "default" && intSliceContains(j.Config.RecursionStatus, int(resp.StatusCode)) {
-		j.handleDefaultRecursionJob(resp)
+	if len(resp.ScraperData) > 0 {
+		// print the result anyway, as scraper found something
+		j.Output.Result(resp)
 	}
 }
 

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -36,6 +36,7 @@ type HTTPOptions struct {
 	Recursion         bool     `json:"recursion"`
 	RecursionDepth    int      `json:"recursion_depth"`
 	RecursionStrategy string   `json:"recursion_strategy"`
+	RecursionStatus   []int    `json:"recursion_status"`
 	ReplayProxyURL    string   `json:"replay_proxy_url"`
 	SNI               string   `json:"sni"`
 	Timeout           int      `json:"timeout"`
@@ -148,6 +149,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.HTTP.Recursion = false
 	c.HTTP.RecursionDepth = 0
 	c.HTTP.RecursionStrategy = "default"
+	c.HTTP.RecursionStatus = []int{301, 302, 303, 307, 308}
 	c.HTTP.ReplayProxyURL = ""
 	c.HTTP.Timeout = 10
 	c.HTTP.SNI = ""
@@ -475,6 +477,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	conf.Recursion = parseOpts.HTTP.Recursion
 	conf.RecursionDepth = parseOpts.HTTP.RecursionDepth
 	conf.RecursionStrategy = parseOpts.HTTP.RecursionStrategy
+	conf.RecursionStatus = parseOpts.HTTP.RecursionStatus
 	conf.AutoCalibration = parseOpts.General.AutoCalibration
 	conf.AutoCalibrationPerHost = parseOpts.General.AutoCalibrationPerHost
 	conf.AutoCalibrationStrategy = parseOpts.General.AutoCalibrationStrategy
@@ -551,6 +554,13 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	if parseOpts.HTTP.Recursion {
 		if !strings.HasSuffix(conf.Url, "FUZZ") {
 			errmsg := "When using -recursion the URL (-u) must end with FUZZ keyword."
+			errs.Add(fmt.Errorf(errmsg))
+		}
+	}
+
+	for _, v := range parseOpts.HTTP.RecursionStatus {
+		if v < 100 || v >= 600 {
+			errmsg := "Invalid recursion_status, status code must be between 100 and 599."
 			errs.Add(fmt.Errorf(errmsg))
 		}
 	}

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -48,6 +48,7 @@ type GeneralOptions struct {
 	AutoCalibration         bool     `json:"autocalibration"`
 	AutoCalibrationKeyword  string   `json:"autocalibration_keyword"`
 	AutoCalibrationPerHost  bool     `json:"autocalibration_per_host"`
+	AutoCalibrationPerPath  bool     `json:"autocalibration_per_path"`
 	AutoCalibrationStrategy string   `json:"autocalibration_strategy"`
 	AutoCalibrationStrings  []string `json:"autocalibration_strings"`
 	Colors                  bool     `json:"colors"`
@@ -480,6 +481,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	conf.RecursionStatus = parseOpts.HTTP.RecursionStatus
 	conf.AutoCalibration = parseOpts.General.AutoCalibration
 	conf.AutoCalibrationPerHost = parseOpts.General.AutoCalibrationPerHost
+	conf.AutoCalibrationPerPath = parseOpts.General.AutoCalibrationPerPath
 	conf.AutoCalibrationStrategy = parseOpts.General.AutoCalibrationStrategy
 	conf.Threads = parseOpts.General.Threads
 	conf.Timeout = parseOpts.HTTP.Timeout
@@ -515,6 +517,11 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 
 	if conf.AutoCalibrationPerHost {
 		// AutoCalibrationPerHost implies AutoCalibration
+		conf.AutoCalibration = true
+	}
+
+	if conf.AutoCalibrationPerPath {
+		// AutoCalibrationPerPath implies AutoCalibration
 		conf.AutoCalibration = true
 	}
 


### PR DESCRIPTION
# Description

I added the option `-recursion-status` to control what response codes cause recursion to happen, the main use case is to recurse on 403.

Also i added the option `-acp` to auto calibrate per path, so if a 403 path is recursed and and all subsequest requests also receive 403 they are not also recursed.

Fixes: #691
