### PR TITLE
[FEATURE] Automatic ratelimit adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 - master
   - New
+    - New command line parameter for auto adjasting ratelimiting based on amount of 429 `-ar`
   - Changed
     - Explicitly allow TLS1.0 
     - Fix markdown output file format

--- a/help.go
+++ b/help.go
@@ -61,7 +61,7 @@ func Usage() {
 		Description:   "",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"ac", "acc", "ack", "ach", "acs", "c", "config", "json", "maxtime", "maxtime-job", "noninteractive", "p", "rate", "scraperfile", "scrapers", "search", "s", "sa", "se", "sf", "t", "v", "V"},
+		ExpectedFlags: []string{"ac", "acc", "ack", "ach", "acs", "ar", "c", "config", "json", "maxtime", "maxtime-job", "noninteractive", "p", "rate", "scraperfile", "scrapers", "search", "s", "sa", "se", "sf", "t", "v", "V"},
 	}
 	u_compat := UsageSection{
 		Name:          "COMPATIBILITY OPTIONS",

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.BoolVar(&ignored, "i", true, "Dummy flag for copy as curl functionality (ignored)")
 	flag.BoolVar(&ignored, "k", false, "Dummy flag for backwards compatibility")
 	flag.BoolVar(&opts.Output.OutputSkipEmptyFile, "or", opts.Output.OutputSkipEmptyFile, "Don't create the output file if we don't have results")
+	flag.BoolVar(&opts.General.AutoRatelimit, "ar", opts.General.AutoRatelimit, "Automatically adjast ratelimit based on amount of 429s received")
 	flag.BoolVar(&opts.General.AutoCalibration, "ac", opts.General.AutoCalibration, "Automatically calibrate filtering options")
 	flag.BoolVar(&opts.General.AutoCalibrationPerHost, "ach", opts.General.AutoCalibration, "Per host autocalibration")
 	flag.BoolVar(&opts.General.Colors, "c", opts.General.Colors, "Colorize output.")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	StopOn403               bool                  `json:"stop_403"`
 	StopOnAll               bool                  `json:"stop_all"`
 	StopOnErrors            bool                  `json:"stop_errors"`
+	AutoRatelimit           bool                  `json:"auto_ratelimit"`
 	Threads                 int                   `json:"threads"`
 	Timeout                 int                   `json:"timeout"`
 	Url                     string                `json:"url"`

--- a/pkg/ffuf/configmarshaller.go
+++ b/pkg/ffuf/configmarshaller.go
@@ -27,6 +27,7 @@ func (c *Config) ToOptions() ConfigOptions {
 	o.HTTP.URL = c.Url
 	o.HTTP.Http2 = c.Http2
 
+	o.General.AutoRatelimit = c.AutoRatelimit
 	o.General.AutoCalibration = c.AutoCalibration
 	o.General.AutoCalibrationKeyword = c.AutoCalibrationKeyword
 	o.General.AutoCalibrationPerHost = c.AutoCalibrationPerHost

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -65,6 +65,7 @@ type GeneralOptions struct {
 	StopOn403               bool     `json:"stop_on_403"`
 	StopOnAll               bool     `json:"stop_on_all"`
 	StopOnErrors            bool     `json:"stop_on_errors"`
+	AutoRatelimit           bool     `json:"auto_ratelimit"`
 	Threads                 int      `json:"threads"`
 	Verbose                 bool     `json:"verbose"`
 }
@@ -120,6 +121,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.Filter.Status = ""
 	c.Filter.Time = ""
 	c.Filter.Words = ""
+	c.General.AutoRatelimit = false
 	c.General.AutoCalibration = false
 	c.General.AutoCalibrationKeyword = "FUZZ"
 	c.General.AutoCalibrationStrategy = "basic"
@@ -475,6 +477,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	conf.Recursion = parseOpts.HTTP.Recursion
 	conf.RecursionDepth = parseOpts.HTTP.RecursionDepth
 	conf.RecursionStrategy = parseOpts.HTTP.RecursionStrategy
+	conf.AutoRatelimit = parseOpts.General.AutoRatelimit
 	conf.AutoCalibration = parseOpts.General.AutoCalibration
 	conf.AutoCalibrationPerHost = parseOpts.General.AutoCalibrationPerHost
 	conf.AutoCalibrationStrategy = parseOpts.General.AutoCalibrationStrategy


### PR DESCRIPTION
# Description

Adds the option `-ar` to enable automatic adjustments to rate limiting based on the amount of 429 received.

i used the following script to test it
```python
#!/usr/bin/env python
# encoding: utf-8
import time
from flask import Flask, redirect

app = Flask(__name__)
clients = {}

@app.route('/admin', methods=['GET'])
def admin():
	return redirect("/admin/", code=302)

@app.route('/admin/<path>', methods=['GET'])
def nested_admin(path):
	id = str(int(time.time()))
	if id in clients.keys():
		clients[id] += 1
	else:
		clients[id] = 1

	if clients[id] > 10:
		return "Too Fast", 429

	return "Not Found", 404

app.run(debug=True)
```

and the requests per second went from 120 to 9 when it started on the /admin/ path
<img width="641" alt="Screenshot 2023-06-16 103600" src="https://github.com/ffuf/ffuf/assets/11355060/623ddf55-38c4-42cc-bf2b-31c6ca816f0d">


