### PR TITLE
Disable HTTP/2 support when not enabled

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,7 @@
 
 * [adamtlangley](https://github.com/adamtlangley)
 * [adilsoybali](https://github.com/adilsoybali)
+* [alexvec](https://github.com/alexvec)
 * [AverageSecurityGuy](https://github.com/averagesecurityguy)
 * [bp0](https://github.com/bp0lr)
 * [bjhulst](https://github.com/bjhulst)

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -44,10 +44,7 @@ func NewSimpleRunner(conf *ffuf.Config, replay bool) ffuf.RunnerProvider {
 		}
 	}
 	simplerunner.config = conf
-	simplerunner.client = &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse },
-		Timeout:       time.Duration(time.Duration(conf.Timeout) * time.Second),
-		Transport: &http.Transport{
+	transport := &http.Transport{
 			ForceAttemptHTTP2:   conf.Http2,
 			Proxy:               proxyURL,
 			MaxIdleConns:        1000,
@@ -63,7 +60,15 @@ func NewSimpleRunner(conf *ffuf.Config, replay bool) ffuf.RunnerProvider {
 				Renegotiation:      tls.RenegotiateOnceAsClient,
 				ServerName:         conf.SNI,
 			},
-		}}
+		}
+	if !conf.Http2 {
+		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
+	}
+	simplerunner.client = &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse },
+		Timeout:       time.Duration(time.Duration(conf.Timeout) * time.Second),
+		Transport: transport
+	}
 
 	if conf.FollowRedirects {
 		simplerunner.client.CheckRedirect = nil


### PR DESCRIPTION
# Description

The parameter `-usehttp2` is disabled by default, however the ffuf client doesn't actually disable HTTP/2 requests when that parameter is set to `false`.

As it is [officially documented](https://pkg.go.dev/net/http#pkg-overview)

`Starting with Go 1.6, the http package has transparent support for the HTTP/2 protocol when using HTTPS. Programs that must disable HTTP/2 can do so by setting Transport.TLSNextProto (for clients) or Server.TLSNextProto (for servers) to a non-nil, empty map.`

However, this isn't being done in the runner client, https://github.com/ffuf/ffuf/blob/5fd821c17d5589c8f66211389d99e6f0885354d1/pkg/runner/simple.go#L51

Not forcing HTTP/2 is not the same as disabling HTTP/2.

I have modified the client code to disable HTTP/2 requests completely if the parameter `-usehttp2` , by setting an empty map under `TLSNextProto`:
`transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}`