### PR TITLE
Fix Issue696 -- Divide by 0 Error when setting rate to 0 manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Changed
     - Explicitly allow TLS1.0 
     - Fix markdown output file format
+    - Fixed divide by 0 error when setting rate limit to 0 manually.
   
 - v2.0.0
   - New

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@
 * [Daviey](https://github.com/Daviey)
 * [delic](https://github.com/delic)
 * [denandz](https://github.com/denandz)
+* [Ephex2](https://github.com/Ephex2)
 * [erbbysam](https://github.com/erbbysam)
 * [eur0pa](https://github.com/eur0pa)
 * [fabiobauer](https://github.com/fabiobauer)
@@ -46,4 +47,3 @@
 * [SolomonSklash](https://github.com/SolomonSklash)
 * [TomNomNom](https://github.com/tomnomnom)
 * [xfgusta](https://github.com/xfgusta)
-* [Ephex2](https://github.com/Ephex2)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,4 +46,4 @@
 * [SolomonSklash](https://github.com/SolomonSklash)
 * [TomNomNom](https://github.com/tomnomnom)
 * [xfgusta](https://github.com/xfgusta)
-
+* [Ephex2](https://github.com/Ephex2)

--- a/pkg/ffuf/rate.go
+++ b/pkg/ffuf/rate.go
@@ -65,7 +65,12 @@ func (r *RateThrottle) CurrentRate() int64 {
 }
 
 func (r *RateThrottle) ChangeRate(rate int) {
-	ratemicros := 1000000 / rate
+	ratemicros := 0 // set default to 0, avoids integer divide by 0 error
+
+	if rate != 0 {
+		ratemicros = 1000000 / rate
+	}
+
 	r.RateLimiter.Stop()
 	r.RateLimiter = time.NewTicker(time.Microsecond * time.Duration(ratemicros))
 	r.Config.Rate = int64(rate)


### PR DESCRIPTION
# Description

Added check to RateThrottle.ChangeRate() in rate.go to prevent a divide by 0 error when the rate is set to 0. Ref: issue 696: https://github.com/ffuf/ffuf/issues/696

Fixes: #696 

# Additionally

Name added to contributors.md as requested.
Change made to CHANGELOG.md may not be in the right place, please verify, I'm new here :)
