### PR TITLE
Edit outputDirectory

### DIFF
--- a/pkg/ffuf/request.go
+++ b/pkg/ffuf/request.go
@@ -16,6 +16,14 @@ type Request struct {
 	Raw      string
 }
 
+type RequestWithoutExcludedFields struct {
+	Method  string
+	Host    string
+	Url     string
+	Headers map[string]string
+	Data    []byte
+}
+
 func NewRequest(conf *Config) Request {
 	var req Request
 	req.Method = conf.Method

--- a/pkg/ffuf/response.go
+++ b/pkg/ffuf/response.go
@@ -23,6 +23,16 @@ type Response struct {
 	Time          time.Duration
 }
 
+type ResponseWithoutExcludedFields struct {
+	StatusCode    int64
+	Headers       map[string][]string
+	ContentLength int64
+	ContentWords  int64
+	ContentLines  int64
+	ContentType   string
+	Time          time.Duration
+}
+
 // GetRedirectLocation returns the redirect location for a 3xx redirect HTTP response
 func (resp *Response) GetRedirectLocation(absolute bool) string {
 


### PR DESCRIPTION
# Description

The current outputDirectory function creates unreadable content that makes it difficult for anyone to handle the saved content. This is because there is no indication of where the content data starts. To address this, I've implemented a new saving method. In this approach, I am saving the request headers and response headers in JSON format on the first line of the file. Following that, the response content. This should help make the output more organized and easier to handle.

Fixes: #(issue number)

## Additonally
....
