### PR TITLE
Fixed Error for HTML Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
   - Changed
     - Explicitly allow TLS1.0 
     - Fix markdown output file format
-    - Fix html output in template html.output
   
 - v2.0.0
   - New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Changed
     - Explicitly allow TLS1.0 
     - Fix markdown output file format
+    - Fix html output in template html.output
   
 - v2.0.0
   - New

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,6 +18,7 @@
 * [eur0pa](https://github.com/eur0pa)
 * [fabiobauer](https://github.com/fabiobauer)
 * [fang0654](https://github.com/fang0654)
+* [haseobang](https://github.com/haseobang)
 * [Hazegard](https://github.com/Hazegard)
 * [helpermika](https://github.com/helpermika)
 * [h1x](https://github.com/h1x-lnx)

--- a/pkg/output/file_html.go
+++ b/pkg/output/file_html.go
@@ -108,7 +108,7 @@ const (
                 <div style="display:none">
 |result_raw|{{ $result.StatusCode }}{{ range $keyword, $value := $result.Input }}|{{ $value | printf "%s" }}{{ end }}|{{ $result.Url }}|{{ $result.RedirectLocation }}|{{ $result.Position }}|{{ $result.ContentLength }}|{{ $result.ContentWords }}|{{ $result.ContentLines }}|{{ $result.ContentType }}|{{ $result.Duration }}|{{ $result.ResultFile }}|{{ $result.ScraperData }}|{{ $result.FfufHash }}|
                 </div>
-                <tr class="result-{{ $result.StatusCode }}" style="background-color: {{$result.HTMLColor}};">
+                <tr class="result-{{ $result.StatusCode }}" style="background-color: {{ $result.HTMLColor }};">
                     <td><font color="black" class="status-code">{{ $result.StatusCode }}</font></td>
                     {{ range $keyword, $value := $result.Input }}
                         <td>{{ $value | printf "%s" }}</td>


### PR DESCRIPTION
Fixed Error for HTML Output regarding template output.html

I kept getting the following error with -of html
[ERR] template: output.html:74:94: executing "output.html" at <$result.HTMLColor>: can't evaluate field HTMLColor in type output.htmlResult

This fix worked for me.

Closes #684 