### PR TITLE
Add alias for interactive commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 - master
   - New
+  - Add `q`, `qd`, `qs` alias for `queueshow`, `queuedel` and `queueskip`
   - Changed
   
 - v2.1.0

--- a/pkg/interactive/termhandler.go
+++ b/pkg/interactive/termhandler.go
@@ -45,9 +45,7 @@ func (i *interactive) handleInput(in []byte) {
 		}
 	} else {
 		switch args[0] {
-		case "?":
-			i.printHelp()
-		case "help":
+		case "?", "help":
 			i.printHelp()
 		case "resume":
 			i.paused = false
@@ -164,9 +162,9 @@ func (i *interactive) handleInput(in []byte) {
 				i.appendFilter("time", args[1])
 				i.Job.Output.Info("New response time filter value set")
 			}
-		case "queueshow":
+		case "q", "queueshow":
 			i.printQueue()
-		case "queuedel":
+		case "qd", "queuedel":
 			if len(args) < 2 {
 				i.Job.Output.Error("Please define the index of a queued job to remove. Use \"queueshow\" for listing of jobs.")
 			} else if len(args) > 2 {
@@ -174,7 +172,7 @@ func (i *interactive) handleInput(in []byte) {
 			} else {
 				i.deleteQueue(args[1])
 			}
-		case "queueskip":
+		case "qs", "queueskip":
 			i.Job.SkipQueue()
 			i.Job.Output.Info("Skipping to the next queued job")
 		case "rate":


### PR DESCRIPTION
# Description

Many interative tools have aliases, queueshow, queuedel, and queueskip are often used. Having those aliases are a lot faster :)

## Additonally

- [ ] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`.  #727 
The file should be alphabetically ordered.
- [x] Add a short description of the fix to `CHANGELOG.md`
