### PR TITLE
Avoid quit in interractive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - master
   - New
   - Changed
+    - Add `quit` command to interactive mode
   
 - v2.1.0
   - New

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -294,11 +294,11 @@ func (j *Job) interruptMonitor() {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		for range sigChan {
-			j.Error = "Caught keyboard interrupt (Ctrl-C)\n"
-			// resume if paused
+			// ignore if paused
 			if j.Paused {
-				j.pauseWg.Done()
+				return
 			}
+			j.Error = "Caught keyboard interrupt (Ctrl-C)\n"
 			// Stop the job
 			j.Stop()
 		}

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -226,6 +226,13 @@ func (j *Job) Resume() {
 	}
 }
 
+func (j *Job) Quit() {
+	if j.Paused {
+		j.pauseWg.Done()
+		j.Stop()
+	}
+}
+
 func (j *Job) startExecution() {
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/pkg/interactive/termhandler.go
+++ b/pkg/interactive/termhandler.go
@@ -61,6 +61,8 @@ func (i *interactive) handleInput(in []byte) {
 			for _, r := range i.Job.Output.GetCurrentResults() {
 				i.Job.Output.PrintResult(r)
 			}
+		case "quit":
+			i.Job.Quit()
 		case "savejson":
 			if len(args) < 2 {
 				i.Job.Output.Error("Please define the filename")
@@ -313,6 +315,7 @@ available commands:
  resume                   - resume current ffuf job (or: ENTER) 
  show                     - show results for the current job
  savejson [filename]      - save current matches to a file
+ quit                     - quit ffuf
  help                     - you are looking at it
 `
 	i.Job.Output.Raw(fmt.Sprintf(help, fc, fc, fl, fl, fw, fw, fs, fs, ft, ft, rate))


### PR DESCRIPTION
# Description

When I use interactive mode, I often ends by closing ffuf by mistake. This PR avoid this issue : if you want to close ffuf while in interactive mode, you have to write "quit" (like many other interactive tools)


## Additonally

- [ ] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`.  #727 
The file should be alphabetically ordered.
- [x] Add a short description of the fix to `CHANGELOG.md`

Thanks for contributing to ffuf :)
