### PR TITLE
Chouettevan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Changed
     - Fix a bug in autocalibration strategy merging, when two files have the same strategy key
     - Fix panic when setting rate to 0 in the interactive console
+    - Fix greedy recursion strategy,do not fuzz recursively on filename matches such as /index.php
   
 - v2.1.0
   - New

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,3 +50,4 @@
 * [SolomonSklash](https://github.com/SolomonSklash)
 * [TomNomNom](https://github.com/tomnomnom)
 * [xfgusta](https://github.com/xfgusta)
+* [chouettevan](https://github.com/chouettevan)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
 * [bsysop](https://twitter.com/bsysop)
 * [ccsplit](https://github.com/ccsplit)
 * [choket](https://github.com/choket)
+* [chouettevan](https://github.com/chouettevan)
 * [codingo](https://github.com/codingo)
 * [c_sto](https://github.com/c-sto)
 * [Damian89](https://github.com/Damian89)
@@ -50,4 +51,3 @@
 * [SolomonSklash](https://github.com/SolomonSklash)
 * [TomNomNom](https://github.com/tomnomnom)
 * [xfgusta](https://github.com/xfgusta)
-* [chouettevan](https://github.com/chouettevan)

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -509,7 +509,7 @@ func (j *Job) handleScraperResult(resp *Response, sres ScraperResult) {
 // handleGreedyRecursionJob adds a recursion job to the queue if the maximum depth has not been reached
 func (j *Job) handleGreedyRecursionJob(resp Response) {
 	// Handle greedy recursion strategy. Match has been determined before calling handleRecursionJob
-	if j.Config.RecursionDepth == 0 || j.currentDepth < j.Config.RecursionDepth {
+	if j.Config.RecursionDepth == 0 || j.currentDepth < j.Config.RecursionDepth && fileExtensions.MatchString(resp.Request.Url) {
 		recUrl := resp.Request.Url + "/" + "FUZZ"
 		newJob := QueueJob{Url: recUrl, depth: j.currentDepth + 1, req: RecursionRequest(j.Config, recUrl)}
 		j.queuejobs = append(j.queuejobs, newJob)
@@ -522,7 +522,7 @@ func (j *Job) handleGreedyRecursionJob(resp Response) {
 // handleDefaultRecursionJob adds a new recursion job to the job queue if a new directory is found and maximum depth has
 // not been reached
 func (j *Job) handleDefaultRecursionJob(resp Response) {
-	if (resp.Request.Url + "/") != resp.GetRedirectLocation(true) || fileExtensions.MatchString(resp.Request.Url) {
+	if (resp.Request.Url + "/") != resp.GetRedirectLocation(true) {
 		// Not a directory, return early
 		return
 	}

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -48,6 +48,7 @@ type QueueJob struct {
 	depth int
 	req   Request
 }
+// This is the regexp used to match endpoins with file extensions,such as /robots.txt
 var fileExtensions = regexp.MustCompile(`\.[a-zA-Z0-9]+$`)
 
 func NewJob(conf *Config) *Job {
@@ -509,7 +510,7 @@ func (j *Job) handleScraperResult(resp *Response, sres ScraperResult) {
 // handleGreedyRecursionJob adds a recursion job to the queue if the maximum depth has not been reached
 func (j *Job) handleGreedyRecursionJob(resp Response) {
 	// Handle greedy recursion strategy. Match has been determined before calling handleRecursionJob
-	if j.Config.RecursionDepth == 0 || j.currentDepth < j.Config.RecursionDepth && fileExtensions.MatchString(resp.Request.Url) {
+	if j.Config.RecursionDepth == 0 || j.currentDepth < j.Config.RecursionDepth && !fileExtensions.MatchString(resp.Request.Url) {
 		recUrl := resp.Request.Url + "/" + "FUZZ"
 		newJob := QueueJob{Url: recUrl, depth: j.currentDepth + 1, req: RecursionRequest(j.Config, recUrl)}
 		j.queuejobs = append(j.queuejobs, newJob)


### PR DESCRIPTION
# Description

adds regexp-based pattern matching to ensure -recursion-strategy greedy doesn't searches recursively on endpoints with file extensions,such as robots.txt

Fixes: #769

