### PR TITLE
Add Winget and Scoop installation instructions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,6 +46,7 @@
 * [seblw](https://github.com/seblw)
 * [Serizao](https://github.com/Serizao)
 * [Shaked](https://github.com/Shaked)
+* [sitiom](https://github.com/sitiom)
 * [Skyehopper](https://github.com/Skyehopper)
 * [SolomonSklash](https://github.com/SolomonSklash)
 * [TomNomNom](https://github.com/tomnomnom)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ A fast web fuzzer written in Go.
 - [Download](https://github.com/ffuf/ffuf/releases/latest) a prebuilt binary from [releases page](https://github.com/ffuf/ffuf/releases/latest), unpack and run!
 
   _or_
+- If you are on Windows with [Scoop](https://scoop.sh/), ffuf can be installed with: `scoop install ffuf`
+
+  _or_
+- If you are on Windows with [Winget](https://learn.microsoft.com/en-us/windows/package-manager/), ffuf can be installed with: `winget install ffuf.ffuf`
+
+  _or_
 - If you are on macOS with [homebrew](https://brew.sh), ffuf can be installed with: `brew install ffuf`
   
   _or_


### PR DESCRIPTION
# Description

- Related to https://github.com/ffuf/ffuf/issues/374

ffuf can now be installed with [Winget](https://learn.microsoft.com/en-us/windows/package-manager/) and [Scoop](https://scoop.sh/) 🎉
- https://github.com/ScoopInstaller/Main/pull/5872
- https://github.com/microsoft/winget-pkgs/pull/160179

## Additonally

- [x] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`. 
The file should be alphabetically ordered.
- [ ] Add a short description of the fix to `CHANGELOG.md`

Thanks for contributing to ffuf :)
