### PR TITLE
Add support for random user agents with each request

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@
 * [ccsplit](https://github.com/ccsplit)
 * [choket](https://github.com/choket)
 * [codingo](https://github.com/codingo)
+* [Crelic](https://github.com/Crelic1/)
 * [c_sto](https://github.com/c-sto)
 * [Damian89](https://github.com/Damian89)
 * [Daviey](https://github.com/Daviey)

--- a/help.go
+++ b/help.go
@@ -61,7 +61,7 @@ func Usage() {
 		Description:   "",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"ac", "acc", "ack", "ach", "acs", "c", "config", "json", "maxtime", "maxtime-job", "noninteractive", "p", "rate", "scraperfile", "scrapers", "search", "s", "sa", "se", "sf", "t", "v", "V"},
+		ExpectedFlags: []string{"ac", "acc", "ack", "ach", "acs", "c", "config", "json", "maxtime", "maxtime-job", "noninteractive", "p", "random-agent", "rate", "scraperfile", "scrapers", "search", "s", "sa", "se", "sf", "t", "v", "V"},
 	}
 	u_compat := UsageSection{
 		Name:          "COMPATIBILITY OPTIONS",

--- a/main.go
+++ b/main.go
@@ -94,6 +94,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.HTTP.ClientCert, "cc", "", "Client cert for authentication. Client key needs to be defined as well for this to work")
 	flag.StringVar(&opts.HTTP.ClientKey, "ck", "", "Client key for authentication. Client certificate needs to be defined as well for this to work")
 	flag.StringVar(&opts.General.ConfigFile, "config", "", "Load configuration from a file")
+	flag.StringVar(&opts.General.RandomAgent, "random-agent", opts.General.RandomAgent, "Send a random User-Agent header with each request, specify a file with user agents")
 	flag.StringVar(&opts.General.ScraperFile, "scraperfile", "", "Custom scraper file path")
 	flag.StringVar(&opts.General.Scrapers, "scrapers", opts.General.Scrapers, "Active scraper groups")
 	flag.StringVar(&opts.Filter.Mode, "fmode", opts.Filter.Mode, "Filter set operator. Either of: and, or")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	ProgressFrequency         int                   `json:"-"`
 	ProxyURL                  string                `json:"proxyurl"`
 	Quiet                     bool                  `json:"quiet"`
+	RandomAgent               string                `json:"random-agent"`
 	Rate                      int64                 `json:"rate"`
 	Raw                       bool                  `json:"raw"`
 	Recursion                 bool                  `json:"recursion"`

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -60,6 +60,7 @@ type GeneralOptions struct {
 	MaxTimeJob                int      `json:"maxtime_job"`
 	Noninteractive            bool     `json:"noninteractive"`
 	Quiet                     bool     `json:"quiet"`
+	RandomAgent               string   `json:"random-agent"`
 	Rate                      int      `json:"rate"`
 	ScraperFile               string   `json:"scraperfile"`
 	Scrapers                  string   `json:"scrapers"`
@@ -134,6 +135,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.General.MaxTimeJob = 0
 	c.General.Noninteractive = false
 	c.General.Quiet = false
+	c.General.RandomAgent = ""
 	c.General.Rate = 0
 	c.General.Searchhash = ""
 	c.General.ScraperFile = ""
@@ -476,6 +478,15 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	// Using -acs implies -ac
 	if len(parseOpts.General.AutoCalibrationStrategies) > 0 {
 		conf.AutoCalibration = true
+	}
+
+	// Checking the random-agent config
+	if parseOpts.General.RandomAgent != "" {
+		if !FileExists(parseOpts.General.RandomAgent) {
+			errs.Add(fmt.Errorf("the user-agent wordlist %s does not exist", parseOpts.General.RandomAgent))
+		} else {
+			conf.RandomAgent = parseOpts.General.RandomAgent
+		}
 	}
 
 	if parseOpts.General.Rate < 0 {

--- a/pkg/ffuf/util.go
+++ b/pkg/ffuf/util.go
@@ -144,3 +144,32 @@ func mergeMaps(m1 map[string][]string, m2 map[string][]string) map[string][]stri
 	}
 	return merged
 }
+
+// getRandomLine returns a random line from a given file.
+func GetRandomLine(filePath string) (string, error) {
+
+	// Read the entire file into memory
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	// Split the content into lines
+	lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
+
+	// Remove empty lines
+	nonEmptyLines := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			nonEmptyLines = append(nonEmptyLines, trimmed)
+		}
+	}
+
+	if len(nonEmptyLines) == 0 {
+		return "", fmt.Errorf("no lines found in file")
+	}
+
+	// Pick a random line
+	return nonEmptyLines[rand.Intn(len(nonEmptyLines))], nil
+}

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -125,6 +125,15 @@ func (r *SimpleRunner) Execute(req *ffuf.Request) (ffuf.Response, error) {
 		return ffuf.Response{}, err
 	}
 
+	// If random agent is set pick a random agent here.
+	if r.config.RandomAgent != "" {
+		if _, ok := req.Headers["User-Agent"]; !ok {
+			if ua, err := ffuf.GetRandomLine(r.config.RandomAgent); err == nil {
+				req.Headers["User-Agent"] = ua
+			}
+		}
+	}
+
 	// set default User-Agent header if not present
 	if _, ok := req.Headers["User-Agent"]; !ok {
 		req.Headers["User-Agent"] = fmt.Sprintf("%s v%s", "Fuzz Faster U Fool", ffuf.Version())


### PR DESCRIPTION
# Description

Users may add a `-random-agent` flag followed by a wordlist containing user agents, FFUF will then pick a user agent at random for each request.
Will be over-ridden by `-H "User-Agent: fizzbuzz"`
Will revert the default FFUF User-Agent if the wordlist provided is empty.

## Additonally

- [ ] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`.  ✅
The file should be alphabetically ordered. ✅
- [ ] Add a short description of the fix to `CHANGELOG.md` ❌ - Sorry unsure how I should structure this

Thanks for contributing to ffuf :) 
