### PR TITLE
Suppressed warning on unused keywords

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,6 +35,7 @@
 * [Kiblyn11](https://github.com/Kiblyn11)
 * [l4yton](https://github.com/l4yton)
 * [lc](https://github.com/lc)
+* [Mojo8898](https://github.com/Mojo8898)
 * [mprencipe](https://github.com/mprencipe)
 * [nnwakelam](https://twitter.com/nnwakelam)
 * [noraj](https://pwn.by/noraj)

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -592,8 +592,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 			}
 		} else {
 			if !keywordPresent(provider.Keyword, &conf) {
-				errmsg := fmt.Sprintf("Keyword %s defined, but not found in headers, method, URL or POST data.", provider.Keyword)
-				_, _ = fmt.Fprintf(os.Stderr, "%s\n", fmt.Errorf(errmsg))
+				// Warning suppressed
 			} else {
 				newInputProviders = append(newInputProviders, provider)
 			}


### PR DESCRIPTION
# Description

Suppressed the pointless warning shown on unused keywords such as in the following example output snippet:

```
<SNIP>
Keyword DIRSMALL defined, but not found in headers, method, URL or POST data.
Keyword DIRMEDIUM defined, but not found in headers, method, URL or POST data.
Keyword DIRBIG defined, but not found in headers, method, URL or POST data.
Keyword FILESMALL defined, but not found in headers, method, URL or POST data.
Keyword FILEMEDIUM defined, but not found in headers, method, URL or POST data.
Keyword FILEBIG defined, but not found in headers, method, URL or POST data.
Keyword WORDSMALL defined, but not found in headers, method, URL or POST data.
Keyword WORDMEDIUM defined, but not found in headers, method, URL or POST data.
Keyword WORDBIG defined, but not found in headers, method, URL or POST data.
Keyword PARAM defined, but not found in headers, method, URL or POST data.
<SNIP>
```

Fixes: #751 