### PR TITLE
Add new capabilities to scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - master
   - New
     - Added audit logging functionality
+    - Extend scraper funcionality.
   - Changed
     - Fix a bug in autocalibration strategy merging, when two files have the same strategy key
     - Fix a bug in -or, causing output to not to be written in any case

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@
 * [bp0](https://github.com/bp0lr)
 * [bjhulst](https://github.com/bjhulst)
 * [bsysop](https://twitter.com/bsysop)
+* [ccc-aaa](https://github.com/ccc-aaa)
 * [ccsplit](https://github.com/ccsplit)
 * [choket](https://github.com/choket)
 * [codingo](https://github.com/codingo)

--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -19,6 +19,7 @@ type ScraperRule struct {
 	Target       string `json:"target"`
 	compiledRule *regexp.Regexp
 	Type         string   `json:"type"`
+	QueryAttr		 string		`json:"query_attr"`
 	OnlyMatched  bool     `json:"onlymatched"`
 	Action       []string `json:"action"`
 }
@@ -149,9 +150,18 @@ func (r *ScraperRule) checkQuery(data string) []string {
 	if err != nil {
 		return []string{}
 	}
-	doc.Find(r.Rule).Each(func(i int, sel *goquery.Selection) {
-		val = append(val, sel.Text())
-	})
+	if r.QueryAttr == "" {
+		doc.Find(r.Rule).Each(func(i int, sel *goquery.Selection) {
+			val = append(val, sel.Text())
+		})
+	} else {
+		doc.Find(r.Rule).Each(func(i int, sel *goquery.Selection) {
+			text, exists := sel.Attr(r.QueryAttr)
+			if exists {
+				val = append(val, text)
+			}
+		})
+	}
 	return val
 }
 


### PR DESCRIPTION
# Description

Adds `query_attr` into scraper rule allow query rules extracting data from attribute specified instead of the body of the matching element.

## Additonally

- [x] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`. 
The file should be alphabetically ordered.
- [x] Add a short description of the fix to `CHANGELOG.md`
