### PR TITLE
Add option to not store results in memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - master
   - New
     - Added audit logging functionality
+    - New output option: Don't store results in memory
   - Changed
     - Fix a bug in autocalibration strategy merging, when two files have the same strategy key
     - Fix a bug in -or, causing output to not to be written in any case

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,3 +50,4 @@
 * [SolomonSklash](https://github.com/SolomonSklash)
 * [TomNomNom](https://github.com/tomnomnom)
 * [xfgusta](https://github.com/xfgusta)
+* [veids](https://github.com/veids)

--- a/help.go
+++ b/help.go
@@ -96,7 +96,7 @@ func Usage() {
 		Description:   "Options for output. Output file formats, file names and debug file locations.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"audit-log", "debug-log", "o", "of", "od", "or"},
+		ExpectedFlags: []string{"audit-log", "debug-log", "o", "of", "od", "or", "dontstoreresults"},
 	}
 	sections := []UsageSection{u_http, u_general, u_compat, u_matcher, u_filter, u_input, u_output}
 

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.BoolVar(&ignored, "i", true, "Dummy flag for copy as curl functionality (ignored)")
 	flag.BoolVar(&ignored, "k", false, "Dummy flag for backwards compatibility")
 	flag.BoolVar(&opts.Output.OutputSkipEmptyFile, "or", opts.Output.OutputSkipEmptyFile, "Don't create the output file if we don't have results")
+	flag.BoolVar(&opts.Output.DontStoreResults, "dontstoreresults", opts.Output.DontStoreResults, "Don't store results")
 	flag.BoolVar(&opts.General.AutoCalibration, "ac", opts.General.AutoCalibration, "Automatically calibrate filtering options")
 	flag.BoolVar(&opts.General.AutoCalibrationPerHost, "ach", opts.General.AutoCalibration, "Per host autocalibration")
 	flag.BoolVar(&opts.General.Colors, "c", opts.General.Colors, "Colorize output.")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	OutputFile                string                `json:"outputfile"`
 	OutputFormat              string                `json:"outputformat"`
 	OutputSkipEmptyFile       bool                  `json:"OutputSkipEmptyFile"`
+	DontStoreResults          bool                  `json:"DontStoreResults"`
 	ProgressFrequency         int                   `json:"-"`
 	ProxyURL                  string                `json:"proxyurl"`
 	Quiet                     bool                  `json:"quiet"`

--- a/pkg/ffuf/configmarshaller.go
+++ b/pkg/ffuf/configmarshaller.go
@@ -80,6 +80,7 @@ func (c *Config) ToOptions() ConfigOptions {
 	o.Output.OutputFile = c.OutputFile
 	o.Output.OutputFormat = c.OutputFormat
 	o.Output.OutputSkipEmptyFile = c.OutputSkipEmptyFile
+	o.Output.DontStoreResults = c.DontStoreResults
 
 	o.Filter.Mode = c.FilterMode
 	o.Filter.Lines = ""

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -93,6 +93,7 @@ type OutputOptions struct {
 	OutputFile          string `json:"output_file"`
 	OutputFormat        string `json:"output_format"`
 	OutputSkipEmptyFile bool   `json:"output_skip_empty"`
+	DontStoreResults    bool   `json:"dont_store_results"`
 }
 
 type FilterOptions struct {
@@ -180,6 +181,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.Output.OutputFile = ""
 	c.Output.OutputFormat = "json"
 	c.Output.OutputSkipEmptyFile = false
+	c.Output.DontStoreResults = false
 	return c
 }
 
@@ -518,6 +520,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	conf.OutputFile = parseOpts.Output.OutputFile
 	conf.OutputDirectory = parseOpts.Output.OutputDirectory
 	conf.OutputSkipEmptyFile = parseOpts.Output.OutputSkipEmptyFile
+	conf.DontStoreResults = parseOpts.Output.DontStoreResults
 	conf.IgnoreBody = parseOpts.HTTP.IgnoreBody
 	conf.Quiet = parseOpts.General.Quiet
 	conf.ScraperFile = parseOpts.General.ScraperFile

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -338,7 +338,10 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 		ResultFile:       resp.ResultFile,
 		Host:             resp.Request.Host,
 	}
-	s.CurrentResults = append(s.CurrentResults, sResult)
+
+	if !s.config.DontStoreResults {
+		s.CurrentResults = append(s.CurrentResults, sResult)
+	}
 	// Output the result
 	s.PrintResult(sResult)
 }


### PR DESCRIPTION
# Description

Currently, every single result of ffuf is stored in memory in the `Stdout.Results` object. This can have a bad effect when working with large dictionaries and their combination (hosts + large wordlist).

So we can use the `-dontstoreresults` option to disable that behavior and use `stdout` parameters to get what we need directly from the pipe.

## Side effects

* We can't use the `show` command from the interactive session as it does nothing with the option enabled.
* Also, the output to file option becomes useless too.