### PR TITLE
Add proxy list file (-xf) option

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@
 * [bjhulst](https://github.com/bjhulst)
 * [bsysop](https://twitter.com/bsysop)
 * [ccsplit](https://github.com/ccsplit)
+* [chadhyatt](https://github.com/chadhyatt)
 * [choket](https://github.com/choket)
 * [codingo](https://github.com/codingo)
 * [c_sto](https://github.com/c-sto)

--- a/help.go
+++ b/help.go
@@ -54,7 +54,7 @@ func Usage() {
 		Description:   "Options controlling the HTTP request and its parts.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"cc", "ck", "H", "X", "b", "d", "r", "u", "raw", "recursion", "recursion-depth", "recursion-strategy", "replay-proxy", "timeout", "ignore-body", "x", "sni", "http2"},
+		ExpectedFlags: []string{"cc", "ck", "H", "X", "b", "d", "r", "u", "raw", "recursion", "recursion-depth", "recursion-strategy", "replay-proxy", "timeout", "ignore-body", "x", "xf", "sni", "http2"},
 	}
 	u_general := UsageSection{
 		Name:          "GENERAL OPTIONS",

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.HTTP.Data, "data-binary", opts.HTTP.Data, "POST data (alias of -d)")
 	flag.StringVar(&opts.HTTP.Method, "X", opts.HTTP.Method, "HTTP method to use")
 	flag.StringVar(&opts.HTTP.ProxyURL, "x", opts.HTTP.ProxyURL, "Proxy URL (SOCKS5 or HTTP). For example: http://127.0.0.1:8080 or socks5://127.0.0.1:8080")
-	flag.StringVar(&opts.HTTP.ProxyListFile, "xf", opts.HTTP.ProxyURL, "Path to a list of (SOCKS5/HTTP) proxies to be pooled from.")
+	flag.StringVar(&opts.HTTP.ProxyListFile, "xf", opts.HTTP.ProxyListFile, "Path to a list of (SOCKS5/HTTP) proxies to be pooled from.")
 	flag.StringVar(&opts.HTTP.ReplayProxyURL, "replay-proxy", opts.HTTP.ReplayProxyURL, "Replay matched requests using this proxy.")
 	flag.StringVar(&opts.HTTP.RecursionStrategy, "recursion-strategy", opts.HTTP.RecursionStrategy, "Recursion strategy: \"default\" for a redirect based, and \"greedy\" to recurse on all matches")
 	flag.StringVar(&opts.HTTP.URL, "u", opts.HTTP.URL, "Target URL")

--- a/main.go
+++ b/main.go
@@ -111,6 +111,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.HTTP.Data, "data-binary", opts.HTTP.Data, "POST data (alias of -d)")
 	flag.StringVar(&opts.HTTP.Method, "X", opts.HTTP.Method, "HTTP method to use")
 	flag.StringVar(&opts.HTTP.ProxyURL, "x", opts.HTTP.ProxyURL, "Proxy URL (SOCKS5 or HTTP). For example: http://127.0.0.1:8080 or socks5://127.0.0.1:8080")
+	flag.StringVar(&opts.HTTP.ProxyListFile, "xf", opts.HTTP.ProxyURL, "Path to a list of (SOCKS5/HTTP) proxies to be pooled from.")
 	flag.StringVar(&opts.HTTP.ReplayProxyURL, "replay-proxy", opts.HTTP.ReplayProxyURL, "Replay matched requests using this proxy.")
 	flag.StringVar(&opts.HTTP.RecursionStrategy, "recursion-strategy", opts.HTTP.RecursionStrategy, "Recursion strategy: \"default\" for a redirect based, and \"greedy\" to recurse on all matches")
 	flag.StringVar(&opts.HTTP.URL, "u", opts.HTTP.URL, "Target URL")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -45,6 +45,8 @@ type Config struct {
 	OutputSkipEmptyFile       bool                  `json:"OutputSkipEmptyFile"`
 	ProgressFrequency         int                   `json:"-"`
 	ProxyURL                  string                `json:"proxyurl"`
+	ProxyListFile             string                `json:"proxylistfile"`
+	ProxyPool                 *ProxyPool            `json:"-"` // Underlying pool for ^^^
 	Quiet                     bool                  `json:"quiet"`
 	Rate                      int64                 `json:"rate"`
 	Raw                       bool                  `json:"raw"`

--- a/pkg/ffuf/configmarshaller.go
+++ b/pkg/ffuf/configmarshaller.go
@@ -18,6 +18,7 @@ func (c *Config) ToOptions() ConfigOptions {
 	o.HTTP.IgnoreBody = c.IgnoreBody
 	o.HTTP.Method = c.Method
 	o.HTTP.ProxyURL = c.ProxyURL
+	o.HTTP.ProxyListFile = c.ProxyListFile
 	o.HTTP.Raw = c.Raw
 	o.HTTP.Recursion = c.Recursion
 	o.HTTP.RecursionDepth = c.RecursionDepth

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -442,7 +442,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 			errs.Add(fmt.Errorf("Both proxy url (-x) and proxy list path (-xf) provided, only one can be used"))
 		} else {
 			pool, err := NewProxyPool(parseOpts.HTTP.ProxyListFile)
-			if err == nil {
+			if err != nil {
 				errs.Add(err)
 			} else {
 				conf.ProxyListFile = parseOpts.HTTP.ProxyListFile

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -33,6 +33,7 @@ type HTTPOptions struct {
 	IgnoreBody        bool     `json:"ignore_body"`
 	Method            string   `json:"method"`
 	ProxyURL          string   `json:"proxy_url"`
+	ProxyListFile     string   `json:"proxy_list_file"`
 	Raw               bool     `json:"raw"`
 	Recursion         bool     `json:"recursion"`
 	RecursionDepth    int      `json:"recursion_depth"`
@@ -429,11 +430,24 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 
 	// Verify proxy url format
 	if len(parseOpts.HTTP.ProxyURL) > 0 {
-		u, err := url.Parse(parseOpts.HTTP.ProxyURL)
-		if err != nil || u.Opaque != "" || (u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "socks5") {
+		if _, isValid := parseProxyUrl(parseOpts.HTTP.ProxyURL); !isValid {
 			errs.Add(fmt.Errorf("Bad proxy url (-x) format. Expected http, https or socks5 url"))
 		} else {
 			conf.ProxyURL = parseOpts.HTTP.ProxyURL
+		}
+	}
+
+	if parseOpts.HTTP.ProxyListFile != "" {
+		if parseOpts.HTTP.ProxyURL != "" {
+			errs.Add(fmt.Errorf("Both proxy url (-x) and proxy list path (-xf) provided, only one can be used"))
+		} else {
+			pool, err := NewProxyPool(parseOpts.HTTP.ProxyListFile)
+			if err == nil {
+				errs.Add(err)
+			} else {
+				conf.ProxyListFile = parseOpts.HTTP.ProxyListFile
+				conf.ProxyPool = pool
+			}
 		}
 	}
 

--- a/pkg/ffuf/proxypool.go
+++ b/pkg/ffuf/proxypool.go
@@ -1,0 +1,84 @@
+package ffuf
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+)
+
+type ProxyFunc func(*http.Request) (*url.URL, error)
+
+type ProxyPool struct {
+	Proxies []ProxyFunc
+
+	index       int
+	accessMutex sync.Mutex
+}
+
+func NewProxyPool(filePath string) (*ProxyPool, error) {
+	pool := ProxyPool{}
+
+	{
+		f, err := os.Open(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("Error opening proxy file: %w", err)
+		}
+
+		proxies := []ProxyFunc{}
+
+		scanner := bufio.NewScanner(f)
+		scanner.Split(bufio.ScanLines)
+
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			} else if _, err := url.Parse(line); err != nil {
+				continue
+			}
+
+			if strings.HasPrefix(line, "#") {
+				continue
+			}
+
+			u, isValid := parseProxyUrl(line)
+			if !isValid {
+				return nil, fmt.Errorf("Bad proxy url (-x) format. Expected http, https or socks5 url")
+			}
+
+			proxies = append(proxies, http.ProxyURL(u))
+		}
+
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("Error reading proxy file: %w", err)
+		}
+
+		pool.Proxies = proxies
+	}
+
+	return &pool, nil
+}
+
+// Request a proxy from the pool
+func (pool *ProxyPool) Get() (ProxyFunc, error) {
+	pool.accessMutex.Lock()
+	defer pool.accessMutex.Unlock()
+
+	poolLen := len(pool.Proxies)
+	if poolLen == 0 {
+		return nil, fmt.Errorf("No proxies available in the pool")
+	}
+
+	proxy := pool.Proxies[pool.index]
+	if pool.index == poolLen-1 {
+		pool.index = 0
+	} else {
+		pool.index++
+	}
+
+	return proxy, nil
+}

--- a/pkg/ffuf/util.go
+++ b/pkg/ffuf/util.go
@@ -147,5 +147,5 @@ func mergeMaps(m1 map[string][]string, m2 map[string][]string) map[string][]stri
 
 func parseProxyUrl(proxyUrl string) (u *url.URL, isValid bool) {
 	u, err := url.Parse(proxyUrl)
-	return u, err != nil || u.Opaque != "" || (u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "socks5")
+	return u, err == nil && u.Opaque == "" && (u.Scheme == "http" || u.Scheme == "https" || u.Scheme == "socks5")
 }

--- a/pkg/ffuf/util.go
+++ b/pkg/ffuf/util.go
@@ -144,3 +144,8 @@ func mergeMaps(m1 map[string][]string, m2 map[string][]string) map[string][]stri
 	}
 	return merged
 }
+
+func parseProxyUrl(proxyUrl string) (u *url.URL, isValid bool) {
+	u, err := url.Parse(proxyUrl)
+	return u, err != nil || u.Opaque != "" || (u.Scheme != "http" && u.Scheme != "https" && u.Scheme != "socks5")
+}

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -108,6 +109,10 @@ func (s *Stdoutput) Banner() {
 	}
 	if len(s.config.ReplayProxyURL) > 0 {
 		printOption([]byte("ReplayProxy"), []byte(s.config.ReplayProxyURL))
+	}
+	if len(s.config.ProxyListFile) > 0 {
+		proxyListPath, _ := filepath.Abs(s.config.ProxyListFile) // Shouldn't ever fail, file is parsed and checked in options parser
+		printOption([]byte("Proxy List"), []byte(proxyListPath))
 	}
 
 	// Timeout

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -151,7 +151,20 @@ func (r *SimpleRunner) Execute(req *ffuf.Request) (ffuf.Response, error) {
 		req.Raw = string(rawreq)
 	}
 
-	httpresp, err := r.client.Do(httpreq)
+	// If we're using a proxy list, get a proxy url from the pool and set it as the transport's proxy
+	client := r.client
+	if r.config.ProxyPool != nil {
+		newClient := &*r.client
+		newTransport := &*r.client.Transport.(*http.Transport)
+
+		proxyUrl, _ := r.config.ProxyPool.Get()
+		newTransport.Proxy = proxyUrl
+
+		newClient.Transport = newTransport
+		client = newClient
+	}
+
+	httpresp, err := client.Do(httpreq)
 	if err != nil {
 		return ffuf.Response{}, err
 	}


### PR DESCRIPTION
Adds a proxy list option (`-xf`) acting as a pool of proxies to be used per request, allowing use of more than just one proxy URL per run.

May or may not have missed something, first time messing with this codebase *and* I'm running on 2 hours of sleep :sweat_smile: