### PR TITLE
Add Docker support for ffuf

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Git
+.git
+.gitignore
+
+# Build & release configs
+.goreleaser.yml
+
+# Docker
+Dockerfile
+.dockerignore
+
+# Docs, images, examples
+README.md
+CHANGELOG.md
+CONTRIBUTORS.md
+LICENSE
+_img
+ffufrc.example
+
+# Tests
+**/*_test.go
+**/testdata
+
+# IDE/editor files
+*.swp
+*.swo
+*.bak
+*.tmp
+.vscode
+.idea
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - master
   - New
     - Added audit logging functionality
+    - Added Docker support to build and run ffuf in a container
   - Changed
     - Fix a bug in autocalibration strategy merging, when two files have the same strategy key
     - Fix a bug in -or, causing output to not to be written in any case

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,6 +42,7 @@
 * [penguinxoxo](https://github.com/penguinxoxo)
 * [p0dalirius](https://github.com/p0dalirius)
 * [putsi](https://github.com/putsi)
+* [Reza Rasoulzade](https://github.com/rzarslzde)
 * [SakiiR](https://github.com/SakiiR)
 * [seblw](https://github.com/seblw)
 * [Serizao](https://github.com/Serizao)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.23 AS builder
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o ffuf .
+
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates
+WORKDIR /ffuf
+COPY --from=builder /app/ffuf /usr/local/bin/ffuf
+LABEL org.opencontainers.image.title="ffuf" \
+      org.opencontainers.image.description="Fast web fuzzer written in Go" \
+      org.opencontainers.image.source="https://github.com/ffuf/ffuf"
+ENTRYPOINT ["ffuf"]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ By using the FUZZ keyword at the end of URL (`-u`):
 ffuf -w /path/to/wordlist -u https://target/FUZZ
 ```
 
+## Docker
+
+You can also run ffuf inside a Docker container without installing Go:
+
+### Build the Image
+```bash
+docker build -t ffuf .
+```
+
+### Example with wordlist
+```bash
+docker run --rm -v /path/to/wordlist:/ffuf/wordlist ffuf \
+  -w /ffuf/wordlist -u https://target/FUZZ
+```
+
 ### Virtual host discovery (without DNS records)
 
 [![asciicast](https://asciinema.org/a/211360.png)](https://asciinema.org/a/211360)


### PR DESCRIPTION
# Description

This PR adds **Docker support** for ffuf.  
It introduces a lightweight multi-stage `Dockerfile` and a `.dockerignore` file, allowing users to build and run ffuf inside a container without installing Go on their host system.  

### Usage Example
```bash
docker build -t ffuf .
docker run --rm ffuf -h
docker run --rm -v ~/wordlists:/wordlists ffuf \
  -w /wordlists/directory-list.txt -u http://example.com/FUZZ

## Additonally

- Added my name to CONTRIBUTORS.md
- Added a short description in CHANGELOG.md
- Updated README.md with Docker guides
- It would also be possible to publish the image to GitHub Container Registry (ghcr.io) or Docker Hub.

Thanks for contributing to ffuf :)
