### PR TITLE
Add -time flag to display request timestamps

### DIFF
--- a/help.go
+++ b/help.go
@@ -61,7 +61,7 @@ func Usage() {
 		Description:   "",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"ac", "acc", "ack", "ach", "acs", "c", "config", "json", "maxtime", "maxtime-job", "noninteractive", "p", "rate", "scraperfile", "scrapers", "search", "s", "sa", "se", "sf", "t", "v", "V"},
+		ExpectedFlags: []string{"ac", "acc", "ack", "ach", "acs", "c", "config", "json", "maxtime", "maxtime-job", "noninteractive", "p", "rate", "scraperfile", "scrapers", "search", "s", "sa", "se", "sf", "t", "time", "v", "V"},
 	}
 	u_compat := UsageSection{
 		Name:          "COMPATIBILITY OPTIONS",

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.BoolVar(&opts.General.Json, "json", opts.General.Json, "JSON output, printing newline-delimited JSON records")
 	flag.BoolVar(&opts.General.Noninteractive, "noninteractive", opts.General.Noninteractive, "Disable the interactive console functionality")
 	flag.BoolVar(&opts.General.Quiet, "s", opts.General.Quiet, "Do not print additional information (silent mode)")
+	flag.BoolVar(&opts.General.ShowTimestamp, "time", opts.General.ShowTimestamp, "Show timestamp for each request in American format (MM/DD/YYYY HH:MM:SS)")
 	flag.BoolVar(&opts.General.ShowVersion, "V", opts.General.ShowVersion, "Show version information.")
 	flag.BoolVar(&opts.General.StopOn403, "sf", opts.General.StopOn403, "Stop when > 95% of responses return 403 Forbidden")
 	flag.BoolVar(&opts.General.StopOnAll, "sa", opts.General.StopOnAll, "Stop on all error cases. Implies -sf and -se.")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	ProxyURL                  string                `json:"proxyurl"`
 	Quiet                     bool                  `json:"quiet"`
 	Rate                      int64                 `json:"rate"`
+	ShowTimestamp             bool                  `json:"show_timestamp"`
 	Raw                       bool                  `json:"raw"`
 	Recursion                 bool                  `json:"recursion"`
 	RecursionDepth            int                   `json:"recursion_depth"`
@@ -110,6 +111,7 @@ func NewConfig(ctx context.Context, cancel context.CancelFunc) Config {
 	conf.ProxyURL = ""
 	conf.Quiet = false
 	conf.Rate = 0
+	conf.ShowTimestamp = false
 	conf.Raw = false
 	conf.Recursion = false
 	conf.RecursionDepth = 0

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -109,6 +109,7 @@ type Result struct {
 	RedirectLocation string              `json:"redirectlocation"`
 	Url              string              `json:"url"`
 	Duration         time.Duration       `json:"duration"`
+	Timestamp        time.Time           `json:"timestamp"`
 	ScraperData      map[string][]string `json:"scraper"`
 	ResultFile       string              `json:"resultfile"`
 	Host             string              `json:"host"`

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -64,6 +64,7 @@ type GeneralOptions struct {
 	ScraperFile               string   `json:"scraperfile"`
 	Scrapers                  string   `json:"scrapers"`
 	Searchhash                string   `json:"-"`
+	ShowTimestamp             bool     `json:"show_timestamp"`
 	ShowVersion               bool     `toml:"-" json:"-"`
 	StopOn403                 bool     `json:"stop_on_403"`
 	StopOnAll                 bool     `json:"stop_on_all"`
@@ -139,6 +140,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.General.Searchhash = ""
 	c.General.ScraperFile = ""
 	c.General.Scrapers = "all"
+	c.General.ShowTimestamp = false
 	c.General.ShowVersion = false
 	c.General.StopOn403 = false
 	c.General.StopOnAll = false
@@ -522,6 +524,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	conf.Quiet = parseOpts.General.Quiet
 	conf.ScraperFile = parseOpts.General.ScraperFile
 	conf.Scrapers = parseOpts.General.Scrapers
+	conf.ShowTimestamp = parseOpts.General.ShowTimestamp
 	conf.StopOn403 = parseOpts.General.StopOn403
 	conf.StopOnAll = parseOpts.General.StopOnAll
 	conf.StopOnErrors = parseOpts.General.StopOnErrors

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -335,6 +335,7 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 		ScraperData:      resp.ScraperData,
 		Url:              resp.Request.Url,
 		Duration:         resp.Duration,
+		Timestamp:        resp.Timestamp,
 		ResultFile:       resp.ResultFile,
 		Host:             resp.Request.Host,
 	}
@@ -413,7 +414,11 @@ func (s *Stdoutput) resultQuiet(res ffuf.Result) {
 func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 	var res_hdr, res_str string
 	res_str = "%s%s    * %s: %s\n"
-	res_hdr = fmt.Sprintf("%s%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, s.colorize(res.StatusCode), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), ANSI_CLEAR)
+	timestamp := ""
+	if s.config.ShowTimestamp && !res.Timestamp.IsZero() {
+		timestamp = fmt.Sprintf("[%s] ", res.Timestamp.Format("01/02/2006 03:04:05 PM"))
+	}
+	res_hdr = fmt.Sprintf("%s%s%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, timestamp, s.colorize(res.StatusCode), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), ANSI_CLEAR)
 	reslines := ""
 	if s.config.Verbose {
 		reslines = fmt.Sprintf("%s%s| URL | %s\n", reslines, TERMINAL_CLEAR_LINE, res.Url)
@@ -446,7 +451,11 @@ func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 }
 
 func (s *Stdoutput) resultNormal(res ffuf.Result) {
-	resnormal := fmt.Sprintf("%s%s%-23s [Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, s.colorize(res.StatusCode), s.prepareInputsOneLine(res), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), ANSI_CLEAR)
+	timestamp := ""
+	if s.config.ShowTimestamp && !res.Timestamp.IsZero() {
+		timestamp = fmt.Sprintf("[%s] ", res.Timestamp.Format("01/02/2006 03:04:05 PM"))
+	}
+	resnormal := fmt.Sprintf("%s%s%s%-23s [Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, timestamp, s.colorize(res.StatusCode), s.prepareInputsOneLine(res), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), ANSI_CLEAR)
 	fmt.Println(resnormal)
 }
 


### PR DESCRIPTION
# Description

Adds a new -time command-line flag that displays timestamps in American.  format (MM/DD/YYYY HH:MM:SS AM/PM) for each request result:
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           * Added ShowTimestamp field to Config and ConfigOptions structs
* Added Timestamp field to Result struct                                                                                                                                                                                     
* Updated resultNormal() and resultMultiline() to show timestamps when enabled
* Added -time flag to CLI parser and help documentation

```bash

ffuf -u https://ffuf.me/FUZZ -w foo.txt -mc 200 -time -p 3.5


[10/21/2025 05:53:16 PM] swagger/                [Status: 200, Size: 5558, Words: 1925, Lines: 188, Duration: 75ms]
[10/21/2025 05:53:16 PM] swagger-resources/configuration/ui [Status: 200, Size: 5558, Words: 1925, Lines: 188, Duration: 88ms]
[10/21/2025 05:53:16 PM] swagger.json            [Status: 200, Size: 5558, Words: 1925, Lines: 188, Duration: 82ms]
[10/21/2025 05:53:16 PM] swagger-ui.json         [Status: 200, Size: 5558, Words: 1925, Lines: 188, Duration: 90ms]
[10/21/2025 05:53:16 PM] swagger.yml             [Status: 200, Size: 5558, Words: 1925, Lines: 188, Duration: 85ms]
[10/21/2025 05:53:16 PM] swagger.yaml            [Status: 200, Size: 5558, Words: 1925, Lines: 188, Duration: 86ms]
[10/21/2025 05:53:16 PM] swagger/static/index.html [Status: 200, Size: 5558, Words: 1925, Lines: 188, Duration: 83ms]
[10/21/2025 05:53:16 PM] swagger-ui/             [Status: 200, Size: 5558, Words: 1925, Lines: 188, Duration: 92ms]

```