### PR TITLE
Add Content-Type filtering and matching support (-mct/-fct flags) | Feature

### DIFF
--- a/help.go
+++ b/help.go
@@ -75,14 +75,14 @@ func Usage() {
 		Description:   "Matchers for the response filtering.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"mmode", "mc", "ml", "mr", "ms", "mt", "mw"},
+		ExpectedFlags: []string{"mmode", "mc", "mct", "ml", "mr", "ms", "mt", "mw"},
 	}
 	u_filter := UsageSection{
 		Name:          "FILTER OPTIONS",
 		Description:   "Filters for the response filtering.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"fmode", "fc", "fl", "fr", "fs", "ft", "fw"},
+		ExpectedFlags: []string{"fmode", "fc", "fct", "fl", "fr", "fs", "ft", "fw"},
 	}
 	u_input := UsageSection{
 		Name:          "INPUT OPTIONS",

--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.Filter.Status, "fc", opts.Filter.Status, "Filter HTTP status codes from response. Comma separated list of codes and ranges")
 	flag.StringVar(&opts.Filter.Time, "ft", opts.Filter.Time, "Filter by number of milliseconds to the first response byte, either greater or less than. EG: >100 or <100")
 	flag.StringVar(&opts.Filter.Words, "fw", opts.Filter.Words, "Filter by amount of words in response. Comma separated list of word counts and ranges")
+	flag.StringVar(&opts.Filter.ContentType, "fct", opts.Filter.ContentType, "Filter HTTP response Content-Type header. Comma separated list. Supports exact (text/html), wildcard (application/*), substring (json), or 'all'")
 	flag.StringVar(&opts.General.Delay, "p", opts.General.Delay, "Seconds of `delay` between requests, or a range of random delay. For example \"0.1\" or \"0.1-2.0\"")
 	flag.StringVar(&opts.General.Searchhash, "search", opts.General.Searchhash, "Search for a FFUFHASH payload from ffuf history")
 	flag.StringVar(&opts.HTTP.Data, "d", opts.HTTP.Data, "POST data")
@@ -127,6 +128,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.Matcher.Status, "mc", opts.Matcher.Status, "Match HTTP status codes, or \"all\" for everything.")
 	flag.StringVar(&opts.Matcher.Time, "mt", opts.Matcher.Time, "Match how many milliseconds to the first response byte, either greater or less than. EG: >100 or <100")
 	flag.StringVar(&opts.Matcher.Words, "mw", opts.Matcher.Words, "Match amount of words in response")
+	flag.StringVar(&opts.Matcher.ContentType, "mct", opts.Matcher.ContentType, "Match HTTP response Content-Type header. Comma separated list. Supports exact (text/html), wildcard (application/*), substring (json), or 'all'")
 	flag.StringVar(&opts.Output.AuditLog, "audit-log", opts.Output.AuditLog, "Write audit log containing all requests, responses and config")
 	flag.StringVar(&opts.Output.DebugLog, "debug-log", opts.Output.DebugLog, "Write all of the internal logging to the specified file.")
 	flag.StringVar(&opts.Output.OutputDirectory, "od", opts.Output.OutputDirectory, "Directory path to store matched results to.")
@@ -339,6 +341,9 @@ func SetupFilters(parseOpts *ffuf.ConfigOptions, conf *ffuf.Config) error {
 		if f.Name == "mt" {
 			matcherSet = true
 		}
+		if f.Name == "mct" {
+			matcherSet = true
+		}
 		if f.Name == "mw" {
 			matcherSet = true
 			warningIgnoreBody = true
@@ -373,6 +378,11 @@ func SetupFilters(parseOpts *ffuf.ConfigOptions, conf *ffuf.Config) error {
 			errs.Add(err)
 		}
 	}
+	if parseOpts.Filter.ContentType != "" {
+		if err := conf.MatcherManager.AddFilter("contenttype", parseOpts.Filter.ContentType, false); err != nil {
+			errs.Add(err)
+		}
+	}
 	if parseOpts.Filter.Lines != "" {
 		warningIgnoreBody = true
 		if err := conf.MatcherManager.AddFilter("line", parseOpts.Filter.Lines, false); err != nil {
@@ -396,6 +406,11 @@ func SetupFilters(parseOpts *ffuf.ConfigOptions, conf *ffuf.Config) error {
 	}
 	if parseOpts.Matcher.Words != "" {
 		if err := conf.MatcherManager.AddMatcher("word", parseOpts.Matcher.Words); err != nil {
+			errs.Add(err)
+		}
+	}
+	if parseOpts.Matcher.ContentType != "" {
+		if err := conf.MatcherManager.AddMatcher("contenttype", parseOpts.Matcher.ContentType); err != nil {
 			errs.Add(err)
 		}
 	}

--- a/pkg/ffuf/configmarshaller.go
+++ b/pkg/ffuf/configmarshaller.go
@@ -86,6 +86,7 @@ func (c *Config) ToOptions() ConfigOptions {
 	o.Filter.Regexp = ""
 	o.Filter.Size = ""
 	o.Filter.Status = ""
+	o.Filter.ContentType = ""
 	o.Filter.Time = ""
 	o.Filter.Words = ""
 	for name, filter := range c.MatcherManager.GetFilters() {
@@ -98,6 +99,8 @@ func (c *Config) ToOptions() ConfigOptions {
 			o.Filter.Size = filter.Repr()
 		case "status":
 			o.Filter.Status = filter.Repr()
+		case "contenttype":
+			o.Filter.ContentType = filter.Repr()
 		case "time":
 			o.Filter.Time = filter.Repr()
 		case "words":
@@ -109,6 +112,7 @@ func (c *Config) ToOptions() ConfigOptions {
 	o.Matcher.Regexp = ""
 	o.Matcher.Size = ""
 	o.Matcher.Status = ""
+	o.Matcher.ContentType = ""
 	o.Matcher.Time = ""
 	o.Matcher.Words = ""
 	for name, filter := range c.MatcherManager.GetMatchers() {
@@ -121,6 +125,8 @@ func (c *Config) ToOptions() ConfigOptions {
 			o.Matcher.Size = filter.Repr()
 		case "status":
 			o.Matcher.Status = filter.Repr()
+		case "contenttype":
+			o.Matcher.ContentType = filter.Repr()
 		case "time":
 			o.Matcher.Time = filter.Repr()
 		case "words":

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -101,6 +101,7 @@ type FilterOptions struct {
 	Regexp string `json:"regexp"`
 	Size   string `json:"size"`
 	Status string `json:"status"`
+	ContentType string `json:"content_type"`
 	Time   string `json:"time"`
 	Words  string `json:"words"`
 }
@@ -111,6 +112,7 @@ type MatcherOptions struct {
 	Regexp string `json:"regexp"`
 	Size   string `json:"size"`
 	Status string `json:"status"`
+	ContentType string `json:"content_type"`
 	Time   string `json:"time"`
 	Words  string `json:"words"`
 }
@@ -172,6 +174,7 @@ func NewConfigOptions() *ConfigOptions {
 	c.Matcher.Regexp = ""
 	c.Matcher.Size = ""
 	c.Matcher.Status = "200-299,301,302,307,401,403,405,500"
+	c.Matcher.ContentType = ""
 	c.Matcher.Time = ""
 	c.Matcher.Words = ""
 	c.Output.AuditLog = ""

--- a/pkg/filter/contenttype.go
+++ b/pkg/filter/contenttype.go
@@ -1,0 +1,82 @@
+package filter
+
+import (
+    "encoding/json"
+    "fmt"
+    "strings"
+
+    "github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+type ContentTypeFilter struct {
+    Value []string
+}
+
+func NewContentTypeFilter(value string) (ffuf.FilterProvider, error) {
+    vals := make([]string, 0)
+    for _, v := range strings.Split(value, ",") {
+        v = strings.TrimSpace(v)
+        if v == "" {
+            continue
+        }
+        vals = append(vals, v)
+    }
+    if len(vals) == 0 {
+        return &ContentTypeFilter{}, fmt.Errorf("Content-Type filter or matcher (-fct / -mct): invalid value %s", value)
+    }
+    return &ContentTypeFilter{Value: vals}, nil
+}
+
+func (f *ContentTypeFilter) MarshalJSON() ([]byte, error) {
+    return json.Marshal(&struct{
+        Value string `json:"value"`
+    }{Value: strings.Join(f.Value, ",")})
+}
+
+func (f *ContentTypeFilter) Filter(response *ffuf.Response) (bool, error) {
+    // Normalize response content type (strip params)
+    respct := strings.ToLower(strings.TrimSpace(response.ContentType))
+    if respct == "" {
+        respct = ""
+    }
+    if strings.Contains(respct, ";") {
+        respct = strings.TrimSpace(strings.SplitN(respct, ";", 2)[0])
+    }
+    for _, v := range f.Value {
+        v = strings.ToLower(strings.TrimSpace(v))
+        if v == "all" {
+            return true, nil
+        }
+        if v == "" {
+            continue
+        }
+        // support wildcard like application/*
+        if strings.HasSuffix(v, "/*") {
+            prefix := strings.SplitN(v, "/", 2)[0]
+            if strings.HasPrefix(respct, prefix+"/") {
+                return true, nil
+            }
+            continue
+        }
+        if strings.Contains(v, "/") {
+            // exact mediatype match
+            if respct == v {
+                return true, nil
+            }
+            continue
+        }
+        // fallback: substring match (e.g., "json" matches "application/json")
+        if strings.Contains(respct, v) {
+            return true, nil
+        }
+    }
+    return false, nil
+}
+
+func (f *ContentTypeFilter) Repr() string {
+    return strings.Join(f.Value, ",")
+}
+
+func (f *ContentTypeFilter) ReprVerbose() string {
+    return fmt.Sprintf("Response Content-Type: %s", f.Repr())
+}

--- a/pkg/filter/contenttype_test.go
+++ b/pkg/filter/contenttype_test.go
@@ -1,0 +1,90 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+func TestNewContentTypeFilter(t *testing.T) {
+	f, _ := NewContentTypeFilter("application/json,text/html")
+	ctf := f.(*ContentTypeFilter)
+	if len(ctf.Value) != 2 {
+		t.Errorf("ContentTypeFilter should have 2 values, has %d", len(ctf.Value))
+	}
+}
+
+func TestContentTypeFiltering(t *testing.T) {
+	f, _ := NewContentTypeFilter("application/json")
+	ctf := f.(*ContentTypeFilter)
+	resp := &ffuf.Response{
+		ContentType: "application/json; charset=utf-8",
+	}
+	match, err := ctf.Filter(resp)
+	if err != nil {
+		t.Errorf("Filter error: %s", err)
+	}
+	if !match {
+		t.Errorf("Should match 'application/json' content type")
+	}
+}
+
+func TestContentTypeFilteringWildcard(t *testing.T) {
+	f, _ := NewContentTypeFilter("application/*")
+	ctf := f.(*ContentTypeFilter)
+	resp := &ffuf.Response{
+		ContentType: "application/xml",
+	}
+	match, err := ctf.Filter(resp)
+	if err != nil {
+		t.Errorf("Filter error: %s", err)
+	}
+	if !match {
+		t.Errorf("Should match 'application/*' wildcard")
+	}
+}
+
+func TestContentTypeFilteringNoMatch(t *testing.T) {
+	f, _ := NewContentTypeFilter("application/json")
+	ctf := f.(*ContentTypeFilter)
+	resp := &ffuf.Response{
+		ContentType: "text/html",
+	}
+	match, err := ctf.Filter(resp)
+	if err != nil {
+		t.Errorf("Filter error: %s", err)
+	}
+	if match {
+		t.Errorf("Should not match 'text/html' when expecting 'application/json'")
+	}
+}
+
+func TestContentTypeFilteringSubstring(t *testing.T) {
+	f, _ := NewContentTypeFilter("json")
+	ctf := f.(*ContentTypeFilter)
+	resp := &ffuf.Response{
+		ContentType: "application/json",
+	}
+	match, err := ctf.Filter(resp)
+	if err != nil {
+		t.Errorf("Filter error: %s", err)
+	}
+	if !match {
+		t.Errorf("Should match 'json' substring in 'application/json'")
+	}
+}
+
+func TestContentTypeFilteringAll(t *testing.T) {
+	f, _ := NewContentTypeFilter("all")
+	ctf := f.(*ContentTypeFilter)
+	resp := &ffuf.Response{
+		ContentType: "text/plain",
+	}
+	match, err := ctf.Filter(resp)
+	if err != nil {
+		t.Errorf("Filter error: %s", err)
+	}
+	if !match {
+		t.Errorf("Should match all content types with 'all' keyword")
+	}
+}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -71,6 +71,9 @@ func NewFilterByName(name string, value string) (ffuf.FilterProvider, error) {
 	if name == "time" {
 		return NewTimeFilter(value)
 	}
+	if name == "contenttype" {
+		return NewContentTypeFilter(value)
+	}
 	return nil, fmt.Errorf("Could not create filter with name %s", name)
 }
 

--- a/pkg/interactive/termhandler.go
+++ b/pkg/interactive/termhandler.go
@@ -164,6 +164,24 @@ func (i *interactive) handleInput(in []byte) {
 				i.appendFilter("time", args[1])
 				i.Job.Output.Info("New response time filter value set")
 			}
+		case "fct":
+			if len(args) < 2 {
+				i.Job.Output.Error("Please define a value for content-type filter, or \"none\" for removing it")
+			} else if len(args) > 2 {
+				i.Job.Output.Error("Too many arguments for \"fct\"")
+			} else {
+				i.updateFilter("contenttype", args[1], true)
+				i.Job.Output.Info("New content-type filter value set")
+			}
+		case "afct":
+			if len(args) < 2 {
+				i.Job.Output.Error("Please define a value to append to content-type filter")
+			} else if len(args) > 2 {
+				i.Job.Output.Error("Too many arguments for \"afct\"")
+			} else {
+				i.appendFilter("contenttype", args[1])
+				i.Job.Output.Info("New content-type filter value set")
+			}
 		case "queueshow":
 			i.printQueue()
 		case "queuedel":
@@ -277,7 +295,7 @@ func (i *interactive) printPrompt() {
 }
 
 func (i *interactive) printHelp() {
-	var fc, fl, fs, ft, fw string
+	var fc, fl, fs, ft, fw, fct string
 	for name, filter := range i.Job.Config.MatcherManager.GetFilters() {
 		switch name {
 		case "status":
@@ -290,6 +308,8 @@ func (i *interactive) printHelp() {
 			fs = "(active: " + filter.Repr() + ")"
 		case "time":
 			ft = "(active: " + filter.Repr() + ")"
+		case "contenttype":
+			fct = "(active: " + filter.Repr() + ")"
 		}
 	}
 	rate := fmt.Sprintf("(active: %d)", i.Job.Config.Rate)
@@ -305,6 +325,8 @@ available commands:
  fs   [value]             - (re)configure size filter %s
  aft  [value]             - append to time filter %s
  ft   [value]             - (re)configure time filter %s
+ afct [value]             - append to content-type filter %s
+ fct  [value]             - (re)configure content-type filter %s
  rate [value]             - adjust rate of requests per second %s
  queueshow                - show job queue
  queuedel [number]        - delete a job in the queue
@@ -315,5 +337,5 @@ available commands:
  savejson [filename]      - save current matches to a file
  help                     - you are looking at it
 `
-	i.Job.Output.Raw(fmt.Sprintf(help, fc, fc, fl, fl, fw, fw, fs, fs, ft, ft, rate))
+	i.Job.Output.Raw(fmt.Sprintf(help, fc, fc, fl, fl, fw, fw, fs, fs, ft, ft, fct, fct, rate))
 }


### PR DESCRIPTION
Implemented new flags to filter and match HTTP responses based on Content-Type header:
- -mct: Match responses with specific Content-Type (show only these)
- -fct: Filter responses with specific Content-Type (hide these)

Features:
- Exact match: application/json, text/plain, text/html
- Wildcard support: application/*, text/*, image/*
- Substring match: json, xml, plain
- 'all' keyword: matches any content-type
- Comma-separated list support for multiple values
- Automatic charset parameter stripping (e.g., '; charset=utf-8')
- Case-insensitive matching

Interactive mode support:
- fct [value]: Set content-type filter
- afct [value]: Append to content-type filter

Modified files:
- main.go: Added CLI flags and SetupFilters integration
- pkg/ffuf/optionsparser.go: Added ContentType fields to options
- pkg/ffuf/configmarshaller.go: Config marshalling support
- pkg/filter/filter.go: Registered contenttype filter
- pkg/filter/contenttype.go: Filter implementation (new)
- pkg/filter/contenttype_test.go: Unit tests (new)
- pkg/interactive/termhandler.go: Interactive commands
- help.go: Updated expected flags

All unit tests passing.
