### PR TITLE
Add contributor sumanrox to CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,6 +42,7 @@
 * [penguinxoxo](https://github.com/penguinxoxo)
 * [p0dalirius](https://github.com/p0dalirius)
 * [putsi](https://github.com/putsi)
+* [sumanrox](https://github.com/sumanrox)
 * [SakiiR](https://github.com/SakiiR)
 * [seblw](https://github.com/seblw)
 * [Serizao](https://github.com/Serizao)


### PR DESCRIPTION
Implemented new flags to filter and match HTTP responses based on Content-Type header:
- -mct: Match responses with specific Content-Type (show only these)
- -fct: Filter responses with specific Content-Type (hide these)

Features:
- Exact match: application/json, text/plain, text/html
- Wildcard support: application/*, text/*, image/*
- Substring match: json, xml, plain
- 'all' keyword: matches any content-type
- Comma-separated list support for multiple values
- Automatic charset parameter stripping (e.g., '; charset=utf-8')
- Case-insensitive matching

Interactive mode support:
- fct [value]: Set content-type filter
- afct [value]: Append to content-type filter
