### PR TITLE
Added Smart calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 - master
   - New
     - Added audit logging functionality
+    - Added smart calibration (-sc) - automatically analyzes first N responses and filters out dominant patterns
+    - Added -scs flag to configure smart calibration sample size (default: 100)
+    - Added -sct flag to configure smart calibration threshold percentage (default: 90)
   - Changed
     - Fix a bug in autocalibration strategy merging, when two files have the same strategy key
     - Fix a bug in -or, causing output to not to be written in any case

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 * [choket](https://github.com/choket)
 * [codingo](https://github.com/codingo)
 * [c_sto](https://github.com/c-sto)
+* [ChernovHere](https://github.com/ChernovHere)
 * [Damian89](https://github.com/Damian89)
 * [Daviey](https://github.com/Daviey)
 * [delic](https://github.com/delic)

--- a/README.md
+++ b/README.md
@@ -189,8 +189,11 @@ GENERAL OPTIONS:
   -rate               Rate of requests per second (default: 0)
   -s                  Do not print additional information (silent mode) (default: false)
   -sa                 Stop on all error cases. Implies -sf and -se. (default: false)
+  -sc                 Smart calibration: analyze first N responses and auto-filter common patterns (default: false)
   -scraperfile        Custom scraper file path
   -scrapers           Active scraper groups (default: all)
+  -scs                Smart calibration sample size (default: 100) (default: 100)
+  -sct                Smart calibration threshold percentage (default: 90) (default: 90)
   -se                 Stop on spurious errors (default: false)
   -search             Search for a FFUFHASH payload from ffuf history
   -sf                 Stop when > 95% of responses return 403 Forbidden (default: false)

--- a/help.go
+++ b/help.go
@@ -61,7 +61,7 @@ func Usage() {
 		Description:   "",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"ac", "acc", "ack", "ach", "acs", "c", "config", "json", "maxtime", "maxtime-job", "noninteractive", "p", "rate", "scraperfile", "scrapers", "search", "s", "sa", "se", "sf", "t", "v", "V"},
+		ExpectedFlags: []string{"ac", "acc", "ack", "ach", "acs", "sc", "scs", "sct", "c", "config", "json", "maxtime", "maxtime-job", "noninteractive", "p", "rate", "scraperfile", "scrapers", "search", "s", "sa", "se", "sf", "t", "v", "V"},
 	}
 	u_compat := UsageSection{
 		Name:          "COMPATIBILITY OPTIONS",

--- a/main.go
+++ b/main.go
@@ -67,6 +67,10 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.BoolVar(&opts.Output.OutputSkipEmptyFile, "or", opts.Output.OutputSkipEmptyFile, "Don't create the output file if we don't have results")
 	flag.BoolVar(&opts.General.AutoCalibration, "ac", opts.General.AutoCalibration, "Automatically calibrate filtering options")
 	flag.BoolVar(&opts.General.AutoCalibrationPerHost, "ach", opts.General.AutoCalibration, "Per host autocalibration")
+	// Smart calibration - новые флаги
+	flag.BoolVar(&opts.General.SmartCalibration, "sc", opts.General.SmartCalibration, "Smart calibration: analyze first N responses and auto-filter common patterns")
+	flag.IntVar(&opts.General.SmartCalibrationSamples, "scs", opts.General.SmartCalibrationSamples, "Smart calibration sample size (default: 100)")
+	flag.IntVar(&opts.General.SmartCalibrationThreshold, "sct", opts.General.SmartCalibrationThreshold, "Smart calibration threshold percentage (default: 90)")
 	flag.BoolVar(&opts.General.Colors, "c", opts.General.Colors, "Colorize output.")
 	flag.BoolVar(&opts.General.Json, "json", opts.General.Json, "JSON output, printing newline-delimited JSON records")
 	flag.BoolVar(&opts.General.Noninteractive, "noninteractive", opts.General.Noninteractive, "Disable the interactive console functionality")

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -11,6 +11,10 @@ type Config struct {
 	AutoCalibrationPerHost    bool                  `json:"autocalibration_perhost"`
 	AutoCalibrationStrategies []string              `json:"autocalibration_strategies"`
 	AutoCalibrationStrings    []string              `json:"autocalibration_strings"`
+	// Smart calibration - новые параметры для умной калибровки
+	SmartCalibration          bool                  `json:"smart_calibration"`
+	SmartCalibrationSamples   int                   `json:"smart_calibration_samples"`
+	SmartCalibrationThreshold int                   `json:"smart_calibration_threshold"`
 	Cancel                    context.CancelFunc    `json:"-"`
 	Colors                    bool                  `json:"colors"`
 	CommandKeywords           []string              `json:"-"`
@@ -83,6 +87,10 @@ func NewConfig(ctx context.Context, cancel context.CancelFunc) Config {
 	conf.AutoCalibrationKeyword = "FUZZ"
 	conf.AutoCalibrationStrategies = []string{"basic"}
 	conf.AutoCalibrationStrings = make([]string, 0)
+	// Smart calibration - значения по умолчанию
+	conf.SmartCalibration = false
+	conf.SmartCalibrationSamples = 100
+	conf.SmartCalibrationThreshold = 90
 	conf.CommandKeywords = make([]string, 0)
 	conf.Context = ctx
 	conf.Cancel = cancel

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -41,6 +41,8 @@ type Job struct {
 	currentDepth         int
 	calibMutex           sync.Mutex
 	pauseWg              sync.WaitGroup
+	// Smart calibration - статистика для умной калибровки
+	SmartCalibStats      *SmartCalibrationStats
 }
 
 type QueueJob struct {
@@ -63,6 +65,8 @@ func NewJob(conf *Config) *Job {
 	j.currentDepth = 0
 	j.Rate = NewRateThrottle(conf)
 	j.skipQueue = false
+	// Smart calibration - инициализация статистики
+	j.SmartCalibStats = NewSmartCalibrationStats()
 	return &j
 }
 
@@ -476,6 +480,17 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 	}
 	j.pauseWg.Wait()
 
+	// ========== SMART CALIBRATION - собираем статистику первых N ответов ==========
+	if j.Config.SmartCalibration && !j.SmartCalibStats.IsCalibrationDone() {
+		j.SmartCalibStats.AddResponse(resp)
+		
+		// Проверяем, достигли ли мы нужного количества сэмплов
+		if j.SmartCalibStats.ShouldCalibrate(j.Config.SmartCalibrationSamples) {
+			j.applySmartCalibration()
+		}
+	}
+	// ========== END SMART CALIBRATION ==========
+
 	// Handle autocalibration, must be done after the actual request to ensure sane value in req.Host
 	_ = j.CalibrateIfNeeded(HostURLFromRequest(req), input)
 
@@ -616,4 +631,67 @@ func (j *Job) Stop() {
 // Stop current, resume to next
 func (j *Job) Next() {
 	j.RunningJob = false
+}
+
+// applySmartCalibration - анализирует собранные ответы и применяет фильтры
+// Вызывается после того, как собрано достаточное количество сэмплов
+// После применения фильтров перезапускает сканирование с начала вордлиста
+func (j *Job) applySmartCalibration() {
+	j.calibMutex.Lock()
+	defer j.calibMutex.Unlock()
+
+	// Проверяем ещё раз под мьютексом
+	if j.SmartCalibStats.IsCalibrationDone() {
+		return
+	}
+
+	// Выводим статистику
+	j.Output.Info("=== SMART CALIBRATION ===")
+	j.Output.Info(j.SmartCalibStats.GetDetailedStats())
+
+	// Получаем рекомендуемые фильтры
+	filters := j.SmartCalibStats.AnalyzeAndGetFilters(j.Config.SmartCalibrationThreshold)
+
+	if len(filters) == 0 {
+		j.Output.Info("Smart calibration: No dominant response pattern found, no filters applied")
+	} else {
+		for _, f := range filters {
+			percent := float64(f.Count) / float64(j.Config.SmartCalibrationSamples) * 100
+			j.Output.Info(fmt.Sprintf("Smart calibration: Adding filter -%s %s (matched %.1f%% of samples)",
+				getFilterFlag(f.Type), f.Value, percent))
+			
+			// Применяем фильтр
+			err := j.Config.MatcherManager.AddFilter(f.Type, f.Value, false)
+			if err != nil {
+				j.Output.Error(fmt.Sprintf("Failed to add filter: %s", err))
+			}
+		}
+	}
+
+	j.SmartCalibStats.SetCalibrationDone()
+
+	// Перезапускаем сканирование с начала вордлиста
+	j.Output.Info("Smart calibration: Restarting scan from beginning with new filters...")
+	j.Output.Info("=========================")
+	
+	// Сбрасываем вордлист на начало
+	j.Input.Reset()
+	j.Counter = 0
+	j.startTimeJob = time.Now()
+}
+
+// getFilterFlag - возвращает флаг командной строки для типа фильтра
+func getFilterFlag(filterType string) string {
+	switch filterType {
+	case "size":
+		return "fs"
+	case "word":
+		return "fw"
+	case "line":
+		return "fl"
+	case "status":
+		return "fc"
+	default:
+		return filterType
+	}
 }

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -52,6 +52,10 @@ type GeneralOptions struct {
 	AutoCalibrationPerHost    bool     `json:"autocalibration_per_host"`
 	AutoCalibrationStrategies []string `json:"autocalibration_strategies"`
 	AutoCalibrationStrings    []string `json:"autocalibration_strings"`
+	// Smart calibration - новые параметры
+	SmartCalibration          bool     `json:"smart_calibration"`
+	SmartCalibrationSamples   int      `json:"smart_calibration_samples"`
+	SmartCalibrationThreshold int      `json:"smart_calibration_threshold"`
 	Colors                    bool     `json:"colors"`
 	ConfigFile                string   `toml:"-" json:"config_file"`
 	Delay                     string   `json:"delay"`
@@ -128,6 +132,10 @@ func NewConfigOptions() *ConfigOptions {
 	c.General.AutoCalibration = false
 	c.General.AutoCalibrationKeyword = "FUZZ"
 	c.General.AutoCalibrationStrategies = []string{"basic"}
+	// Smart calibration - значения по умолчанию
+	c.General.SmartCalibration = false
+	c.General.SmartCalibrationSamples = 100
+	c.General.SmartCalibrationThreshold = 90
 	c.General.Colors = false
 	c.General.Delay = ""
 	c.General.Json = false
@@ -533,6 +541,10 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	conf.AutoCalibration = parseOpts.General.AutoCalibration
 	conf.AutoCalibrationPerHost = parseOpts.General.AutoCalibrationPerHost
 	conf.AutoCalibrationStrategies = parseOpts.General.AutoCalibrationStrategies
+	// Smart calibration - копирование параметров
+	conf.SmartCalibration = parseOpts.General.SmartCalibration
+	conf.SmartCalibrationSamples = parseOpts.General.SmartCalibrationSamples
+	conf.SmartCalibrationThreshold = parseOpts.General.SmartCalibrationThreshold
 	conf.Threads = parseOpts.General.Threads
 	conf.Timeout = parseOpts.HTTP.Timeout
 	conf.MaxTime = parseOpts.General.MaxTime

--- a/pkg/ffuf/smart_calibration.go
+++ b/pkg/ffuf/smart_calibration.go
@@ -1,0 +1,203 @@
+package ffuf
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+)
+
+// ResponseSignature - сигнатура ответа для группировки похожих ответов
+type ResponseSignature struct {
+	StatusCode    int64
+	ContentLength int64
+	ContentWords  int64
+	ContentLines  int64
+}
+
+// SmartCalibrationStats - статистика для умной калибровки
+type SmartCalibrationStats struct {
+	sync.Mutex
+	Responses       []Response
+	SignatureCounts map[ResponseSignature]int
+	TotalCollected  int
+	CalibrationDone bool
+}
+
+// NewSmartCalibrationStats - создание новой статистики
+func NewSmartCalibrationStats() *SmartCalibrationStats {
+	return &SmartCalibrationStats{
+		Responses:       make([]Response, 0),
+		SignatureCounts: make(map[ResponseSignature]int),
+		TotalCollected:  0,
+		CalibrationDone: false,
+	}
+}
+
+// GetSignature - получить сигнатуру ответа
+func GetSignature(resp Response) ResponseSignature {
+	return ResponseSignature{
+		StatusCode:    resp.StatusCode,
+		ContentLength: resp.ContentLength,
+		ContentWords:  resp.ContentWords,
+		ContentLines:  resp.ContentLines,
+	}
+}
+
+// AddResponse - добавить ответ в статистику
+func (s *SmartCalibrationStats) AddResponse(resp Response) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.Responses = append(s.Responses, resp)
+	sig := GetSignature(resp)
+	s.SignatureCounts[sig]++
+	s.TotalCollected++
+}
+
+// ShouldCalibrate - проверить, нужна ли калибровка (собрано достаточно данных)
+func (s *SmartCalibrationStats) ShouldCalibrate(sampleSize int) bool {
+	s.Lock()
+	defer s.Unlock()
+	return s.TotalCollected >= sampleSize && !s.CalibrationDone
+}
+
+// IsCalibrationDone - проверить, завершена ли калибровка
+func (s *SmartCalibrationStats) IsCalibrationDone() bool {
+	s.Lock()
+	defer s.Unlock()
+	return s.CalibrationDone
+}
+
+// SetCalibrationDone - установить флаг завершения калибровки
+func (s *SmartCalibrationStats) SetCalibrationDone() {
+	s.Lock()
+	defer s.Unlock()
+	s.CalibrationDone = true
+}
+
+// SignatureCount - структура для сортировки сигнатур по количеству
+type SignatureCount struct {
+	Signature ResponseSignature
+	Count     int
+}
+
+// AnalyzeAndGetFilters - анализ собранных ответов и получение фильтров
+// thresholdPercent - процент от общего количества, при превышении которого добавляется фильтр
+// Например, если thresholdPercent=50 и 60% ответов имеют одинаковый размер, этот размер будет отфильтрован
+func (s *SmartCalibrationStats) AnalyzeAndGetFilters(thresholdPercent int) []FilterConfig {
+	s.Lock()
+	defer s.Unlock()
+
+	filters := make([]FilterConfig, 0)
+	if s.TotalCollected == 0 {
+		return filters
+	}
+
+	threshold := float64(thresholdPercent) / 100.0
+
+	// Собираем статистику по отдельным параметрам
+	statusCounts := make(map[int64]int)
+	sizeCounts := make(map[int64]int)
+	wordCounts := make(map[int64]int)
+	lineCounts := make(map[int64]int)
+
+	for _, resp := range s.Responses {
+		statusCounts[resp.StatusCode]++
+		sizeCounts[resp.ContentLength]++
+		wordCounts[resp.ContentWords]++
+		lineCounts[resp.ContentLines]++
+	}
+
+	// Проверяем каждый параметр на превышение порога
+	// Приоритет: size > words > lines > status (от более специфичного к менее)
+
+	// Проверка по размеру
+	for size, count := range sizeCounts {
+		if float64(count)/float64(s.TotalCollected) >= threshold {
+			filters = append(filters, FilterConfig{
+				Type:  "size",
+				Value: strconv.FormatInt(size, 10),
+				Count: count,
+			})
+		}
+	}
+
+	// Если нашли фильтр по размеру, не ищем по другим параметрам
+	if len(filters) > 0 {
+		return filters
+	}
+
+	// Проверка по количеству слов
+	for words, count := range wordCounts {
+		if float64(count)/float64(s.TotalCollected) >= threshold {
+			filters = append(filters, FilterConfig{
+				Type:  "word",
+				Value: strconv.FormatInt(words, 10),
+				Count: count,
+			})
+		}
+	}
+
+	if len(filters) > 0 {
+		return filters
+	}
+
+	// Проверка по количеству строк
+	for lines, count := range lineCounts {
+		if float64(count)/float64(s.TotalCollected) >= threshold {
+			filters = append(filters, FilterConfig{
+				Type:  "line",
+				Value: strconv.FormatInt(lines, 10),
+				Count: count,
+			})
+		}
+	}
+
+	return filters
+}
+
+// FilterConfig - конфигурация найденного фильтра
+type FilterConfig struct {
+	Type  string // "size", "word", "line", "status"
+	Value string
+	Count int
+}
+
+// GetDetailedStats - получить детальную статистику для вывода
+func (s *SmartCalibrationStats) GetDetailedStats() string {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.TotalCollected == 0 {
+		return "No responses collected yet"
+	}
+
+	// Сортируем сигнатуры по количеству
+	sorted := make([]SignatureCount, 0, len(s.SignatureCounts))
+	for sig, count := range s.SignatureCounts {
+		sorted = append(sorted, SignatureCount{Signature: sig, Count: count})
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Count > sorted[j].Count
+	})
+
+	result := fmt.Sprintf("Smart Calibration Stats (collected %d responses):\n", s.TotalCollected)
+	result += "Most common response patterns:\n"
+
+	// Показываем топ-5 сигнатур
+	limit := 5
+	if len(sorted) < limit {
+		limit = len(sorted)
+	}
+	for i := 0; i < limit; i++ {
+		sc := sorted[i]
+		percent := float64(sc.Count) / float64(s.TotalCollected) * 100
+		result += fmt.Sprintf("  [%d] Status:%d Size:%d Words:%d Lines:%d - %.1f%% (%d responses)\n",
+			i+1, sc.Signature.StatusCode, sc.Signature.ContentLength,
+			sc.Signature.ContentWords, sc.Signature.ContentLines,
+			percent, sc.Count)
+	}
+
+	return result
+}


### PR DESCRIPTION
## Problem
When fuzzing wildcard domains or endpoints with catch-all responses, ffuf **returns thousands of false positives** with identical response signatures. Users have to **manually** identify the pattern and restart scan with **-fs/-fw/-fl** filters.

## Solution
Smart calibration (-sc) **automates this process**:

1. **Collects** first N responses from wordlist (default: 100)
2. **Analyzes** response patterns (size, words, lines)
3. If >90% of responses share the same signature - **auto-applies filter**
4. **Restarts** scan from beginning with new filters

| Flag              | Description | Default |
| :----------------: | :------: | :----: |
| `-sc`        |   **Enable smart calibration**   | `false` |
| `-scs`           |   **Sample size (number of responses to analyze)**   | `100` |
| `-sct`    |  **Threshold percentage for filtering**   | `90` |
