### PR TITLE
Warn when single-use flags are duplicated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - New
     - Added audit logging functionality
   - Changed
+    - Warn when single-use CLI flags are provided multiple times (for example: `-X PUT ... -X PUT`) and only the last value is used
     - Fix a bug in autocalibration strategy merging, when two files have the same strategy key
     - Fix a bug in -or, causing output to not to be written in any case
     - Fix panic when setting rate to 0 in the interactive console

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,6 @@
 # Contributors
 
+* [0xjah](https://github.com/0xjah)
 * [adamtlangley](https://github.com/adamtlangley)
 * [adilsoybali](https://github.com/adilsoybali)
 * [AverageSecurityGuy](https://github.com/averagesecurityguy)

--- a/main.go
+++ b/main.go
@@ -47,6 +47,40 @@ func (m *wordlistFlag) Set(value string) error {
 	return nil
 }
 
+// singleUseFlags is the set of flags that should only be provided once.
+// Flags that are intentionally multi-use (e.g. -H, -w, -b, -acc, -acs, -enc,
+// -input-cmd, -cookie, -d/-data/-data-ascii/-data-binary aliases) are excluded.
+var singleUseFlags = []string{
+	"X", "u", "x", "o", "of", "od", "t", "rate", "timeout", "p",
+	"maxtime", "maxtime-job", "mode", "recursion-depth", "recursion-strategy",
+	"replay-proxy", "request", "request-proto", "config", "debug-log",
+	"audit-log", "scraperfile", "scrapers", "input-shell", "input-num",
+	"mc", "ml", "mr", "ms", "mt", "mw",
+	"fc", "fl", "fr", "fs", "ft", "fw",
+	"fmode", "mmode", "ack", "acs", "sni", "search",
+	"cc", "ck", "e",
+}
+
+// warnDuplicateFlags scans os.Args for flags that appear more than once
+// but should only be provided once, and prints a warning for each duplicate.
+func warnDuplicateFlags() {
+	counts := make(map[string]int)
+	for _, arg := range os.Args[1:] {
+		// Strip leading dashes to get the flag name (handles both -flag and --flag)
+		trimmed := strings.TrimLeft(arg, "-")
+		// Only count the flag name part (before any = sign)
+		name := strings.SplitN(trimmed, "=", 2)[0]
+		if name != "" && name != arg { // it was actually a flag (had a dash)
+			counts[name]++
+		}
+	}
+	for _, name := range singleUseFlags {
+		if counts[name] > 1 {
+			fmt.Fprintf(os.Stderr, "[WARN] Flag -%s was provided %d times. Only the last value will be used.\n", name, counts[name])
+		}
+	}
+}
+
 // ParseFlags parses the command line flags and (re)populates the ConfigOptions struct
 func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	var ignored bool
@@ -141,6 +175,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.Var(&wordlists, "w", "Wordlist file path and (optional) keyword separated by colon. eg. '/path/to/wordlist:KEYWORD'")
 	flag.Var(&encoders, "enc", "Encoders for keywords, eg. 'FUZZ:urlencode b64encode'")
 	flag.Usage = Usage
+	warnDuplicateFlags()
 	flag.Parse()
 
 	opts.General.AutoCalibrationStrings = autocalibrationstrings


### PR DESCRIPTION
Fixes confusion from repeated single-use flags (e.g. -X PUT ... -X PUT).

Scan os.Args before flag.Parse() and print warnings when single-use flags are provided multiple times.

# Description

Please add a short description of pull request contents.
If this PR addresses an existing issue, please add the issue number below.

Fixes: #818

## Additonally

- [x] If this is the first time you are contributing to ffuf, add your name to CONTRIBUTORS.md.
The file should be alphabetically ordered.
- [x] Add a short description of the fix to CHANGELOG.md

Thanks for contributing to ffuf :)