### PR TITLE
Detect terminal width and shorten progress line on narrow terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - Fix a bug in autocalibration strategy merging, when two files have the same strategy key
     - Fix a bug in -or, causing output to not to be written in any case
     - Fix panic when setting rate to 0 in the interactive console
+    - Detect terminal width and render a shorter progress line when the full one would not fit, fixing the wrap-then-overwrite corruption on narrow terminals
   
 - v2.1.0
   - New

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -167,6 +167,14 @@ func (s *Stdoutput) Progress(status ffuf.Progress) {
 		return
 	}
 
+	fmt.Fprintf(os.Stderr, "%s%s", TERMINAL_CLEAR_LINE, formatProgress(status, terminalWidth()))
+}
+
+// formatProgress returns the progress line for the given status, picking the
+// widest variant that fits within width columns. When width <= 0 (e.g. stderr
+// is not a tty, or detection failed) the full variant is returned so output to
+// pipes/files is unchanged.
+func formatProgress(status ffuf.Progress, width int) string {
 	dur := time.Since(status.StartedAt)
 	runningSecs := int(dur / time.Second)
 	var reqRate int64
@@ -182,7 +190,26 @@ func (s *Stdoutput) Progress(status ffuf.Progress) {
 	dur -= mins * time.Minute
 	secs := dur / time.Second
 
-	fmt.Fprintf(os.Stderr, "%s:: Progress: [%d/%d] :: Job [%d/%d] :: %d req/sec :: Duration: [%d:%02d:%02d] :: Errors: %d ::", TERMINAL_CLEAR_LINE, status.ReqCount, status.ReqTotal, status.QueuePos, status.QueueTotal, reqRate, hours, mins, secs, status.ErrorCount)
+	full := fmt.Sprintf(":: Progress: [%d/%d] :: Job [%d/%d] :: %d req/sec :: Duration: [%d:%02d:%02d] :: Errors: %d ::",
+		status.ReqCount, status.ReqTotal, status.QueuePos, status.QueueTotal, reqRate, hours, mins, secs, status.ErrorCount)
+	if width <= 0 || len(full) <= width {
+		return full
+	}
+
+	medium := fmt.Sprintf(":: [%d/%d] %d r/s %d:%02d:%02d Errs:%d",
+		status.ReqCount, status.ReqTotal, reqRate, hours, mins, secs, status.ErrorCount)
+	if len(medium) <= width {
+		return medium
+	}
+
+	tiny := fmt.Sprintf(":: [%d/%d]", status.ReqCount, status.ReqTotal)
+	if len(tiny) <= width {
+		return tiny
+	}
+
+	// Last resort: truncate so we never overflow the terminal width and
+	// trigger the wrap-then-overwrite corruption from issue #166.
+	return tiny[:width]
 }
 
 func (s *Stdoutput) Info(infostring string) {

--- a/pkg/output/stdout_test.go
+++ b/pkg/output/stdout_test.go
@@ -1,0 +1,67 @@
+package output
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+func TestFormatProgressFitsWidth(t *testing.T) {
+	status := ffuf.Progress{
+		StartedAt:  time.Now().Add(-15 * time.Second),
+		ReqCount:   1234,
+		ReqTotal:   12345,
+		ReqSec:     78,
+		QueuePos:   2,
+		QueueTotal: 3,
+		ErrorCount: 9,
+	}
+
+	cases := []struct {
+		name  string
+		width int
+	}{
+		{"unknown_width_returns_full", 0},
+		{"wide_terminal_returns_full", 200},
+		{"narrow_120", 120},
+		{"narrow_80", 80},
+		{"narrow_50", 50},
+		{"narrow_30", 30},
+		{"narrow_15", 15},
+		{"narrow_5", 5},
+		{"narrow_1", 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := formatProgress(status, tc.width)
+			if strings.ContainsAny(out, "\n\r") {
+				t.Fatalf("output must not contain newlines or carriage returns: %q", out)
+			}
+			if tc.width > 0 && len(out) > tc.width {
+				t.Fatalf("width=%d but len(output)=%d: %q", tc.width, len(out), out)
+			}
+		})
+	}
+}
+
+func TestFormatProgressFullVariantContent(t *testing.T) {
+	status := ffuf.Progress{
+		StartedAt:  time.Now().Add(-1 * time.Second),
+		ReqCount:   100,
+		ReqTotal:   200,
+		ReqSec:     50,
+		QueuePos:   1,
+		QueueTotal: 1,
+		ErrorCount: 0,
+	}
+
+	out := formatProgress(status, 0)
+	for _, want := range []string{"Progress:", "[100/200]", "Job [1/1]", "50 req/sec", "Errors: 0"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("full progress output missing %q: %q", want, out)
+		}
+	}
+}

--- a/pkg/output/termsize.go
+++ b/pkg/output/termsize.go
@@ -1,0 +1,20 @@
+//go:build !windows
+// +build !windows
+
+package output
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// terminalWidth returns the width of the terminal attached to stderr in
+// columns, or 0 if it cannot be determined (e.g. stderr is not a tty).
+func terminalWidth() int {
+	ws, err := unix.IoctlGetWinsize(int(os.Stderr.Fd()), unix.TIOCGWINSZ)
+	if err != nil {
+		return 0
+	}
+	return int(ws.Col)
+}

--- a/pkg/output/termsize_windows.go
+++ b/pkg/output/termsize_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+// +build windows
+
+package output
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// terminalWidth returns the width of the terminal attached to stderr in
+// columns, or 0 if it cannot be determined (e.g. stderr is not a console).
+func terminalWidth() int {
+	var info windows.ConsoleScreenBufferInfo
+	if err := windows.GetConsoleScreenBufferInfo(windows.Handle(os.Stderr.Fd()), &info); err != nil {
+		return 0
+	}
+	return int(info.Window.Right - info.Window.Left + 1)
+}


### PR DESCRIPTION
The progress line written to stderr in `Stdoutput.Progress` is ~100 characters wide. On terminals narrower than that, it wraps onto the next line and the next refresh's `\r` returns the cursor to the start of the wrapped line instead of the start of the original line, producing the corrupted output reported in #166:

```
:: Progress: [646/6245] :: Job [1/1] :: 80 req/sec :: Duration: [0:00:08] :: Err:: Progress: [675/6245] :: Job [1/1] :: 84 req/sec :: Duration: [0:00:08] :: Err...
```

This detects the terminal width via `ioctl(TIOCGWINSZ)` on POSIX and `GetConsoleScreenBufferInfo` on Windows (both via the existing `golang.org/x/sys` dependency) and picks the widest of three progressively shorter progress line variants that fits:

1. `:: Progress: [N/T] :: Job [Q/QT] :: R req/sec :: Duration: [h:mm:ss] :: Errors: E ::` (full)
2. `:: [N/T] R r/s h:mm:ss Errs:E` (medium)
3. `:: [N/T]` (tiny — truncated to width if even this is too long)

When the terminal width cannot be determined (stderr is not a tty, or detection fails), the full variant is used so output to pipes and files is unchanged. Existing behavior for `-s` / quiet mode is unchanged.

The progress formatting was extracted into a `formatProgress(status, width)` helper so it can be unit-tested at arbitrary widths without a real tty. The new tests verify that no variant ever exceeds the requested width and that the full variant retains the original content.

Fixes #166