### PR TITLE
MD5 response filtering and calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - master
   - New
     - Added audit logging functionality
+    - Aded `-sh` flag to display MD5 hash of the response body
+    - Added `-fhf` flag to filter responses by MD5 hash (comma-separated)
   - Changed
     - Fix a bug in autocalibration strategy merging, when two files have the same strategy key
     - Fix a bug in -or, causing output to not to be written in any case

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@
 * [helpermika](https://github.com/helpermika)
 * [h1x](https://github.com/h1x-lnx)
 * [Ice3man543](https://github.com/Ice3man543)
+* [InternetD0g](https://github.com/InternetD0g)
 * [JamTookTheBait](https://github.com/JamTookTheBait)
 * [jimen0](https://github.com/jimen0)
 * [joohoi](https://github.com/joohoi)

--- a/help.go
+++ b/help.go
@@ -61,7 +61,7 @@ func Usage() {
 		Description:   "",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"ac", "acc", "ack", "ach", "acs", "c", "config", "json", "maxtime", "maxtime-job", "noninteractive", "p", "rate", "scraperfile", "scrapers", "search", "s", "sa", "se", "sf", "t", "v", "V"},
+		ExpectedFlags: []string{"ac", "acc", "ack", "ach", "acs", "c", "config", "json", "maxtime", "maxtime-job", "noninteractive", "p", "rate", "scraperfile", "scrapers", "search", "s", "sa", "se", "sf","sh","t", "v", "V"},
 	}
 	u_compat := UsageSection{
 		Name:          "COMPATIBILITY OPTIONS",
@@ -82,7 +82,7 @@ func Usage() {
 		Description:   "Filters for the response filtering.",
 		Flags:         make([]UsageFlag, 0),
 		Hidden:        false,
-		ExpectedFlags: []string{"fmode", "fc", "fl", "fr", "fs", "ft", "fw"},
+		ExpectedFlags: []string{"fmode", "fc", "fl", "fr", "fs", "ft", "fw", "fhf"},
 	}
 	u_input := UsageSection{
 		Name:          "INPUT OPTIONS",

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.BoolVar(&opts.General.StopOnAll, "sa", opts.General.StopOnAll, "Stop on all error cases. Implies -sf and -se.")
 	flag.BoolVar(&opts.General.StopOnErrors, "se", opts.General.StopOnErrors, "Stop on spurious errors")
 	flag.BoolVar(&opts.General.Verbose, "v", opts.General.Verbose, "Verbose output, printing full URL and redirect location (if any) with the results.")
+	flag.BoolVar(&opts.General.ShowHash, "sh", opts.General.ShowHash, "Show MD5 hash of response body in output")
 	flag.BoolVar(&opts.HTTP.FollowRedirects, "r", opts.HTTP.FollowRedirects, "Follow redirects")
 	flag.BoolVar(&opts.HTTP.IgnoreBody, "ignore-body", opts.HTTP.IgnoreBody, "Do not fetch the response content.")
 	flag.BoolVar(&opts.HTTP.Raw, "raw", opts.HTTP.Raw, "Do not encode URI")
@@ -103,6 +104,7 @@ func ParseFlags(opts *ffuf.ConfigOptions) *ffuf.ConfigOptions {
 	flag.StringVar(&opts.Filter.Status, "fc", opts.Filter.Status, "Filter HTTP status codes from response. Comma separated list of codes and ranges")
 	flag.StringVar(&opts.Filter.Time, "ft", opts.Filter.Time, "Filter by number of milliseconds to the first response byte, either greater or less than. EG: >100 or <100")
 	flag.StringVar(&opts.Filter.Words, "fw", opts.Filter.Words, "Filter by amount of words in response. Comma separated list of word counts and ranges")
+	flag.StringVar(&opts.Filter.Hash, "fhf", opts.Filter.Hash, "Filter by MD5 hash of response body")
 	flag.StringVar(&opts.General.Delay, "p", opts.General.Delay, "Seconds of `delay` between requests, or a range of random delay. For example \"0.1\" or \"0.1-2.0\"")
 	flag.StringVar(&opts.General.Searchhash, "search", opts.General.Searchhash, "Search for a FFUFHASH payload from ffuf history")
 	flag.StringVar(&opts.HTTP.Data, "d", opts.HTTP.Data, "POST data")
@@ -383,6 +385,11 @@ func SetupFilters(parseOpts *ffuf.ConfigOptions, conf *ffuf.Config) error {
 		if err := conf.MatcherManager.AddFilter("time", parseOpts.Filter.Time, false); err != nil {
 			errs.Add(err)
 		}
+	}
+	if parseOpts.Filter.Hash != "" {
+		if err := conf.MatcherManager.AddFilter("hash", parseOpts.Filter.Hash, false); err != nil {
+			errs.Add(err)
+    		}
 	}
 	if parseOpts.Matcher.Size != "" {
 		if err := conf.MatcherManager.AddMatcher("size", parseOpts.Matcher.Size); err != nil {

--- a/pkg/ffuf/config.go
+++ b/pkg/ffuf/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	DirSearchCompat           bool                  `json:"dirsearch_compatibility"`
 	Encoders                  []string              `json:"encoders"`
 	Extensions                []string              `json:"extensions"`
+	FilterHash                string                `json:"filter_hash"`
 	FilterMode                string                `json:"fmode"`
 	FollowRedirects           bool                  `json:"follow_redirects"`
 	Headers                   map[string]string     `json:"headers"`
@@ -56,6 +57,7 @@ type Config struct {
 	RequestProto              string                `json:"requestproto"`
 	ScraperFile               string                `json:"scraperfile"`
 	Scrapers                  string                `json:"scrapers"`
+	ShowHash                  bool                  `json:"show_hash"`
 	SNI                       string                `json:"sni"`
 	StopOn403                 bool                  `json:"stop_403"`
 	StopOnAll                 bool                  `json:"stop_all"`

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -113,4 +113,5 @@ type Result struct {
 	ResultFile       string              `json:"resultfile"`
 	Host             string              `json:"host"`
 	HTMLColor        string              `json:"-"`
+	ResponseHash     string              `json:"response_hash"`
 }

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -63,6 +63,7 @@ type GeneralOptions struct {
 	Rate                      int      `json:"rate"`
 	ScraperFile               string   `json:"scraperfile"`
 	Scrapers                  string   `json:"scrapers"`
+	ShowHash                  bool     `json:"show_hash"`
 	Searchhash                string   `json:"-"`
 	ShowVersion               bool     `toml:"-" json:"-"`
 	StopOn403                 bool     `json:"stop_on_403"`
@@ -96,6 +97,7 @@ type OutputOptions struct {
 }
 
 type FilterOptions struct {
+	Hash   string `json:"hash"`
 	Mode   string `json:"mode"`
 	Lines  string `json:"lines"`
 	Regexp string `json:"regexp"`
@@ -541,6 +543,8 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	conf.Verbose = parseOpts.General.Verbose
 	conf.Json = parseOpts.General.Json
 	conf.Http2 = parseOpts.HTTP.Http2
+	conf.ShowHash = parseOpts.General.ShowHash
+	conf.FilterHash = parseOpts.Filter.Hash
 
 	// Check that fmode and mmode have sane values
 	valid_opmodes := []string{"and", "or"}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -71,6 +71,9 @@ func NewFilterByName(name string, value string) (ffuf.FilterProvider, error) {
 	if name == "time" {
 		return NewTimeFilter(value)
 	}
+	if name == "hash" {
+		return NewHashFilter(value)
+	}
 	return nil, fmt.Errorf("Could not create filter with name %s", name)
 }
 

--- a/pkg/filter/hash.go
+++ b/pkg/filter/hash.go
@@ -1,0 +1,54 @@
+package filter
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+type HashFilter struct {
+	Value []string
+}
+
+func NewHashFilter(value string) (ffuf.FilterProvider, error) {
+	var hashes []string
+	for _, h := range strings.Split(value, ",") {
+		hashes = append(hashes, strings.TrimSpace(h))
+	}
+	return &HashFilter{Value: hashes}, nil
+}
+
+func (f *HashFilter) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Value string `json:"value"`
+	}{
+		Value: strings.Join(f.Value, ","),
+	})
+}
+
+func CalculateHash(resp *ffuf.Response) string {
+	hasher := md5.New()
+	hasher.Write(resp.Data)
+	return fmt.Sprintf("%x", hasher.Sum(nil))
+}
+
+func (f *HashFilter) Filter(response *ffuf.Response) (bool, error) {
+	currentHash := CalculateHash(response)
+	for _, targetHash := range f.Value {
+		if currentHash == targetHash {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (f *HashFilter) Repr() string {
+	return strings.Join(f.Value, ",")
+}
+
+func (f *HashFilter) ReprVerbose() string {
+	return fmt.Sprintf("Response hash: %s", f.Repr())
+}

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -324,6 +324,11 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 	for k, v := range resp.Request.Input {
 		inputs[k] = v
 	}
+	var responseHash string
+	if s.config.ShowHash || s.config.FilterHash != "" {
+		responseHash = filter.CalculateHash(&resp)
+	}
+	
 	sResult := ffuf.Result{
 		Input:            inputs,
 		Position:         resp.Request.Position,
@@ -338,7 +343,7 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 		Duration:         resp.Duration,
 		ResultFile:       resp.ResultFile,
 		Host:             resp.Request.Host,
-		ResponseHash:     filter.CalculateHash(&resp),
+		ResponseHash:     responseHash,
 	}
 	s.CurrentResults = append(s.CurrentResults, sResult)
 	// Output the result

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/filter"
 )
 
 const (
@@ -337,6 +338,7 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 		Duration:         resp.Duration,
 		ResultFile:       resp.ResultFile,
 		Host:             resp.Request.Host,
+		ResponseHash:     filter.CalculateHash(&resp),
 	}
 	s.CurrentResults = append(s.CurrentResults, sResult)
 	// Output the result
@@ -446,7 +448,11 @@ func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 }
 
 func (s *Stdoutput) resultNormal(res ffuf.Result) {
-	resnormal := fmt.Sprintf("%s%s%-23s [Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, s.colorize(res.StatusCode), s.prepareInputsOneLine(res), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), ANSI_CLEAR)
+	prefix := ""
+	if s.config.ShowHash {
+		prefix = fmt.Sprintf("[%s] ", res.ResponseHash)
+	}
+	resnormal := fmt.Sprintf("%s%s%-23s [Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, s.colorize(res.StatusCode), prefix + s.prepareInputsOneLine(res), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), ANSI_CLEAR)
 	fmt.Println(resnormal)
 }
 


### PR DESCRIPTION
# Description

In this PR functionality to calculate MD5 hash of the response body and to filter responses by their MD5 hash has been added!
In some situations relying on content length filtering might be misleading.
One of the cases appeared in my practice: default error page was sharing the same content length with the flag-containing response, so this feature guarantees the user won't miss any unique responses!

Added two  new flags:

**-sh** (Show Hash) - calculates an displays MD5 hash of the response body
**-fhf** (Filter Hash) - calculates the hash for filtering logic, enabling the tool to automatically hide responses that match a specific MD5 hash

Enabling hash calculation slows down the performance for approx 15% from what I've tested, but this is the price to pay.
If flags are not in use - performance is not affected


## Additonally

Running ffuf with `-fhf` calculates the hash two times, it does not significantly affect the performance though. Running ffuf with both `-sh` and `-fhf` also calculates the hash two times.  
##
_This is my first contribution, hope it helps someone!_ 