### PR TITLE
Fix gzip-bomb OOM: bound decompressed response body size (CWE-409)

### DIFF
--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -176,31 +176,32 @@ func (r *SimpleRunner) Execute(req *ffuf.Request) (ffuf.Response, error) {
 		resp.Request.Raw = string(rawreq)
 		resp.Raw = string(rawresp)
 	}
-	var bodyReader io.ReadCloser
-	if httpresp.Header.Get("Content-Encoding") == "gzip" {
-		bodyReader, err = gzip.NewReader(httpresp.Body)
-		if err != nil {
-			// fallback to raw data
-			bodyReader = httpresp.Body
-		}
-	} else if httpresp.Header.Get("Content-Encoding") == "br" {
-		bodyReader = io.NopCloser(brotli.NewReader(httpresp.Body))
-		if err != nil {
-			// fallback to raw data
-			bodyReader = httpresp.Body
-		}
-	} else if httpresp.Header.Get("Content-Encoding") == "deflate" {
+	var bodyReader io.Reader = httpresp.Body
+	switch httpresp.Header.Get("Content-Encoding") {
+	case "gzip":
+		if zr, zerr := gzip.NewReader(httpresp.Body); zerr == nil {
+			bodyReader = zr
+		} // else: fall back to the raw (undecoded) body
+	case "br":
+		bodyReader = brotli.NewReader(httpresp.Body)
+	case "deflate":
 		bodyReader = flate.NewReader(httpresp.Body)
-		if err != nil {
-			// fallback to raw data
-			bodyReader = httpresp.Body
-		}
-	} else {
-		bodyReader = httpresp.Body
 	}
 
-	if respbody, err := io.ReadAll(bodyReader); err == nil {
-		resp.ContentLength = int64(len(string(respbody)))
+	// Bound the DECOMPRESSED read. The Content-Length guard above is not
+	// sufficient on its own: a malicious server can send a small compressed body
+	// (or a chunked response with no Content-Length, or one the transport
+	// transparently decoded and stripped the headers from) that expands to
+	// gigabytes. LimitReader caps the bytes we ever pull from the possibly-
+	// decompressing reader, so a decompression bomb only materialises
+	// MAX_DOWNLOAD_SIZE+1 bytes in memory instead of OOM-killing the process.
+	limited := io.LimitReader(bodyReader, int64(MAX_DOWNLOAD_SIZE)+1)
+	if respbody, rerr := io.ReadAll(limited); rerr == nil {
+		if len(respbody) > MAX_DOWNLOAD_SIZE {
+			resp.Cancelled = true
+			return resp, nil
+		}
+		resp.ContentLength = int64(len(respbody))
 		resp.Data = respbody
 	}
 

--- a/pkg/runner/simple_test.go
+++ b/pkg/runner/simple_test.go
@@ -1,0 +1,125 @@
+package runner
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+// gzipBomb returns a gzip stream that decompresses to `decompressed` bytes of
+// zeros. The compressed form is tiny (zeros compress ~1000x), so the test moves
+// almost no data over the wire while forcing a large decompression.
+func gzipBomb(t *testing.T, decompressed int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	chunk := make([]byte, 1<<20) // 1 MiB of zeros, reused
+	for written := 0; written < decompressed; {
+		n := len(chunk)
+		if r := decompressed - written; r < n {
+			n = r
+		}
+		if _, err := zw.Write(chunk[:n]); err != nil {
+			t.Fatalf("gzip write: %v", err)
+		}
+		written += n
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func runnerFor(t *testing.T, url string) (ffuf.RunnerProvider, ffuf.Request) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	conf := ffuf.NewConfig(ctx, cancel)
+	conf.Method = "GET"
+	runner := NewSimpleRunner(&conf, false)
+	req := ffuf.NewRequest(&conf)
+	req.Method = "GET"
+	req.Url = url
+	return runner, req
+}
+
+// A malicious server returning a decompression bomb must not be read into memory
+// unbounded. The response is capped at MAX_DOWNLOAD_SIZE and marked Cancelled
+// rather than OOM-killing the process. Regression test for the gzip-bomb DoS
+// (CWE-409): before the fix, io.ReadAll on the decompressed stream had no bound.
+func TestExecute_GzipBombIsCapped(t *testing.T) {
+	const decompressed = 64 << 20 // 64 MiB, well over the 5 MiB cap
+	bomb := gzipBomb(t, decompressed)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Length", strconv.Itoa(len(bomb)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(bomb)
+	}))
+	defer srv.Close()
+
+	// Path 1: default client. The transport adds Accept-Encoding: gzip itself,
+	// transparently decodes, and strips Content-Encoding/Content-Length, so the
+	// header-based guard never fires. The LimitReader is what saves us.
+	t.Run("transparent transport decode", func(t *testing.T) {
+		runner, req := runnerFor(t, srv.URL+"/")
+		resp, err := runner.Execute(&req)
+		if err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if !resp.Cancelled {
+			t.Fatalf("expected cancelled response, got %d bytes of data", len(resp.Data))
+		}
+		if len(resp.Data) > MAX_DOWNLOAD_SIZE {
+			t.Fatalf("read %d bytes, must not exceed MAX_DOWNLOAD_SIZE (%d)", len(resp.Data), MAX_DOWNLOAD_SIZE)
+		}
+	})
+
+	// Path 2: client sends its own Accept-Encoding, so the transport does NOT
+	// auto-decode. Content-Encoding: gzip survives and Content-Length reflects the
+	// small compressed size, passing the guard, so the manual decoder + LimitReader
+	// must catch it.
+	t.Run("manual decode with preserved headers", func(t *testing.T) {
+		runner, req := runnerFor(t, srv.URL+"/")
+		req.Headers["Accept-Encoding"] = "gzip"
+		resp, err := runner.Execute(&req)
+		if err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if !resp.Cancelled {
+			t.Fatalf("expected cancelled response, got %d bytes of data", len(resp.Data))
+		}
+		if len(resp.Data) > MAX_DOWNLOAD_SIZE {
+			t.Fatalf("read %d bytes, must not exceed MAX_DOWNLOAD_SIZE (%d)", len(resp.Data), MAX_DOWNLOAD_SIZE)
+		}
+	})
+}
+
+// A normal, small response must still be read in full and not cancelled, so the
+// size cap does not regress ordinary fuzzing behaviour.
+func TestExecute_NormalResponseUnaffected(t *testing.T) {
+	body := []byte("hello world")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	runner, req := runnerFor(t, srv.URL+"/")
+	resp, err := runner.Execute(&req)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if resp.Cancelled {
+		t.Fatal("normal response must not be cancelled")
+	}
+	if !bytes.Equal(resp.Data, body) {
+		t.Fatalf("body = %q, want %q", resp.Data, body)
+	}
+}


### PR DESCRIPTION
## Summary

A malicious target server can crash ffuf (OOM) on default configuration by returning a decompression bomb. The response size guard in `pkg/runner/simple.go` only checks the server-supplied `Content-Length`, which reflects the *compressed* size and is absent when the response is chunked or transparently decompressed by `net/http`'s transport. `io.ReadAll` then reads the fully *decompressed* stream with no bound, so a ~1 MB compressed body that expands to gigabytes exhausts memory and the process is OOM-killed.

Reported via private disclosure by **João Tricta (Hakai Offensive Security)**. Assessed by the reporter as CVSS 3.1 7.5 (`AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`), CWE-409.

## Affected paths (all bypass the guard)

1. **gzip, default config** — the transport adds `Accept-Encoding: gzip` itself, transparently decodes, and strips `Content-Encoding`/`Content-Length`, so the guard is skipped and the already-decoded body is read unbounded.
2. **brotli/deflate (or gzip with headers preserved)** — `Content-Length` is the small compressed size, passes the 5 MB check, then manual decompression feeds an unbounded `io.ReadAll`.
3. **chunked / no Content-Length** — `strconv.Atoi("")` errors, so the guard is skipped entirely.

## Fix

Wrap the (possibly decompressing) body reader in `io.LimitReader(bodyReader, MAX_DOWNLOAD_SIZE+1)` before `io.ReadAll`, and mark responses over the cap as `Cancelled`, consistent with the existing `Content-Length` guard. Because the limit is applied to the *decompressed* reader, peak memory stays ~5 MB regardless of `Content-Encoding`, chunked framing, or transport-level decompression. Also cleans up a stale-`err` check in the brotli/deflate branches that could skip decompression when `Content-Length` was absent.

**Behavioral impact:** negligible for normal use. ffuf already intends a 5 MB cap (`MAX_DOWNLOAD_SIZE`); this makes it actually enforced on decompressed size. The only change is that a response whose compressed size is under 5 MB but decompresses to over 5 MB is now `Cancelled` rather than read in full, which matches how `Content-Length > 5 MB` is already handled.

## Tests

Adds `pkg/runner/simple_test.go` with regression coverage: a 64 MiB gzip bomb asserted `Cancelled` and capped at `MAX_DOWNLOAD_SIZE` via both the transparent-transport-decode and manual-decode paths, plus a control that a normal response is read in full and not cancelled. Verified the bomb tests **fail without the fix** (read the full 64 MiB into memory) and pass with it.
