### PR TITLE
ci: migrate goreleaser to v2 and add tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /ffuf
 .idea
+/dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - id: ffuf
     binary: ffuf
@@ -5,11 +7,7 @@ builds:
       - -trimpath
     env:
       - CGO_ENABLED=0
-    asmflags:
-      - all=-trimpath={{.Env.GOPATH}}
-    gcflags:
-      - all=-trimpath={{.Env.GOPATH}}
-    ldflags: |
+    ldflags: >-
       -s -w -X github.com/ffuf/ffuf/v2/pkg/ffuf.VERSION_APPENDIX= -extldflags '-static'
     goos:
       - linux
@@ -19,21 +17,43 @@ builds:
       - darwin
     goarch:
       - amd64
-      - 386
+      - "386"
       - arm
       - arm64
     ignore:
       - goos: freebsd
         goarch: arm64
+      # Go no longer supports 32-bit ARM on Windows (unsupported GOOS/GOARCH pair
+      # as of modern toolchains), so windows/arm can't be built anymore.
+      - goos: windows
+        goarch: arm
 
 archives:
   - id: tgz
-    format: tar.gz
-    replacements:
-        darwin: macOS
+    formats: [tar.gz]
+    # v2 removed archive `replacements`; reproduce the darwin->macOS naming
+    # (e.g. ffuf_2.2.0_macOS_arm64.tar.gz, ffuf_2.2.0_linux_armv6.tar.gz) here.
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_
+      {{- .Arch }}{{ with .Arm }}v{{ . }}{{ end }}
     format_overrides:
-        - goos: windows
-          format: zip
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
 
 signs:
   - artifacts: checksum
+    args:
+      - "--batch"
+      - "-u"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+
+release:
+  prerelease: auto


### PR DESCRIPTION
Migrates `.goreleaser.yml` to the v2 schema (fixes the `only version: 2 configuration files are supported` error from goreleaser 2.x) and adds `.github/workflows/release.yml` so signed cross-platform archives are built in CI on a `v*` tag push, instead of locally.

## Config changes
- Add `version: 2`.
- Replace the removed archive `replacements` with a `name_template` that keeps the `darwin`->`macOS` naming (e.g. `ffuf_2.2.0_macOS_arm64.tar.gz`, `ffuf_2.2.0_linux_armv6.tar.gz`).
- Drop the GOPATH-templated `asmflags`/`gcflags`; `-trimpath` already trims build paths and `GOPATH` isn't set in CI.
- Switch checksum signing to a batch GPG invocation driven by `GPG_FINGERPRINT`, matching the CI import-gpg step.
- Ignore `windows/arm`, which modern Go no longer supports (drops the `windows_armv6` archive; all other targets unchanged).

## Workflow
`.github/workflows/release.yml` (modeled on acme-dns): on a `v*` tag push, import the GPG key and run `goreleaser release --clean`. Requires repo secrets `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE`.

Validated locally: `goreleaser check` passes and a full snapshot build produces all 16 archives with correct names.