### PR TITLE
ci: pin GPG signing subkey fingerprint in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          fingerprint: D4060D6A12CE425E19693F3EF860001E7E0108E9
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
  The import-gpg action defaulted to the primary key and tried to preset the
  passphrase for its keygrip, which is only a stub (primary secret isn't exported
  to CI), failing with 'Not found <GPG Agent>'. Pin the signing subkey fingerprint
  so the action presets that keygrip and goreleaser signs with the subkey.

