### PR TITLE
Derive release version from git tag; git-<date>-<hash> for dev builds

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,8 +18,9 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          # golangci-lint < v1.45 cannot parse Go 1.18+ compiler export data,
+          # so it is pinned to the last v1 release that supports modern Go.
+          version: v1.64.8
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags: >-
-      -s -w -X github.com/ffuf/ffuf/v2/pkg/ffuf.VERSION_APPENDIX= -extldflags '-static'
+      -s -w -X github.com/ffuf/ffuf/v2/pkg/ffuf.VERSION={{ .Version }} -X github.com/ffuf/ffuf/v2/pkg/ffuf.VERSION_APPENDIX= -extldflags '-static'
     goos:
       - linux
       - windows

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ffuf/ffuf/v2
 
-go 1.17
+go 1.18
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0

--- a/help.go
+++ b/help.go
@@ -123,7 +123,7 @@ func Usage() {
 		}
 	})
 
-	fmt.Printf("Fuzz Faster U Fool - v%s\n\n", ffuf.Version())
+	fmt.Printf("Fuzz Faster U Fool - %s\n\n", ffuf.FormattedVersion())
 
 	// Print out the sections
 	for _, section := range sections {

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -353,7 +353,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 		err := parseRawRequest(parseOpts, &conf)
 		if err != nil {
 			errmsg := fmt.Sprintf("Could not parse raw request: %s", err)
-			errs.Add(fmt.Errorf(errmsg))
+			errs.Add(fmt.Errorf("%s", errmsg))
 		}
 	}
 
@@ -556,11 +556,11 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	}
 	if !fmode_found {
 		errmsg := fmt.Sprintf("Unrecognized value for parameter fmode: %s, valid values are: and, or", parseOpts.Filter.Mode)
-		errs.Add(fmt.Errorf(errmsg))
+		errs.Add(fmt.Errorf("%s", errmsg))
 	}
 	if !mmode_found {
 		errmsg := fmt.Sprintf("Unrecognized value for parameter mmode: %s, valid values are: and, or", parseOpts.Matcher.Mode)
-		errs.Add(fmt.Errorf(errmsg))
+		errs.Add(fmt.Errorf("%s", errmsg))
 	}
 	conf.FilterMode = parseOpts.Filter.Mode
 	conf.MatcherMode = parseOpts.Matcher.Mode
@@ -586,14 +586,14 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 		if provider.Template != "" {
 			if !templatePresent(provider.Template, &conf) {
 				errmsg := fmt.Sprintf("Template %s defined, but not found in pairs in headers, method, URL or POST data.", provider.Template)
-				errs.Add(fmt.Errorf(errmsg))
+				errs.Add(fmt.Errorf("%s", errmsg))
 			} else {
 				newInputProviders = append(newInputProviders, provider)
 			}
 		} else {
 			if !keywordPresent(provider.Keyword, &conf) {
 				errmsg := fmt.Sprintf("Keyword %s defined, but not found in headers, method, URL or POST data.", provider.Keyword)
-				_, _ = fmt.Fprintf(os.Stderr, "%s\n", fmt.Errorf(errmsg))
+				_, _ = fmt.Fprintf(os.Stderr, "%s\n", fmt.Errorf("%s", errmsg))
 			} else {
 				newInputProviders = append(newInputProviders, provider)
 			}
@@ -612,7 +612,7 @@ func ConfigFromOptions(parseOpts *ConfigOptions, ctx context.Context, cancel con
 	if parseOpts.HTTP.Recursion {
 		if !strings.HasSuffix(conf.Url, "FUZZ") {
 			errmsg := "When using -recursion the URL (-u) must end with FUZZ keyword."
-			errs.Add(fmt.Errorf(errmsg))
+			errs.Add(fmt.Errorf("%s", errmsg))
 		}
 	}
 

--- a/pkg/ffuf/util.go
+++ b/pkg/ffuf/util.go
@@ -6,7 +6,9 @@ import (
 	"math/rand"
 	"net/url"
 	"os"
+	"runtime/debug"
 	"strings"
+	"time"
 )
 
 // used for random string generation in calibration function
@@ -77,9 +79,68 @@ func HostURLFromRequest(req Request) string {
 	return u.Host + trimpath
 }
 
-// Version returns the ffuf version string
+// Version returns the ffuf version string.
+//
+// Release builds have their version injected via -ldflags by goreleaser: VERSION
+// is set to the git tag and VERSION_APPENDIX is emptied, so they report a plain
+// semantic version like "2.2.0" with no manual constant bump required.
+//
+// Builds from a source checkout (VERSION_APPENDIX still set) instead report a
+// "git-<UTC date>-<short commit>" identifier derived from the VCS metadata that
+// `go build` embeds into the binary, e.g. "git-20260613-aabbccdd". When that
+// metadata is unavailable it falls back to VERSION+VERSION_APPENDIX.
 func Version() string {
+	if VERSION_APPENDIX == "" {
+		return VERSION
+	}
+	if v := gitVersion(); v != "" {
+		return v
+	}
 	return fmt.Sprintf("%s%s", VERSION, VERSION_APPENDIX)
+}
+
+// gitVersion assembles a "git-<date>-<shorthash>" string from the VCS metadata
+// that `go build` stamps into the binary. It returns "" when the metadata is
+// missing (e.g. a module build outside of a repository).
+func gitVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	var revision string
+	var modified bool
+	var stamp time.Time
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.time":
+			stamp, _ = time.Parse(time.RFC3339, s.Value)
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+	if revision == "" || stamp.IsZero() {
+		return ""
+	}
+	if len(revision) > 8 {
+		revision = revision[:8]
+	}
+	dirty := ""
+	if modified {
+		dirty = "-dirty"
+	}
+	return fmt.Sprintf("git-%s-%s%s", stamp.UTC().Format("20060102"), revision, dirty)
+}
+
+// FormattedVersion returns the version prepared for display. Release builds are
+// prefixed with "v" (e.g. "v2.2.0"); development builds are returned unprefixed
+// (e.g. "git-20260613-aabbccdd") since a "v" reads as noise there.
+func FormattedVersion() string {
+	if VERSION_APPENDIX == "" {
+		return "v" + Version()
+	}
+	return Version()
 }
 
 func CheckOrCreateConfigDir() error {

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -47,8 +47,8 @@ func NewStdoutput(conf *ffuf.Config) *Stdoutput {
 }
 
 func (s *Stdoutput) Banner() {
-	version := strings.ReplaceAll(ffuf.Version(), "<3", fmt.Sprintf("%s<3%s", ANSI_RED, ANSI_CLEAR))
-	fmt.Fprintf(os.Stderr, "%s\n       v%s\n%s\n\n", BANNER_HEADER, version, BANNER_SEP)
+	version := strings.ReplaceAll(ffuf.FormattedVersion(), "<3", fmt.Sprintf("%s<3%s", ANSI_RED, ANSI_CLEAR))
+	fmt.Fprintf(os.Stderr, "%s\n       %s\n%s\n\n", BANNER_HEADER, version, BANNER_SEP)
 	printOption([]byte("Method"), []byte(s.config.Method))
 	printOption([]byte("URL"), []byte(s.config.Url))
 


### PR DESCRIPTION
## Summary

Fixes #901.

Since releases moved to CI, the release binary's reported version was no longer being bumped. Goreleaser only blanked `VERSION_APPENDIX`; it never injected the actual version, so `ffuf.Version()` fell back to the hardcoded `VERSION` constant. The manual constant bump that used to compensate for this got dropped in the move to CI — so a binary built from tag `vX.Y.Z` shipped inside a `X.Y.Z` tarball but still reported the stale constant on `ffuf -V`.

## Changes

- **`.goreleaser.yml`** — inject `VERSION` from the git tag (`-X ...pkg/ffuf.VERSION={{ .Version }}`) alongside the existing appendix blanking. Release versions are now driven by the tag with no manual step.
- **`pkg/ffuf/util.go`** — `Version()` now branches: release builds (appendix emptied by ldflags) return the plain semver; source checkouts derive a `git-<UTC date>-<short commit>` identifier from the VCS metadata `go build` embeds (`debug.ReadBuildInfo()`), e.g. `git-20260613-aabbccdd`, with a `-dirty` suffix for a modified tree. Falls back to `VERSION+VERSION_APPENDIX` when no VCS metadata is present.
- **`help.go` / `pkg/output/stdout.go`** — version display routed through a new `FormattedVersion()` helper that keeps the `v` prefix for release semver (`v2.2.0`) and drops it for dev builds (`git-...`), where a leading `v` reads as noise.

## Verification

| Build | `ffuf -V` / banner |
|-------|--------------------|
| `go build` from checkout | `git-20260711-338753ec-dirty` |
| release ldflags (`VERSION=2.2.0`, appendix empty) | `v2.2.0` |

`go vet ./...` clean; `goreleaser check` passes.

The date is the HEAD **commit** time (`vcs.time`), not build time, so dev version strings are reproducible for a given commit.
