### PR TITLE
Fix terminal control characters leaking into redirected output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     - Fix a bug in autocalibration strategy merging, when two files have the same strategy key
     - Fix a bug in -or, causing output to not to be written in any case
     - Fix panic when setting rate to 0 in the interactive console
+    - Fix terminal control characters being written to stdout/stderr when they're redirected to a file or pipe
   
 - v2.1.0
   - New

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,7 @@
 * [l4yton](https://github.com/l4yton)
 * [lc](https://github.com/lc)
 * [mprencipe](https://github.com/mprencipe)
+* [munzzyy](https://github.com/munzzyy)
 * [nnwakelam](https://twitter.com/nnwakelam)
 * [noraj](https://pwn.by/noraj)
 * [oh6hay](https://github.com/oh6hay)

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -51,7 +51,10 @@ func NewStdoutput(conf *ffuf.Config) *Stdoutput {
 }
 
 // isTerminal reports whether f is an interactive terminal, as opposed to a
-// file or a pipe.
+// regular file or a pipe. This also treats other character devices (e.g.
+// /dev/null) as terminals, which is harmless here since it only affects
+// whether a handful of extra control bytes get written to a destination
+// that isn't going to be read back anyway.
 func isTerminal(f *os.File) bool {
 	fi, err := f.Stat()
 	if err != nil {

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -27,10 +27,12 @@ const (
 )
 
 type Stdoutput struct {
-	config         *ffuf.Config
-	fuzzkeywords   []string
-	Results        []ffuf.Result
-	CurrentResults []ffuf.Result
+	config           *ffuf.Config
+	fuzzkeywords     []string
+	Results          []ffuf.Result
+	CurrentResults   []ffuf.Result
+	stdoutIsTerminal bool
+	stderrIsTerminal bool
 }
 
 func NewStdoutput(conf *ffuf.Config) *Stdoutput {
@@ -39,11 +41,53 @@ func NewStdoutput(conf *ffuf.Config) *Stdoutput {
 	outp.Results = make([]ffuf.Result, 0)
 	outp.CurrentResults = make([]ffuf.Result, 0)
 	outp.fuzzkeywords = make([]string, 0)
+	outp.stdoutIsTerminal = isTerminal(os.Stdout)
+	outp.stderrIsTerminal = isTerminal(os.Stderr)
 	for _, ip := range conf.InputProviders {
 		outp.fuzzkeywords = append(outp.fuzzkeywords, ip.Keyword)
 	}
 	sort.Strings(outp.fuzzkeywords)
 	return &outp
+}
+
+// isTerminal reports whether f is an interactive terminal, as opposed to a
+// file or a pipe.
+func isTerminal(f *os.File) bool {
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// stderrClear returns the terminal control sequence used to redraw the
+// current line, or an empty string when stderr isn't an interactive
+// terminal. Without this, redirecting stderr to a file or another process
+// leaves raw control characters in the output.
+func (s *Stdoutput) stderrClear() string {
+	if s.stderrIsTerminal {
+		return TERMINAL_CLEAR_LINE
+	}
+	return ""
+}
+
+// stdoutClear is the stdout equivalent of stderrClear, used when printing
+// results that overwrite the in-progress progress bar line.
+func (s *Stdoutput) stdoutClear() string {
+	if s.stdoutIsTerminal {
+		return TERMINAL_CLEAR_LINE
+	}
+	return ""
+}
+
+// ansiClear returns the ANSI reset code used to close a color started by
+// colorize(), or an empty string when -c wasn't requested. Without this,
+// result lines carry a trailing reset code even when nothing was colored.
+func (s *Stdoutput) ansiClear() string {
+	if s.config.Colors {
+		return ANSI_CLEAR
+	}
+	return ""
 }
 
 func (s *Stdoutput) Banner() {
@@ -182,7 +226,7 @@ func (s *Stdoutput) Progress(status ffuf.Progress) {
 	dur -= mins * time.Minute
 	secs := dur / time.Second
 
-	fmt.Fprintf(os.Stderr, "%s:: Progress: [%d/%d] :: Job [%d/%d] :: %d req/sec :: Duration: [%d:%02d:%02d] :: Errors: %d ::", TERMINAL_CLEAR_LINE, status.ReqCount, status.ReqTotal, status.QueuePos, status.QueueTotal, reqRate, hours, mins, secs, status.ErrorCount)
+	fmt.Fprintf(os.Stderr, "%s:: Progress: [%d/%d] :: Job [%d/%d] :: %d req/sec :: Duration: [%d:%02d:%02d] :: Errors: %d ::", s.stderrClear(), status.ReqCount, status.ReqTotal, status.QueuePos, status.QueueTotal, reqRate, hours, mins, secs, status.ErrorCount)
 }
 
 func (s *Stdoutput) Info(infostring string) {
@@ -190,9 +234,9 @@ func (s *Stdoutput) Info(infostring string) {
 		fmt.Fprintf(os.Stderr, "%s", infostring)
 	} else {
 		if !s.config.Colors {
-			fmt.Fprintf(os.Stderr, "%s[INFO] %s\n\n", TERMINAL_CLEAR_LINE, infostring)
+			fmt.Fprintf(os.Stderr, "%s[INFO] %s\n\n", s.stderrClear(), infostring)
 		} else {
-			fmt.Fprintf(os.Stderr, "%s[%sINFO%s] %s\n\n", TERMINAL_CLEAR_LINE, ANSI_BLUE, ANSI_CLEAR, infostring)
+			fmt.Fprintf(os.Stderr, "%s[%sINFO%s] %s\n\n", s.stderrClear(), ANSI_BLUE, ANSI_CLEAR, infostring)
 		}
 	}
 }
@@ -202,9 +246,9 @@ func (s *Stdoutput) Error(errstring string) {
 		fmt.Fprintf(os.Stderr, "%s", errstring)
 	} else {
 		if !s.config.Colors {
-			fmt.Fprintf(os.Stderr, "%s[ERR] %s\n", TERMINAL_CLEAR_LINE, errstring)
+			fmt.Fprintf(os.Stderr, "%s[ERR] %s\n", s.stderrClear(), errstring)
 		} else {
-			fmt.Fprintf(os.Stderr, "%s[%sERR%s] %s\n", TERMINAL_CLEAR_LINE, ANSI_RED, ANSI_CLEAR, errstring)
+			fmt.Fprintf(os.Stderr, "%s[%sERR%s] %s\n", s.stderrClear(), ANSI_RED, ANSI_CLEAR, errstring)
 		}
 	}
 }
@@ -214,15 +258,15 @@ func (s *Stdoutput) Warning(warnstring string) {
 		fmt.Fprintf(os.Stderr, "%s", warnstring)
 	} else {
 		if !s.config.Colors {
-			fmt.Fprintf(os.Stderr, "%s[WARN] %s\n", TERMINAL_CLEAR_LINE, warnstring)
+			fmt.Fprintf(os.Stderr, "%s[WARN] %s\n", s.stderrClear(), warnstring)
 		} else {
-			fmt.Fprintf(os.Stderr, "%s[%sWARN%s] %s\n", TERMINAL_CLEAR_LINE, ANSI_RED, ANSI_CLEAR, warnstring)
+			fmt.Fprintf(os.Stderr, "%s[%sWARN%s] %s\n", s.stderrClear(), ANSI_RED, ANSI_CLEAR, warnstring)
 		}
 	}
 }
 
 func (s *Stdoutput) Raw(output string) {
-	fmt.Fprintf(os.Stderr, "%s%s", TERMINAL_CLEAR_LINE, output)
+	fmt.Fprintf(os.Stderr, "%s%s", s.stderrClear(), output)
 }
 
 func (s *Stdoutput) writeToAll(filename string, config *ffuf.Config, res []ffuf.Result) error {
@@ -413,32 +457,32 @@ func (s *Stdoutput) resultQuiet(res ffuf.Result) {
 func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 	var res_hdr, res_str string
 	res_str = "%s%s    * %s: %s\n"
-	res_hdr = fmt.Sprintf("%s%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, s.colorize(res.StatusCode), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), ANSI_CLEAR)
+	res_hdr = fmt.Sprintf("%s%s[Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", s.stdoutClear(), s.colorize(res.StatusCode), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), s.ansiClear())
 	reslines := ""
 	if s.config.Verbose {
-		reslines = fmt.Sprintf("%s%s| URL | %s\n", reslines, TERMINAL_CLEAR_LINE, res.Url)
+		reslines = fmt.Sprintf("%s%s| URL | %s\n", reslines, s.stdoutClear(), res.Url)
 		redirectLocation := res.RedirectLocation
 		if redirectLocation != "" {
-			reslines = fmt.Sprintf("%s%s| --> | %s\n", reslines, TERMINAL_CLEAR_LINE, redirectLocation)
+			reslines = fmt.Sprintf("%s%s| --> | %s\n", reslines, s.stdoutClear(), redirectLocation)
 		}
 	}
 	if res.ResultFile != "" {
-		reslines = fmt.Sprintf("%s%s| RES | %s\n", reslines, TERMINAL_CLEAR_LINE, res.ResultFile)
+		reslines = fmt.Sprintf("%s%s| RES | %s\n", reslines, s.stdoutClear(), res.ResultFile)
 	}
 	for _, k := range s.fuzzkeywords {
 		if ffuf.StrInSlice(k, s.config.CommandKeywords) {
 			// If we're using external command for input, display the position instead of input
-			reslines = fmt.Sprintf(res_str, reslines, TERMINAL_CLEAR_LINE, k, strconv.Itoa(res.Position))
+			reslines = fmt.Sprintf(res_str, reslines, s.stdoutClear(), k, strconv.Itoa(res.Position))
 		} else {
 			// Wordlist input
-			reslines = fmt.Sprintf(res_str, reslines, TERMINAL_CLEAR_LINE, k, res.Input[k])
+			reslines = fmt.Sprintf(res_str, reslines, s.stdoutClear(), k, res.Input[k])
 		}
 	}
 	if len(res.ScraperData) > 0 {
-		reslines = fmt.Sprintf("%s%s| SCR |\n", reslines, TERMINAL_CLEAR_LINE)
+		reslines = fmt.Sprintf("%s%s| SCR |\n", reslines, s.stdoutClear())
 		for k, vslice := range res.ScraperData {
 			for _, v := range vslice {
-				reslines = fmt.Sprintf(res_str, reslines, TERMINAL_CLEAR_LINE, k, v)
+				reslines = fmt.Sprintf(res_str, reslines, s.stdoutClear(), k, v)
 			}
 		}
 	}
@@ -446,7 +490,7 @@ func (s *Stdoutput) resultMultiline(res ffuf.Result) {
 }
 
 func (s *Stdoutput) resultNormal(res ffuf.Result) {
-	resnormal := fmt.Sprintf("%s%s%-23s [Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", TERMINAL_CLEAR_LINE, s.colorize(res.StatusCode), s.prepareInputsOneLine(res), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), ANSI_CLEAR)
+	resnormal := fmt.Sprintf("%s%s%-23s [Status: %d, Size: %d, Words: %d, Lines: %d, Duration: %dms]%s", s.stdoutClear(), s.colorize(res.StatusCode), s.prepareInputsOneLine(res), res.StatusCode, res.ContentLength, res.ContentWords, res.ContentLines, res.Duration.Milliseconds(), s.ansiClear())
 	fmt.Println(resnormal)
 }
 
@@ -455,7 +499,7 @@ func (s *Stdoutput) resultJson(res ffuf.Result) {
 	if err != nil {
 		s.Error(err.Error())
 	} else {
-		fmt.Fprint(os.Stderr, TERMINAL_CLEAR_LINE)
+		fmt.Fprint(os.Stderr, s.stderrClear())
 		fmt.Println(string(resBytes))
 	}
 }

--- a/pkg/output/stdout_test.go
+++ b/pkg/output/stdout_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
@@ -14,13 +15,24 @@ import (
 // fn and returns everything written to it.
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
-	orig := os.Stdout
+	return captureStream(t, &os.Stdout, fn)
+}
+
+// captureStderr is the os.Stderr equivalent of captureStdout.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	return captureStream(t, &os.Stderr, fn)
+}
+
+func captureStream(t *testing.T, stream **os.File, fn func()) string {
+	t.Helper()
+	orig := *stream
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("failed to create pipe: %s", err)
 	}
-	os.Stdout = w
-	defer func() { os.Stdout = orig }()
+	*stream = w
+	defer func() { *stream = orig }()
 
 	fn()
 
@@ -63,5 +75,79 @@ func TestResultOutputKeepsControlCharsOnATerminal(t *testing.T) {
 
 	if !strings.Contains(out, TERMINAL_CLEAR_LINE) {
 		t.Errorf("result line written to a terminal stdout is missing the terminal clear-line sequence: %q", out)
+	}
+}
+
+func TestErrorOutputOmitsControlCharsWhenStderrIsNotATerminal(t *testing.T) {
+	conf := &ffuf.Config{}
+	outp := NewStdoutput(conf)
+	outp.stderrIsTerminal = false
+
+	out := captureStderr(t, func() {
+		outp.Error("something broke")
+	})
+
+	if strings.Contains(out, TERMINAL_CLEAR_LINE) {
+		t.Errorf("Error() written to a non-terminal stderr still contains the terminal clear-line sequence: %q", out)
+	}
+}
+
+func TestErrorOutputKeepsControlCharsOnATerminal(t *testing.T) {
+	conf := &ffuf.Config{}
+	outp := NewStdoutput(conf)
+	outp.stderrIsTerminal = true
+
+	out := captureStderr(t, func() {
+		outp.Error("something broke")
+	})
+
+	if !strings.Contains(out, TERMINAL_CLEAR_LINE) {
+		t.Errorf("Error() written to a terminal stderr is missing the terminal clear-line sequence: %q", out)
+	}
+}
+
+func TestProgressOutputOmitsControlCharsWhenStderrIsNotATerminal(t *testing.T) {
+	conf := &ffuf.Config{}
+	outp := NewStdoutput(conf)
+	outp.stderrIsTerminal = false
+
+	out := captureStderr(t, func() {
+		outp.Progress(ffuf.Progress{StartedAt: time.Now()})
+	})
+
+	if strings.Contains(out, TERMINAL_CLEAR_LINE) {
+		t.Errorf("Progress() written to a non-terminal stderr still contains the terminal clear-line sequence: %q", out)
+	}
+}
+
+func TestResultOutputOmitsColorResetWhenColorsAreDisabled(t *testing.T) {
+	conf := &ffuf.Config{Colors: false}
+	outp := NewStdoutput(conf)
+	outp.stdoutIsTerminal = true // isolate this from the clear-line behavior above
+
+	res := ffuf.Result{StatusCode: 200, ContentLength: 42, ContentWords: 3, ContentLines: 1}
+
+	out := captureStdout(t, func() {
+		outp.PrintResult(res)
+	})
+
+	if strings.Contains(out, ANSI_CLEAR) {
+		t.Errorf("result line printed without -c still carries an ANSI reset code: %q", out)
+	}
+}
+
+func TestResultOutputKeepsColorResetWhenColorsAreEnabled(t *testing.T) {
+	conf := &ffuf.Config{Colors: true}
+	outp := NewStdoutput(conf)
+	outp.stdoutIsTerminal = false // -c output is opt-in and shouldn't depend on terminal detection
+
+	res := ffuf.Result{StatusCode: 200, ContentLength: 42, ContentWords: 3, ContentLines: 1}
+
+	out := captureStdout(t, func() {
+		outp.PrintResult(res)
+	})
+
+	if !strings.Contains(out, ANSI_CLEAR) {
+		t.Errorf("result line printed with -c is missing its ANSI reset code: %q", out)
 	}
 }

--- a/pkg/output/stdout_test.go
+++ b/pkg/output/stdout_test.go
@@ -1,0 +1,67 @@
+package output
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+// captureStdout redirects os.Stdout to an in-memory pipe for the duration of
+// fn and returns everything written to it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %s", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestResultOutputOmitsControlCharsWhenStdoutIsNotATerminal(t *testing.T) {
+	conf := &ffuf.Config{}
+	outp := NewStdoutput(conf)
+	// A pipe (as used by captureStdout, and as ffuf sees when its stdout is
+	// redirected to a file with `>`) is never a terminal.
+	outp.stdoutIsTerminal = false
+
+	res := ffuf.Result{StatusCode: 200, ContentLength: 42, ContentWords: 3, ContentLines: 1}
+
+	out := captureStdout(t, func() {
+		outp.PrintResult(res)
+	})
+
+	if strings.Contains(out, TERMINAL_CLEAR_LINE) {
+		t.Errorf("result line written to a non-terminal stdout still contains the terminal clear-line sequence: %q", out)
+	}
+}
+
+func TestResultOutputKeepsControlCharsOnATerminal(t *testing.T) {
+	conf := &ffuf.Config{}
+	outp := NewStdoutput(conf)
+	// Simulate stdout being an interactive terminal, which is when the
+	// progress-bar-clearing sequence is actually needed.
+	outp.stdoutIsTerminal = true
+
+	res := ffuf.Result{StatusCode: 200, ContentLength: 42, ContentWords: 3, ContentLines: 1}
+
+	out := captureStdout(t, func() {
+		outp.PrintResult(res)
+	})
+
+	if !strings.Contains(out, TERMINAL_CLEAR_LINE) {
+		t.Errorf("result line written to a terminal stdout is missing the terminal clear-line sequence: %q", out)
+	}
+}

--- a/pkg/output/stdout_test.go
+++ b/pkg/output/stdout_test.go
@@ -38,7 +38,9 @@ func captureStream(t *testing.T, stream **os.File, fn func()) string {
 
 	w.Close()
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed to read captured output: %s", err)
+	}
 	return buf.String()
 }
 


### PR DESCRIPTION
# Description

`Progress`, `Info`, `Error`, `Warning`, `Raw` and every result line in
`pkg/output/stdout.go` unconditionally prepend the terminal line-clear
sequence (`\r\x1b[2K` on Linux/macOS, `\r\r` on Windows), and result
lines always append a trailing `\x1b[0m` color reset even when `-c`
was never passed. That's needed to redraw the progress bar on an
interactive terminal, but ffuf has no way to know it's not on one -
redirecting stdout/stderr to a file or a pipe just writes those raw
control bytes into the output instead.

Reproduced on current master:

```
$ ffuf -w wordlist.txt -u http://127.0.0.1:8899/FUZZ -mc 200 > out.txt
$ python3 -c "print(open('out.txt','rb').read())"
b'\r\x1b[2Ka                       [Status: 200, ...]\x1b[0m\n...'
```

Fix: track whether stdout/stderr are actual terminals (`os.ModeCharDevice`,
no new dependency) once in `NewStdoutput`, and only emit the clear-line
sequence and the color reset when writing to one. Explicit `-c` output
is unaffected in either case, since that's the user opting in
regardless of where the output goes.

After the fix, same command:

```
b'a                       [Status: 200, ...]\nb ...\nc ...\n'
```

Verified interactive behavior (progress bar redraw) is unchanged by
running the binary against a pty - the clear-line sequence is still
emitted there, only non-terminal output changes.

Fixes: #285

## Additonally

- [x] Added `munzzyy` to `CONTRIBUTORS.md`
- [x] Added a line to `CHANGELOG.md`
