### PR TITLE
Testing suite: mock-target integration harness + engine race fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,33 @@ jobs:
       - name: go test (race)
         run: go test -race ./... -count=1
 
+  # Non-gating: wall-clock timing and rate-limit tests behind the `timing` build
+  # tag. Kept off the required gate because timing is noisy on shared runners.
+  timing:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: go test -tags=timing
+        run: go test -tags=timing ./... -count=1
+
+  # Informational coverage. Not gated; ratchet a threshold in once it settles.
+  coverage:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: coverage
+        run: |
+          go test -coverprofile=coverage.out ./... >/dev/null
+          go tool cover -func=coverage.out | tail -1
+
   # Characterization goldens (help output, etc.) must be regenerated and
   # committed with any change that affects them.
   golden:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,17 @@ on:
       - master
   pull_request:
 jobs:
-  # Build, vet, and run the whole suite across the supported Go floor + latest on
-  # all three OSes. The race detector runs on Linux and macOS (it needs cgo);
-  # Windows runs the suite without it.
+  # Build, vet, and run the whole suite with the race detector across the
+  # supported Go floor + latest, on Linux and macOS. Windows is intentionally
+  # not in the matrix yet: several existing tests are not Windows-clean (the
+  # help-golden test deadlocks on Windows' small stdout pipe buffer, and a couple
+  # of output tests assume POSIX terminal control), so enabling it would need
+  # those fixed first.
   test:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         go: ['1.18', 'stable']
     runs-on: ${{ matrix.os }}
     steps:
@@ -23,11 +26,7 @@ jobs:
       - name: go vet
         run: go vet ./...
       - name: go test (race)
-        if: runner.os != 'Windows'
         run: go test -race ./... -count=1
-      - name: go test
-        if: runner.os == 'Windows'
-        run: go test ./... -count=1
 
   # Characterization goldens (help output, etc.) must be regenerated and
   # committed with any change that affects them.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,15 +5,39 @@ on:
       - master
   pull_request:
 jobs:
+  # Build, vet, and run the whole suite across the supported Go floor + latest on
+  # all three OSes. The race detector runs on Linux and macOS (it needs cgo);
+  # Windows runs the suite without it.
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go: ['1.18', 'stable']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - name: go vet
+        run: go vet ./...
+      - name: go test (race)
+        if: runner.os != 'Windows'
+        run: go test -race ./... -count=1
+      - name: go test
+        if: runner.os == 'Windows'
+        run: go test ./... -count=1
+
+  # Characterization goldens (help output, etc.) must be regenerated and
+  # committed with any change that affects them.
+  golden:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: stable
-      - name: go test
-        run: go test ./...
       - name: characterization goldens are current
         run: |
           go test -run Characterization -update-golden .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,11 +28,11 @@ jobs:
       - name: go test (race)
         run: go test -race ./... -count=1
 
-  # Non-gating: wall-clock timing and rate-limit tests behind the `timing` build
-  # tag. Kept off the required gate because timing is noisy on shared runners.
+  # Gating: wall-clock timing and rate-limit tests behind the `timing` build tag.
+  # The margins are wide (500ms/800ms) so the required gate stays stable while
+  # still protecting -rate and the time matcher.
   timing:
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -66,6 +66,52 @@ func NewJob(conf *Config) *Job {
 	return &j
 }
 
+// The per-run counters and run-state flags below are mutated by the execution
+// loop and worker goroutines while the progress goroutine and the interrupt
+// handler read them concurrently. ErrorMutex serializes every access. All access
+// goes through these leaf helpers, which never call one another, so they cannot
+// deadlock (including CheckStop, which reads via getters and then calls Stop).
+
+func (j *Job) incCounter()      { j.ErrorMutex.Lock(); j.Counter++; j.ErrorMutex.Unlock() }
+func (j *Job) setCounter(n int) { j.ErrorMutex.Lock(); j.Counter = n; j.ErrorMutex.Unlock() }
+func (j *Job) getCounter() int  { j.ErrorMutex.Lock(); defer j.ErrorMutex.Unlock(); return j.Counter }
+
+func (j *Job) getErrorCounter() int {
+	j.ErrorMutex.Lock()
+	defer j.ErrorMutex.Unlock()
+	return j.ErrorCounter
+}
+func (j *Job) getSpuriousErrorCounter() int {
+	j.ErrorMutex.Lock()
+	defer j.ErrorMutex.Unlock()
+	return j.SpuriousErrorCounter
+}
+func (j *Job) getCount403() int { j.ErrorMutex.Lock(); defer j.ErrorMutex.Unlock(); return j.Count403 }
+func (j *Job) getCount429() int { j.ErrorMutex.Lock(); defer j.ErrorMutex.Unlock(); return j.Count429 }
+
+func (j *Job) setRunning(v bool)    { j.ErrorMutex.Lock(); j.Running = v; j.ErrorMutex.Unlock() }
+func (j *Job) isRunning() bool      { j.ErrorMutex.Lock(); defer j.ErrorMutex.Unlock(); return j.Running }
+func (j *Job) setRunningJob(v bool) { j.ErrorMutex.Lock(); j.RunningJob = v; j.ErrorMutex.Unlock() }
+func (j *Job) isRunningJob() bool {
+	j.ErrorMutex.Lock()
+	defer j.ErrorMutex.Unlock()
+	return j.RunningJob
+}
+func (j *Job) setPaused(v bool) { j.ErrorMutex.Lock(); j.Paused = v; j.ErrorMutex.Unlock() }
+func (j *Job) isPaused() bool   { j.ErrorMutex.Lock(); defer j.ErrorMutex.Unlock(); return j.Paused }
+func (j *Job) setSkipQueue(v bool) {
+	j.ErrorMutex.Lock()
+	j.skipQueue = v
+	j.ErrorMutex.Unlock()
+}
+func (j *Job) isSkipQueue() bool {
+	j.ErrorMutex.Lock()
+	defer j.ErrorMutex.Unlock()
+	return j.skipQueue
+}
+func (j *Job) setError(s string) { j.ErrorMutex.Lock(); j.Error = s; j.ErrorMutex.Unlock() }
+func (j *Job) getError() string  { j.ErrorMutex.Lock(); defer j.ErrorMutex.Unlock(); return j.Error }
+
 // incError increments the error counter
 func (j *Job) incError() {
 	j.ErrorMutex.Lock()
@@ -130,8 +176,8 @@ func (j *Job) Start() {
 	rand.Seed(time.Now().UnixNano())
 	defer j.Stop()
 
-	j.Running = true
-	j.RunningJob = true
+	j.setRunning(true)
+	j.setRunningJob(true)
 	//Show banner if not running in silent mode
 	if !j.Config.Quiet {
 		j.Output.Banner()
@@ -141,7 +187,7 @@ func (j *Job) Start() {
 	for j.jobsInQueue() {
 		j.prepareQueueJob()
 		j.Reset(true)
-		j.RunningJob = true
+		j.setRunningJob(true)
 		j.startExecution()
 	}
 
@@ -154,8 +200,8 @@ func (j *Job) Start() {
 // Reset resets the counters and wordlist position for a job
 func (j *Job) Reset(cycle bool) {
 	j.Input.Reset()
-	j.Counter = 0
-	j.skipQueue = false
+	j.setCounter(0)
+	j.setSkipQueue(false)
 	j.startTimeJob = time.Now()
 	if cycle {
 		j.Output.Cycle()
@@ -188,7 +234,7 @@ func (j *Job) prepareQueueJob() {
 
 // SkipQueue allows to skip the current job and advance to the next queued recursion job
 func (j *Job) SkipQueue() {
-	j.skipQueue = true
+	j.setSkipQueue(true)
 }
 
 func (j *Job) sleepIfNeeded() {
@@ -211,8 +257,8 @@ func (j *Job) sleepIfNeeded() {
 
 // Pause pauses the job process
 func (j *Job) Pause() {
-	if !j.Paused {
-		j.Paused = true
+	if !j.isPaused() {
+		j.setPaused(true)
 		j.pauseWg.Add(1)
 		j.Output.Info("------ PAUSING ------")
 	}
@@ -220,8 +266,8 @@ func (j *Job) Pause() {
 
 // Resume resumes the job process
 func (j *Job) Resume() {
-	if j.Paused {
-		j.Paused = false
+	if j.isPaused() {
+		j.setPaused(false)
 		j.Output.Info("------ RESUMING -----")
 		j.pauseWg.Done()
 	}
@@ -244,12 +290,12 @@ func (j *Job) startExecution() {
 	//Limiter blocks after reaching the buffer, ensuring limited concurrency
 	threadlimiter := make(chan bool, j.Config.Threads)
 
-	for j.Input.Next() && !j.skipQueue {
+	for j.Input.Next() && !j.isSkipQueue() {
 		// Check if we should stop the process
 		j.CheckStop()
 
-		if !j.Running {
-			defer j.Output.Warning(j.Error)
+		if !j.isRunning() {
+			defer j.Output.Warning(j.getError())
 			break
 		}
 		j.pauseWg.Wait()
@@ -263,7 +309,7 @@ func (j *Job) startExecution() {
 		nextInput["FFUFHASH"] = j.ffufHash(nextPosition)
 
 		wg.Add(1)
-		j.Counter++
+		j.incCounter()
 
 		go func() {
 			defer func() { <-threadlimiter }()
@@ -274,8 +320,8 @@ func (j *Job) startExecution() {
 			threadEnd := time.Now()
 			j.Rate.Tick(threadStart, threadEnd)
 		}()
-		if !j.RunningJob {
-			defer j.Output.Warning(j.Error)
+		if !j.isRunningJob() {
+			defer j.Output.Warning(j.getError())
 			return
 		}
 	}
@@ -288,9 +334,9 @@ func (j *Job) interruptMonitor() {
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		for range sigChan {
-			j.Error = "Caught keyboard interrupt (Ctrl-C)\n"
+			j.setError("Caught keyboard interrupt (Ctrl-C)\n")
 			// resume if paused
-			if j.Paused {
+			if j.isPaused() {
 				j.pauseWg.Done()
 			}
 			// Stop the job
@@ -302,16 +348,16 @@ func (j *Job) interruptMonitor() {
 func (j *Job) runBackgroundTasks(wg *sync.WaitGroup) {
 	defer wg.Done()
 	totalProgress := j.Input.Total()
-	for j.Counter <= totalProgress && !j.skipQueue {
+	for j.getCounter() <= totalProgress && !j.isSkipQueue() {
 		j.pauseWg.Wait()
-		if !j.Running {
+		if !j.isRunning() {
 			break
 		}
 		j.updateProgress()
-		if j.Counter == totalProgress {
+		if j.getCounter() == totalProgress {
 			return
 		}
-		if !j.RunningJob {
+		if !j.isRunningJob() {
 			return
 		}
 		time.Sleep(time.Millisecond * time.Duration(j.Config.ProgressFrequency))
@@ -321,12 +367,12 @@ func (j *Job) runBackgroundTasks(wg *sync.WaitGroup) {
 func (j *Job) updateProgress() {
 	prog := Progress{
 		StartedAt:  j.startTimeJob,
-		ReqCount:   j.Counter,
+		ReqCount:   j.getCounter(),
 		ReqTotal:   j.Input.Total(),
 		ReqSec:     j.Rate.CurrentRate(),
 		QueuePos:   j.queuepos,
 		QueueTotal: len(j.queuejobs),
-		ErrorCount: j.ErrorCounter,
+		ErrorCount: j.getErrorCounter(),
 	}
 	j.Output.Progress(prog)
 }
@@ -459,7 +505,7 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 		}
 	}
 
-	if j.SpuriousErrorCounter > 0 {
+	if j.getSpuriousErrorCounter() > 0 {
 		j.resetSpuriousErrors()
 	}
 	if j.Config.StopOn403 || j.Config.StopOnAll {
@@ -561,26 +607,27 @@ func (j *Job) handleDefaultRecursionJob(resp Response) {
 
 // CheckStop stops the job if stopping conditions are met
 func (j *Job) CheckStop() {
-	if j.Counter > 50 {
+	counter := j.getCounter()
+	if counter > 50 {
 		// We have enough samples
 		if j.Config.StopOn403 || j.Config.StopOnAll {
-			if float64(j.Count403)/float64(j.Counter) > 0.95 {
+			if float64(j.getCount403())/float64(counter) > 0.95 {
 				// Over 95% of requests are 403
-				j.Error = "Getting an unusual amount of 403 responses, exiting."
+				j.setError("Getting an unusual amount of 403 responses, exiting.")
 				j.Stop()
 			}
 		}
 		if j.Config.StopOnErrors || j.Config.StopOnAll {
-			if j.SpuriousErrorCounter > j.Config.Threads*2 {
+			if j.getSpuriousErrorCounter() > j.Config.Threads*2 {
 				// Most of the requests are erroring
-				j.Error = "Receiving spurious errors, exiting."
+				j.setError("Receiving spurious errors, exiting.")
 				j.Stop()
 			}
 
 		}
-		if j.Config.StopOnAll && (float64(j.Count429)/float64(j.Counter) > 0.2) {
+		if j.Config.StopOnAll && (float64(j.getCount429())/float64(counter) > 0.2) {
 			// Over 20% of responses are 429
-			j.Error = "Getting an unusual amount of 429 responses, exiting."
+			j.setError("Getting an unusual amount of 429 responses, exiting.")
 			j.Stop()
 		}
 	}
@@ -590,7 +637,7 @@ func (j *Job) CheckStop() {
 		dur := time.Since(j.startTime)
 		runningSecs := int(dur / time.Second)
 		if runningSecs >= j.Config.MaxTime {
-			j.Error = "Maximum running time for entire process reached, exiting."
+			j.setError("Maximum running time for entire process reached, exiting.")
 			j.Stop()
 		}
 	}
@@ -600,7 +647,7 @@ func (j *Job) CheckStop() {
 		dur := time.Since(j.startTimeJob)
 		runningSecs := int(dur / time.Second)
 		if runningSecs >= j.Config.MaxTimeJob {
-			j.Error = "Maximum running time for this job reached, continuing with next job if one exists."
+			j.setError("Maximum running time for this job reached, continuing with next job if one exists.")
 			j.Next()
 
 		}
@@ -609,11 +656,11 @@ func (j *Job) CheckStop() {
 
 // Stop the execution of the Job
 func (j *Job) Stop() {
-	j.Running = false
+	j.setRunning(false)
 	j.Config.Cancel()
 }
 
 // Stop current, resume to next
 func (j *Job) Next() {
-	j.RunningJob = false
+	j.setRunningJob(false)
 }

--- a/pkg/ffuf/rate.go
+++ b/pkg/ffuf/rate.go
@@ -34,6 +34,8 @@ func NewRateThrottle(conf *Config) *RateThrottle {
 
 // CurrentRate calculates requests/second value from circular list of rate
 func (r *RateThrottle) CurrentRate() int64 {
+	r.RateMutex.Lock()
+	defer r.RateMutex.Unlock()
 	n := r.rateCounter.Len()
 	lowest := int64(0)
 	highest := int64(0)
@@ -63,6 +65,8 @@ func (r *RateThrottle) CurrentRate() int64 {
 }
 
 func (r *RateThrottle) ChangeRate(rate int) {
+	r.RateMutex.Lock()
+	defer r.RateMutex.Unlock()
 	ratemicros := 0 // set default to 0, avoids integer divide by 0 error
 
 	if rate != 0 {

--- a/pkg/ffuf/valuerange_property_test.go
+++ b/pkg/ffuf/valuerange_property_test.go
@@ -1,0 +1,80 @@
+package ffuf
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"testing/quick"
+)
+
+// The range/value parsers back every numeric matcher and filter (-mc, -fc, -ms,
+// -fs, ...). These property tests assert their invariants hold across a wide
+// input space via testing/quick (stdlib, no dependency), not just a few examples.
+
+// A "a-b" range with a < b parses to exactly {a, b}; a >= b is an error (the
+// regex matches but ValueRangeFromString rejects min >= max).
+func TestValueRange_RangeInvariant(t *testing.T) {
+	f := func(a, b uint16) bool {
+		lo, hi := int64(a), int64(b)
+		vr, err := ValueRangeFromString(fmt.Sprintf("%d-%d", lo, hi))
+		if lo < hi {
+			return err == nil && vr.Min == lo && vr.Max == hi
+		}
+		return err != nil
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+// A single non-negative integer parses to the degenerate range {n, n}.
+func TestValueRange_SingleValueInvariant(t *testing.T) {
+	f := func(n uint32) bool {
+		vr, err := ValueRangeFromString(strconv.FormatUint(uint64(n), 10))
+		return err == nil && vr.Min == int64(n) && vr.Max == int64(n)
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+// Arbitrary input never panics (it returns an error for anything unparseable).
+func TestValueRange_NeverPanics(t *testing.T) {
+	f := func(s string) bool {
+		_, _ = ValueRangeFromString(s)
+		return true
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+// A single float initializes optRange to a non-range delay whose Min holds the
+// parsed value. (Max is intentionally left unset for a single value: sleepIfNeeded
+// only reads Min when IsRange is false.)
+func TestOptRange_SingleFloatInvariant(t *testing.T) {
+	f := func(whole uint16, frac uint8) bool {
+		val := fmt.Sprintf("%d.%02d", whole, frac%100)
+		want, _ := strconv.ParseFloat(val, 64)
+		var o optRange
+		if err := o.Initialize(val); err != nil {
+			return false
+		}
+		return o.HasDelay && !o.IsRange && o.Min == want
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+// Arbitrary input never panics optRange.Initialize.
+func TestOptRange_NeverPanics(t *testing.T) {
+	f := func(s string) bool {
+		var o optRange
+		_ = o.Initialize(s)
+		return true
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}

--- a/pkg/ffuf/valuerange_property_test.go
+++ b/pkg/ffuf/valuerange_property_test.go
@@ -2,10 +2,15 @@ package ffuf
 
 import (
 	"fmt"
+	"math/rand"
 	"strconv"
 	"testing"
 	"testing/quick"
 )
+
+// qcfg fixes the seed so a failure is reproducible (quick.Check with a nil config
+// seeds from time.Now, which is unreplayable) and raises the sample count.
+var qcfg = &quick.Config{Rand: rand.New(rand.NewSource(1)), MaxCount: 1000}
 
 // The range/value parsers back every numeric matcher and filter (-mc, -fc, -ms,
 // -fs, ...). These property tests assert their invariants hold across a wide
@@ -22,7 +27,7 @@ func TestValueRange_RangeInvariant(t *testing.T) {
 		}
 		return err != nil
 	}
-	if err := quick.Check(f, nil); err != nil {
+	if err := quick.Check(f, qcfg); err != nil {
 		t.Error(err)
 	}
 }
@@ -33,18 +38,19 @@ func TestValueRange_SingleValueInvariant(t *testing.T) {
 		vr, err := ValueRangeFromString(strconv.FormatUint(uint64(n), 10))
 		return err == nil && vr.Min == int64(n) && vr.Max == int64(n)
 	}
-	if err := quick.Check(f, nil); err != nil {
+	if err := quick.Check(f, qcfg); err != nil {
 		t.Error(err)
 	}
 }
 
-// Arbitrary input never panics (it returns an error for anything unparseable).
+// Arbitrary input never panics, and on success the returned range is always
+// well-formed (Min <= Max).
 func TestValueRange_NeverPanics(t *testing.T) {
 	f := func(s string) bool {
-		_, _ = ValueRangeFromString(s)
-		return true
+		vr, err := ValueRangeFromString(s)
+		return err != nil || vr.Min <= vr.Max
 	}
-	if err := quick.Check(f, nil); err != nil {
+	if err := quick.Check(f, qcfg); err != nil {
 		t.Error(err)
 	}
 }
@@ -62,19 +68,20 @@ func TestOptRange_SingleFloatInvariant(t *testing.T) {
 		}
 		return o.HasDelay && !o.IsRange && o.Min == want
 	}
-	if err := quick.Check(f, nil); err != nil {
+	if err := quick.Check(f, qcfg); err != nil {
 		t.Error(err)
 	}
 }
 
-// Arbitrary input never panics optRange.Initialize.
+// Arbitrary input never panics, and any non-empty value that initializes without
+// error must have HasDelay set (the contract of a successfully-parsed delay).
 func TestOptRange_NeverPanics(t *testing.T) {
 	f := func(s string) bool {
 		var o optRange
-		_ = o.Initialize(s)
-		return true
+		err := o.Initialize(s)
+		return err != nil || len(s) == 0 || o.HasDelay
 	}
-	if err := quick.Check(f, nil); err != nil {
+	if err := quick.Check(f, qcfg); err != nil {
 		t.Error(err)
 	}
 }

--- a/pkg/testtarget/server.go
+++ b/pkg/testtarget/server.go
@@ -159,7 +159,23 @@ func (t *Target) handle(w http.ResponseWriter, r *http.Request) {
 		forbidden(w)
 		return
 
-	// --- recursion tree -------------------------------------------------
+	// --- status decoupled from the payload -----------------------------
+	// The status code does not appear in the path or body, so a status matcher
+	// can be told apart from a payload/body matcher.
+	case strings.HasPrefix(p, "/map/"):
+		switch strings.TrimPrefix(p, "/map/") {
+		case "ok":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "mapped alpha")
+		case "bad":
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, "mapped gamma")
+		default:
+			notFound(w)
+		}
+		return
+
+	// --- recursion tree (greedy strategy) -------------------------------
 	case p == "/":
 		fmt.Fprint(w, "root")
 		return
@@ -168,6 +184,20 @@ func (t *Target) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	case p == "/admin/secret":
 		fmt.Fprint(w, "the secret")
+		return
+
+	// --- redirect-based directory (default recursion strategy) ----------
+	// A directory that redirects to itself + "/", which the default recursion
+	// strategy uses to detect a directory to descend into.
+	case p == "/rdir":
+		w.Header().Set("Location", "/rdir/")
+		w.WriteHeader(http.StatusMovedPermanently)
+		return
+	case p == "/rdir/":
+		fmt.Fprint(w, "rdir index")
+		return
+	case p == "/rdir/found":
+		fmt.Fprint(w, "found under rdir")
 		return
 	}
 

--- a/pkg/testtarget/server.go
+++ b/pkg/testtarget/server.go
@@ -180,16 +180,22 @@ func forbidden(w http.ResponseWriter) {
 }
 func notFound(w http.ResponseWriter) { w.WriteHeader(http.StatusNotFound); fmt.Fprint(w, "not found") }
 
+// maxTailInt bounds every path-derived integer. It is far above anything the
+// tests use and keeps the value that reaches size/word/line allocation from
+// being attacker-controlled (a request like /size/99999999999 is rejected
+// rather than allocating from an unbounded, path-supplied size).
+const maxTailInt = 1 << 20
+
 // tailInt parses the integer immediately following prefix in path. It requires
 // the remainder to be exactly an integer (no further path segments), so
-// /size/20 parses and /size/20/extra does not.
+// /size/20 parses and /size/20/extra does not, and enforces 0 <= n <= maxTailInt.
 func tailInt(path, prefix string) (int, bool) {
 	rest := strings.TrimPrefix(path, prefix)
 	if rest == "" || strings.Contains(rest, "/") {
 		return 0, false
 	}
 	n, err := strconv.Atoi(rest)
-	if err != nil {
+	if err != nil || n < 0 || n > maxTailInt {
 		return 0, false
 	}
 	return n, true

--- a/pkg/testtarget/server.go
+++ b/pkg/testtarget/server.go
@@ -1,0 +1,248 @@
+// Package testtarget provides a deterministic mock HTTP target for ffuf
+// integration tests. It models the response dimensions ffuf matches and filters
+// on (status code, body size, word count, line count, latency, reflection,
+// soft-404 baselines, redirects, request-gated endpoints, and a nested
+// directory tree for recursion) and records every request it receives.
+//
+// The server is hermetic: it binds to an ephemeral localhost port via
+// httptest, uses no randomness, and returns byte-identical responses for
+// identical requests. That determinism is what lets integration tests assert on
+// exact result sets. Point the real ffuf http runner at Target.URL and only the
+// target and the output sink are test doubles; the engine, runner, matchers and
+// filters are the real ones.
+package testtarget
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Recorded is one request the target received, exposed via Target.Requests so a
+// test can assert on what ffuf actually sent (method, headers, body, timing).
+type Recorded struct {
+	Method string
+	Path   string
+	Query  string
+	Header http.Header
+	Body   string
+	At     time.Time
+}
+
+// Target wraps an httptest.Server with a thread-safe request recorder.
+type Target struct {
+	*httptest.Server
+	mu       sync.Mutex
+	recorded []Recorded
+}
+
+// New starts a new deterministic target server. The caller must Close it.
+func New() *Target {
+	t := &Target{}
+	t.Server = httptest.NewServer(http.HandlerFunc(t.handle))
+	return t
+}
+
+// Requests returns a snapshot copy of every request received so far.
+func (t *Target) Requests() []Recorded {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]Recorded, len(t.recorded))
+	copy(out, t.recorded)
+	return out
+}
+
+// Count returns how many requests the target has received.
+func (t *Target) Count() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.recorded)
+}
+
+func (t *Target) handle(w http.ResponseWriter, r *http.Request) {
+	body := drain(r)
+	t.mu.Lock()
+	t.recorded = append(t.recorded, Recorded{
+		Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery,
+		Header: r.Header.Clone(), Body: body, At: time.Now(),
+	})
+	t.mu.Unlock()
+
+	p := r.URL.Path
+	switch {
+	// --- match/filter dimension endpoints -------------------------------
+	case strings.HasPrefix(p, "/status/"):
+		if code, ok := tailInt(p, "/status/"); ok {
+			w.WriteHeader(code)
+			fmt.Fprintf(w, "status %d", code)
+			return
+		}
+	case strings.HasPrefix(p, "/size/"):
+		if n, ok := tailInt(p, "/size/"); ok {
+			w.Write(filled(n))
+			return
+		}
+	case strings.HasPrefix(p, "/words/"):
+		if n, ok := tailInt(p, "/words/"); ok {
+			w.Write([]byte(words(n)))
+			return
+		}
+	case strings.HasPrefix(p, "/lines/"):
+		if n, ok := tailInt(p, "/lines/"); ok {
+			w.Write([]byte(lines(n)))
+			return
+		}
+	case strings.HasPrefix(p, "/sleep/"):
+		if ms, ok := tailInt(p, "/sleep/"); ok {
+			time.Sleep(time.Duration(ms) * time.Millisecond)
+			fmt.Fprintf(w, "slept %d", ms)
+			return
+		}
+	case strings.HasPrefix(p, "/reflect/"):
+		val := strings.TrimPrefix(p, "/reflect/")
+		fmt.Fprintf(w, "reflected: %s", val)
+		return
+	case strings.HasPrefix(p, "/redirect/"):
+		if n, ok := tailInt(p, "/redirect/"); ok {
+			if n <= 0 {
+				fmt.Fprint(w, "arrived")
+			} else {
+				w.Header().Set("Location", fmt.Sprintf("/redirect/%d", n-1))
+				w.WriteHeader(http.StatusFound)
+			}
+			return
+		}
+
+	// --- autocalibration: soft-404 baseline with one real outlier -------
+	case p == "/ac/real":
+		// Distinctly larger/wordier than the soft-404 baseline so a calibrated
+		// size or word filter lets it through while the junk is filtered.
+		fmt.Fprint(w, "REAL content that is meaningfully larger than the junk baseline response")
+		return
+	case strings.HasPrefix(p, "/ac/"):
+		// Any other /ac/* path (including ffuf's random calibration probes)
+		// returns a constant small body: the classic soft-404.
+		fmt.Fprint(w, "junk")
+		return
+
+	// --- request-gated endpoints ----------------------------------------
+	case p == "/needs-header":
+		if r.Header.Get("X-Test") == "yes" {
+			fmt.Fprint(w, "header ok")
+			return
+		}
+		forbidden(w)
+		return
+	case p == "/needs-cookie":
+		if c, err := r.Cookie("SESSION"); err == nil && c.Value != "" {
+			fmt.Fprint(w, "cookie ok")
+			return
+		}
+		forbidden(w)
+		return
+	case p == "/needs-method":
+		if r.Method == http.MethodPost {
+			fmt.Fprint(w, "method ok")
+			return
+		}
+		forbidden(w)
+		return
+	case p == "/needs-body":
+		if strings.Contains(body, "token") {
+			fmt.Fprint(w, "body ok")
+			return
+		}
+		forbidden(w)
+		return
+
+	// --- recursion tree -------------------------------------------------
+	case p == "/":
+		fmt.Fprint(w, "root")
+		return
+	case p == "/admin":
+		fmt.Fprint(w, "admin directory")
+		return
+	case p == "/admin/secret":
+		fmt.Fprint(w, "the secret")
+		return
+	}
+
+	notFound(w)
+}
+
+func forbidden(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusForbidden)
+	fmt.Fprint(w, "forbidden")
+}
+func notFound(w http.ResponseWriter) { w.WriteHeader(http.StatusNotFound); fmt.Fprint(w, "not found") }
+
+// tailInt parses the integer immediately following prefix in path. It requires
+// the remainder to be exactly an integer (no further path segments), so
+// /size/20 parses and /size/20/extra does not.
+func tailInt(path, prefix string) (int, bool) {
+	rest := strings.TrimPrefix(path, prefix)
+	if rest == "" || strings.Contains(rest, "/") {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// filled returns n bytes of 'A'. net/http sets Content-Length to n for these
+// small buffered bodies, which is what ffuf's size matcher reads.
+func filled(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = 'A'
+	}
+	return b
+}
+
+// words returns a body of exactly n whitespace-separated tokens.
+func words(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	toks := make([]string, n)
+	for i := range toks {
+		toks[i] = "w"
+	}
+	return strings.Join(toks, " ")
+}
+
+// lines returns a body that ffuf counts as exactly n lines. ffuf's line count
+// is len(strings.Split(data, "\n")), so n "L"s joined by newlines (no trailing
+// newline) yields exactly n, matching the /size and /words convention.
+func lines(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	ls := make([]string, n)
+	for i := range ls {
+		ls[i] = "L"
+	}
+	return strings.Join(ls, "\n")
+}
+
+func drain(r *http.Request) string {
+	if r.Body == nil {
+		return ""
+	}
+	buf := make([]byte, 0, 512)
+	tmp := make([]byte, 512)
+	for {
+		n, err := r.Body.Read(tmp)
+		buf = append(buf, tmp[:n]...)
+		if err != nil {
+			break
+		}
+	}
+	return string(buf)
+}

--- a/pkg/testtarget/server.go
+++ b/pkg/testtarget/server.go
@@ -83,17 +83,17 @@ func (t *Target) handle(w http.ResponseWriter, r *http.Request) {
 		}
 	case strings.HasPrefix(p, "/size/"):
 		if n, ok := tailInt(p, "/size/"); ok {
-			w.Write(filled(n))
+			_, _ = w.Write(filled(n))
 			return
 		}
 	case strings.HasPrefix(p, "/words/"):
 		if n, ok := tailInt(p, "/words/"); ok {
-			w.Write([]byte(words(n)))
+			_, _ = w.Write([]byte(words(n)))
 			return
 		}
 	case strings.HasPrefix(p, "/lines/"):
 		if n, ok := tailInt(p, "/lines/"); ok {
-			w.Write([]byte(lines(n)))
+			_, _ = w.Write([]byte(lines(n)))
 			return
 		}
 	case strings.HasPrefix(p, "/sleep/"):

--- a/pkg/testtarget/server_test.go
+++ b/pkg/testtarget/server_test.go
@@ -1,0 +1,93 @@
+package testtarget
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestBodyHelpers grounds the size/word/line helpers against independently
+// computed values, NOT against ffuf's own counters, so a symmetric off-by-one in
+// both the mock and ffuf can't cancel out and hide a counting regression.
+func TestBodyHelpers(t *testing.T) {
+	for _, n := range []int{0, 1, 37, 100} {
+		if got := len(filled(n)); got != n {
+			t.Errorf("filled(%d) length = %d, want %d", n, got, n)
+		}
+	}
+	// words(n) is n tokens, i.e. n-1 single-space separators.
+	for _, n := range []int{1, 5, 10} {
+		if got := strings.Count(words(n), " "); got != n-1 {
+			t.Errorf("words(%d) has %d spaces, want %d", n, got, n-1)
+		}
+	}
+	// lines(n) is n lines, i.e. n-1 newline separators (no trailing newline).
+	for _, n := range []int{1, 3, 5} {
+		if got := strings.Count(lines(n), "\n"); got != n-1 {
+			t.Errorf("lines(%d) has %d newlines, want %d", n, got, n-1)
+		}
+	}
+}
+
+// TestEndpoints checks the gate/status behavior the integration suite relies on,
+// so a mock bug is caught here rather than misattributed to ffuf.
+func TestEndpoints(t *testing.T) {
+	tt := New()
+	defer tt.Close()
+
+	client := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+
+	cases := []struct {
+		path   string
+		status int
+	}{
+		{"/status/418", 418},
+		{"/size/50", 200},
+		{"/map/ok", 200},
+		{"/map/bad", 500},
+		{"/needs-header", 403}, // gated: no header
+		{"/rdir", 301},         // redirect-based directory
+		{"/nope", 404},
+	}
+	for _, c := range cases {
+		resp, err := client.Get(tt.URL + c.path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", c.path, err)
+		}
+		if resp.StatusCode != c.status {
+			t.Errorf("GET %s: status %d, want %d", c.path, resp.StatusCode, c.status)
+		}
+		resp.Body.Close()
+	}
+
+	// /size/50 body is exactly 50 bytes.
+	resp, err := client.Get(tt.URL + "/size/50")
+	if err != nil {
+		t.Fatalf("GET /size/50: %v", err)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if len(b) != 50 {
+		t.Errorf("/size/50 body = %d bytes, want 50", len(b))
+	}
+
+	// The gated header endpoint opens with the right header.
+	req, _ := http.NewRequest("GET", tt.URL+"/needs-header", nil)
+	req.Header.Set("X-Test", "yes")
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("GET /needs-header (with header): %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("/needs-header with X-Test: got %d, want 200", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// Requests were recorded.
+	if tt.Count() == 0 {
+		t.Error("recorder captured no requests")
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,177 @@
+// Package e2e is the black-box layer: it builds the real ffuf binary and runs it
+// as a subprocess against the in-process mock target (reachable over real TCP),
+// then asserts on its output. This is the only layer that exercises argv -> flag
+// parsing -> engine -> formatted output end to end, which is where CLI/flag wiring
+// regressions surface.
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/testtarget"
+)
+
+// buildFfuf compiles the ffuf binary from the repo root into a temp path.
+func buildFfuf(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "ffuf")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	cmd.Dir = "../.." // go test runs with cwd = this package's dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build ffuf: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func writeWordlist(t *testing.T, words []string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "wordlist-*.txt")
+	if err != nil {
+		t.Fatalf("temp wordlist: %v", err)
+	}
+	defer f.Close()
+	for _, w := range words {
+		fmt.Fprintln(f, w)
+	}
+	return f.Name()
+}
+
+func assertSet(t *testing.T, got, want []string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// matchedPayloads parses -json stdout (one marshaled Result per line) and returns
+// the sorted set of last-path-segments of the matched URLs (the FUZZ payload).
+func matchedPayloads(stdout []byte) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, line := range strings.Split(string(stdout), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var r struct {
+			Url string `json:"url"`
+		}
+		if json.Unmarshal([]byte(line), &r) != nil || r.Url == "" {
+			continue
+		}
+		p := path.Base(r.Url)
+		if !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestE2E_JSONOutput runs the built binary against the mock and checks that the
+// CLI parsed the flags, ran the scan, and emitted the matched set as JSON. This
+// is what protects the declarative flag/config wiring.
+func TestE2E_JSONOutput(t *testing.T) {
+	bin := buildFfuf(t)
+
+	target := testtarget.New()
+	defer target.Close()
+
+	wl := writeWordlist(t, []string{"200", "201", "404"})
+	cmd := exec.Command(bin,
+		"-u", target.URL+"/status/FUZZ",
+		"-w", wl,
+		"-mc", "200,201",
+		"-json",
+		"-t", "1", // deterministic ordering; correctness test, not a concurrency test
+		"-noninteractive",
+	)
+	stdout, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("ffuf run failed: %v", err)
+	}
+
+	assertSet(t, matchedPayloads(stdout), []string{"200", "201"})
+}
+
+// firstHashAndPayload parses the first -json result and returns its FFUFHASH
+// (Input unmarshals from base64 straight into []byte) and the payload (last URL
+// segment).
+func firstHashAndPayload(t *testing.T, stdout []byte) (hash, payload string) {
+	t.Helper()
+	for _, line := range strings.Split(string(stdout), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var r struct {
+			Input map[string][]byte `json:"input"`
+			Url   string            `json:"url"`
+		}
+		if json.Unmarshal([]byte(line), &r) != nil {
+			continue
+		}
+		if h, ok := r.Input["FFUFHASH"]; ok && len(h) > 0 && r.Url != "" {
+			return string(h), path.Base(r.Url)
+		}
+	}
+	t.Fatalf("no result with a FFUFHASH found in:\n%s", stdout)
+	return "", ""
+}
+
+// TestE2E_FFUFHashRoundTrip runs a scan, takes a FFUFHASH from the output, and
+// feeds it back to `ffuf -search`, asserting the original request is
+// reconstructed. This exercises the retained-options history serialization end to
+// end (the mechanism the declarative-config refactor replaced ToOptions with).
+func TestE2E_FFUFHashRoundTrip(t *testing.T) {
+	bin := buildFfuf(t)
+
+	target := testtarget.New()
+	defer target.Close()
+
+	// Isolate the config/history dir for both runs (honored on Linux; on macOS it
+	// falls back to the real dir but the two runs still agree, so the round-trip holds).
+	cfgHome := t.TempDir()
+	env := append(os.Environ(), "XDG_CONFIG_HOME="+cfgHome)
+
+	wl := writeWordlist(t, []string{"200", "201"})
+	run1 := exec.Command(bin,
+		"-u", target.URL+"/status/FUZZ", "-w", wl,
+		"-mc", "200,201", "-json", "-t", "1", "-noninteractive",
+	)
+	run1.Env = env
+	out1, err := run1.Output()
+	if err != nil {
+		t.Fatalf("scan run failed: %v", err)
+	}
+	hash, payload := firstHashAndPayload(t, out1)
+
+	run2 := exec.Command(bin, "-search", hash, "-noninteractive")
+	run2.Env = env
+	out2, err := run2.Output()
+	if err != nil {
+		t.Fatalf("search run failed: %v", err)
+	}
+
+	s := string(out2)
+	if !strings.Contains(s, "Request candidate") {
+		t.Fatalf("-search found no candidate for %q:\n%s", hash, s)
+	}
+	if !strings.Contains(s, "/status/"+payload) {
+		t.Errorf("-search did not reconstruct the request path /status/%s:\n%s", payload, s)
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -6,6 +6,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,23 +18,55 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ffuf/ffuf/v2/pkg/testtarget"
 )
 
-// buildFfuf compiles the ffuf binary from the repo root into a temp path.
-func buildFfuf(t *testing.T) string {
-	t.Helper()
-	bin := filepath.Join(t.TempDir(), "ffuf")
+// ffufBin is the binary built once for the whole package by TestMain.
+var ffufBin string
+
+func TestMain(m *testing.M) { os.Exit(runMain(m)) }
+
+func runMain(m *testing.M) int {
+	dir, err := os.MkdirTemp("", "ffuf-e2e")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer os.RemoveAll(dir)
+
+	ffufBin = filepath.Join(dir, "ffuf")
 	if runtime.GOOS == "windows" {
-		bin += ".exe"
+		ffufBin += ".exe"
 	}
-	cmd := exec.Command("go", "build", "-o", bin, ".")
-	cmd.Dir = "../.." // go test runs with cwd = this package's dir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("go build ffuf: %v\n%s", err, out)
+	build := exec.Command("go", "build", "-o", ffufBin, ".")
+	build.Dir = "../.." // go test runs with cwd = this package's dir
+	if out, err := build.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "go build ffuf failed: %v\n%s", err, out)
+		return 1
 	}
-	return bin
+	return m.Run()
+}
+
+// runFfuf runs the built binary with a hard timeout so a hung run fails fast
+// rather than burning the whole test timeout. env may be nil (inherit).
+func runFfuf(t *testing.T, env []string, args ...string) []byte {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, ffufBin, args...)
+	if env != nil {
+		cmd.Env = env
+	}
+	out, err := cmd.Output()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("ffuf timed out; args: %v", args)
+	}
+	if err != nil {
+		t.Fatalf("ffuf failed: %v; args: %v", err, args)
+	}
+	return out
 }
 
 func writeWordlist(t *testing.T, words []string) string {
@@ -51,27 +84,40 @@ func writeWordlist(t *testing.T, words []string) string {
 
 func assertSet(t *testing.T, got, want []string) {
 	t.Helper()
+	sort.Strings(got)
+	sort.Strings(want)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 }
 
-// matchedPayloads parses -json stdout (one marshaled Result per line) and returns
-// the sorted set of last-path-segments of the matched URLs (the FUZZ payload).
-func matchedPayloads(stdout []byte) []string {
-	seen := make(map[string]bool)
-	var out []string
+// jsonResult is the subset of a -json result line the e2e tests read. Input
+// unmarshals from base64 straight into []byte.
+type jsonResult struct {
+	Input map[string][]byte `json:"input"`
+	Url   string            `json:"url"`
+}
+
+func parseResults(stdout []byte) []jsonResult {
+	var out []jsonResult
 	for _, line := range strings.Split(string(stdout), "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "{") {
 			continue
 		}
-		var r struct {
-			Url string `json:"url"`
+		var r jsonResult
+		if json.Unmarshal([]byte(line), &r) == nil && r.Url != "" {
+			out = append(out, r)
 		}
-		if json.Unmarshal([]byte(line), &r) != nil || r.Url == "" {
-			continue
-		}
+	}
+	return out
+}
+
+// matchedPayloads returns the sorted set of last-path-segments of matched URLs.
+func matchedPayloads(stdout []byte) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, r := range parseResults(stdout) {
 		p := path.Base(r.Url)
 		if !seen[p] {
 			seen[p] = true
@@ -82,96 +128,152 @@ func matchedPayloads(stdout []byte) []string {
 	return out
 }
 
-// TestE2E_JSONOutput runs the built binary against the mock and checks that the
-// CLI parsed the flags, ran the scan, and emitted the matched set as JSON. This
-// is what protects the declarative flag/config wiring.
+// TestE2E_JSONOutput: the CLI parsed the flags, ran the scan, and emitted the
+// matched set as JSON.
 func TestE2E_JSONOutput(t *testing.T) {
-	bin := buildFfuf(t)
-
 	target := testtarget.New()
 	defer target.Close()
 
 	wl := writeWordlist(t, []string{"200", "201", "404"})
-	cmd := exec.Command(bin,
-		"-u", target.URL+"/status/FUZZ",
-		"-w", wl,
-		"-mc", "200,201",
-		"-json",
-		"-t", "1", // deterministic ordering; correctness test, not a concurrency test
-		"-noninteractive",
+	out := runFfuf(t, nil,
+		"-u", target.URL+"/status/FUZZ", "-w", wl,
+		"-mc", "200,201", "-json", "-t", "1", "-noninteractive",
 	)
-	stdout, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("ffuf run failed: %v", err)
-	}
-
-	assertSet(t, matchedPayloads(stdout), []string{"200", "201"})
+	assertSet(t, matchedPayloads(out), []string{"200", "201"})
 }
 
-// firstHashAndPayload parses the first -json result and returns its FFUFHASH
-// (Input unmarshals from base64 straight into []byte) and the payload (last URL
-// segment).
-func firstHashAndPayload(t *testing.T, stdout []byte) (hash, payload string) {
-	t.Helper()
-	for _, line := range strings.Split(string(stdout), "\n") {
-		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "{") {
-			continue
-		}
-		var r struct {
-			Input map[string][]byte `json:"input"`
-			Url   string            `json:"url"`
-		}
-		if json.Unmarshal([]byte(line), &r) != nil {
-			continue
-		}
-		if h, ok := r.Input["FFUFHASH"]; ok && len(h) > 0 && r.Url != "" {
-			return string(h), path.Base(r.Url)
-		}
-	}
-	t.Fatalf("no result with a FFUFHASH found in:\n%s", stdout)
-	return "", ""
-}
-
-// TestE2E_FFUFHashRoundTrip runs a scan, takes a FFUFHASH from the output, and
-// feeds it back to `ffuf -search`, asserting the original request is
-// reconstructed. This exercises the retained-options history serialization end to
-// end (the mechanism the declarative-config refactor replaced ToOptions with).
-func TestE2E_FFUFHashRoundTrip(t *testing.T) {
-	bin := buildFfuf(t)
-
+// TestE2E_DefaultMatcher: with NO -mc, the default status set
+// (200-299,301,302,307,401,403,405,500) applies. This is the only test that
+// exercises main.SetupFilters' defaulting; 404 must be filtered out.
+func TestE2E_DefaultMatcher(t *testing.T) {
 	target := testtarget.New()
 	defer target.Close()
 
-	// Isolate the config/history dir for both runs (honored on Linux; on macOS it
-	// falls back to the real dir but the two runs still agree, so the round-trip holds).
+	wl := writeWordlist(t, []string{"200", "403", "404", "500"})
+	out := runFfuf(t, nil,
+		"-u", target.URL+"/status/FUZZ", "-w", wl,
+		"-json", "-t", "1", "-noninteractive",
+	)
+	assertSet(t, matchedPayloads(out), []string{"200", "403", "500"})
+}
+
+// TestE2E_MatcherSuppressesDefault: setting -mr (any non-status matcher) with no
+// -mc suppresses the default status matcher (SetupFilters: statusSet || !matcherSet).
+// If the default were NOT suppressed, every 200 /reflect response would match and
+// "drop" would leak in.
+func TestE2E_MatcherSuppressesDefault(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	wl := writeWordlist(t, []string{"keep", "drop"})
+	out := runFfuf(t, nil,
+		"-u", target.URL+"/reflect/FUZZ", "-w", wl,
+		"-mr", "keep", "-json", "-t", "1", "-noninteractive",
+	)
+	assertSet(t, matchedPayloads(out), []string{"keep"})
+}
+
+// hashFor returns the FFUFHASH of the result whose URL ends in the given payload.
+func hashFor(t *testing.T, stdout []byte, payload string) string {
+	t.Helper()
+	for _, r := range parseResults(stdout) {
+		if path.Base(r.Url) == payload {
+			if h := r.Input["FFUFHASH"]; len(h) > 0 {
+				return string(h)
+			}
+		}
+	}
+	t.Fatalf("no result for payload %q with a FFUFHASH in:\n%s", payload, stdout)
+	return ""
+}
+
+// TestE2E_FFUFHashRoundTrip: take a FFUFHASH from a scan and feed it to -search,
+// asserting the original request is reconstructed. Exercises the retained-options
+// history serialization end to end. Config dir isolated via XDG_CONFIG_HOME.
+func TestE2E_FFUFHashRoundTrip(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
 	cfgHome := t.TempDir()
 	env := append(os.Environ(), "XDG_CONFIG_HOME="+cfgHome)
 
 	wl := writeWordlist(t, []string{"200", "201"})
-	run1 := exec.Command(bin,
+	out1 := runFfuf(t, env,
 		"-u", target.URL+"/status/FUZZ", "-w", wl,
 		"-mc", "200,201", "-json", "-t", "1", "-noninteractive",
 	)
-	run1.Env = env
-	out1, err := run1.Output()
-	if err != nil {
-		t.Fatalf("scan run failed: %v", err)
-	}
-	hash, payload := firstHashAndPayload(t, out1)
+	hash := hashFor(t, out1, "200")
 
-	run2 := exec.Command(bin, "-search", hash, "-noninteractive")
-	run2.Env = env
-	out2, err := run2.Output()
-	if err != nil {
-		t.Fatalf("search run failed: %v", err)
+	// Hermeticity: on Linux XDG_CONFIG_HOME is honored, so the history must have
+	// been written under the temp dir. (Skipped on macOS where adrg/xdg ignores it.)
+	if runtime.GOOS == "linux" {
+		if _, err := os.Stat(filepath.Join(cfgHome, "ffuf", "history")); err != nil {
+			t.Errorf("history was not written under the isolated config dir: %v", err)
+		}
 	}
 
+	out2 := runFfuf(t, env, "-search", hash, "-noninteractive")
 	s := string(out2)
 	if !strings.Contains(s, "Request candidate") {
 		t.Fatalf("-search found no candidate for %q:\n%s", hash, s)
 	}
-	if !strings.Contains(s, "/status/"+payload) {
-		t.Errorf("-search did not reconstruct the request path /status/%s:\n%s", payload, s)
+	if !strings.Contains(s, "/status/200") {
+		t.Errorf("-search did not reconstruct /status/200:\n%s", s)
+	}
+}
+
+// TestE2E_FFUFHashRecursion: a recursed result's history must carry the RECURSED
+// URL, not the base (historyOptions refreshes HTTP.URL from the live Config). The
+// "secret" match comes from the /admin/ recursion job, so -search must reconstruct
+// /admin/secret.
+func TestE2E_FFUFHashRecursion(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	cfgHome := t.TempDir()
+	env := append(os.Environ(), "XDG_CONFIG_HOME="+cfgHome)
+
+	wl := writeWordlist(t, []string{"admin", "secret"})
+	out1 := runFfuf(t, env,
+		"-u", target.URL+"/FUZZ", "-w", wl,
+		"-mc", "200", "-recursion", "-recursion-strategy", "greedy", "-recursion-depth", "1",
+		"-json", "-t", "1", "-noninteractive",
+	)
+	// "secret" only matches at /admin/secret, i.e. inside the recursion job.
+	if !strings.Contains(strings.Join(matchedPayloads(out1), ","), "secret") {
+		t.Fatalf("recursion did not find 'secret':\n%s", out1)
+	}
+	hash := hashFor(t, out1, "secret")
+
+	out2 := runFfuf(t, env, "-search", hash, "-noninteractive")
+	if !strings.Contains(string(out2), "/admin/secret") {
+		t.Errorf("recursed hash did not reconstruct /admin/secret (history kept the base URL?):\n%s", out2)
+	}
+}
+
+// TestE2E_FFUFHashRequestOptions: headers, method and body must survive the
+// serialize -> history file -> deserialize -> reconstruct round-trip. -search
+// dumps the raw request, so they appear verbatim.
+func TestE2E_FFUFHashRequestOptions(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	cfgHome := t.TempDir()
+	env := append(os.Environ(), "XDG_CONFIG_HOME="+cfgHome)
+
+	wl := writeWordlist(t, []string{"200"})
+	out1 := runFfuf(t, env,
+		"-u", target.URL+"/status/FUZZ", "-w", wl,
+		"-X", "POST", "-H", "X-Test: roundtrip", "-d", "body=FUZZ",
+		"-mc", "200", "-json", "-t", "1", "-noninteractive",
+	)
+	hash := hashFor(t, out1, "200")
+
+	out2 := runFfuf(t, env, "-search", hash, "-noninteractive")
+	s := string(out2)
+	for _, want := range []string{"POST", "X-Test: roundtrip", "body=200"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("-search reconstruction missing %q:\n%s", want, s)
+		}
 	}
 }

--- a/test/integration/behavior_test.go
+++ b/test/integration/behavior_test.go
@@ -101,6 +101,12 @@ func TestAutocalibration(t *testing.T) {
 		[]string{"junk1", "junk2", "real"},
 		func(o *ffuf.ConfigOptions) {
 			o.General.AutoCalibration = true
+			// Custom calibration strings so calibration is hermetic: this path in
+			// autoCalibrationStrings() returns them directly and never reads the
+			// strategy JSON files from AUTOCALIBDIR, which a fresh CI checkout does
+			// not have (without them, calibration silently installs no filter).
+			// Both probe /ac/<string> and return the junk baseline.
+			o.General.AutoCalibrationStrings = []string{"calibrate-one", "calibrate-two"}
 			// Single-threaded so calibration installs the junk-size filter before
 			// any wordlist request is matched. With concurrency, requests race the
 			// calibration and the result is nondeterministic.

--- a/test/integration/behavior_test.go
+++ b/test/integration/behavior_test.go
@@ -166,6 +166,36 @@ func TestRecursion(t *testing.T) {
 // version-robust core signal (it is a 404 at the root, so it can only appear via
 // recursion); the /rdir 301 itself is not asserted because a bare 3xx is handled
 // differently across Go versions.
+// TestAutocalibrationConcurrent runs autocalibration at the default concurrency.
+// It cannot assert an exact set (junk requests already in flight before the filter
+// installs may leak, which is inherent, not a bug), but it locks the #907
+// invariant that survives concurrency: "real" always matches, and no calibration
+// probe string ever appears as a result payload (before #907 the calibration input
+// map was mutated in place and a probe could be reported). Run under -race.
+func TestAutocalibrationConcurrent(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	got := runScan(t, target.URL+"/ac/FUZZ",
+		[]string{"junk1", "junk2", "real"},
+		func(o *ffuf.ConfigOptions) {
+			o.General.AutoCalibration = true
+			o.General.AutoCalibrationStrings = []string{"calibrate-one", "calibrate-two"}
+			// default Threads (40) — the point of this test
+		},
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "all") },
+	)
+
+	if !contains(got, "real") {
+		t.Errorf("'real' should always match; got %v", got)
+	}
+	for _, p := range got {
+		if p != "junk1" && p != "junk2" && p != "real" {
+			t.Errorf("non-wordlist payload %q in results (calibration string leaked): %v", p, got)
+		}
+	}
+}
+
 func TestRecursionDefaultStrategy(t *testing.T) {
 	target := testtarget.New()
 	defer target.Close()

--- a/test/integration/behavior_test.go
+++ b/test/integration/behavior_test.go
@@ -1,0 +1,164 @@
+package integration
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/testtarget"
+)
+
+// assertSet fails unless got equals want as a set (both are pre-sorted by
+// runScan / the literal). Result order is nondeterministic, so this is the only
+// correct comparison.
+func assertSet(t *testing.T, got, want []string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("matched set = %v, want %v", got, want)
+	}
+}
+
+func TestStatusMatcher(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	got := runScan(t, target.URL+"/status/FUZZ",
+		[]string{"200", "301", "404", "500"},
+		nil,
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200,301") },
+	)
+	assertSet(t, got, []string{"200", "301"})
+}
+
+func TestSizeFilter(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	got := runScan(t, target.URL+"/size/FUZZ",
+		[]string{"10", "20", "30"},
+		nil,
+		func(mm ffuf.MatcherManager) {
+			mustMatch(t, mm, "status", "all")
+			mustFilter(t, mm, "size", "20")
+		},
+	)
+	assertSet(t, got, []string{"10", "30"})
+}
+
+func TestWordsFilter(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// /words/5 -> "w w w w w" -> 5 words; filtering words=5 drops it.
+	got := runScan(t, target.URL+"/words/FUZZ",
+		[]string{"1", "5", "10"},
+		nil,
+		func(mm ffuf.MatcherManager) {
+			mustMatch(t, mm, "status", "all")
+			mustFilter(t, mm, "word", "5")
+		},
+	)
+	assertSet(t, got, []string{"1", "10"})
+}
+
+func TestLinesFilter(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// /lines/3 -> "L\nL\nL\n" -> 3 lines; filtering lines=3 drops it.
+	got := runScan(t, target.URL+"/lines/FUZZ",
+		[]string{"1", "3", "5"},
+		nil,
+		func(mm ffuf.MatcherManager) {
+			mustMatch(t, mm, "status", "all")
+			mustFilter(t, mm, "line", "3")
+		},
+	)
+	assertSet(t, got, []string{"1", "5"})
+}
+
+func TestRegexpMatcher(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// Body is "reflected: <val>", so only the alpha request's body contains "alpha".
+	got := runScan(t, target.URL+"/reflect/FUZZ",
+		[]string{"alpha", "beta"},
+		nil,
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "regexp", "alpha") },
+	)
+	assertSet(t, got, []string{"alpha"})
+}
+
+func TestAutocalibration(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// The /ac/ tree returns a constant soft-404 body for everything except
+	// /ac/real. Autocalibration should learn the junk baseline and filter it,
+	// leaving only the genuinely different "real" response.
+	got := runScan(t, target.URL+"/ac/FUZZ",
+		[]string{"junk1", "junk2", "real"},
+		func(o *ffuf.ConfigOptions) {
+			o.General.AutoCalibration = true
+			// Single-threaded so calibration installs the junk-size filter before
+			// any wordlist request is matched. With concurrency, requests race the
+			// calibration and the result is nondeterministic.
+			o.General.Threads = 1
+		},
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "all") },
+	)
+	assertSet(t, got, []string{"real"})
+}
+
+func TestRecursion(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// /admin matches (200); greedy recursion queues /admin/FUZZ, where /admin/secret
+	// matches. Without recursion, "secret" (i.e. /secret) is a 404 and never matches,
+	// so this test fails the moment recursion breaks.
+	got := runScan(t, target.URL+"/FUZZ",
+		[]string{"admin", "secret", "missing"},
+		func(o *ffuf.ConfigOptions) {
+			o.HTTP.Recursion = true
+			o.HTTP.RecursionStrategy = "greedy"
+			o.HTTP.RecursionDepth = 1
+		},
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
+	)
+	assertSet(t, got, []string{"admin", "secret"})
+}
+
+func TestRequestRecorder(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	_ = runScan(t, target.URL+"/status/FUZZ",
+		[]string{"200"},
+		nil,
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
+	)
+
+	reqs := target.Requests()
+	if len(reqs) == 0 {
+		t.Fatal("recorder captured no requests")
+	}
+	if reqs[0].Method != "GET" {
+		t.Errorf("recorded method = %q, want GET", reqs[0].Method)
+	}
+}
+
+func mustMatch(t *testing.T, mm ffuf.MatcherManager, name, value string) {
+	t.Helper()
+	if err := mm.AddMatcher(name, value); err != nil {
+		t.Fatalf("AddMatcher(%q,%q): %v", name, value, err)
+	}
+}
+
+func mustFilter(t *testing.T, mm ffuf.MatcherManager, name, value string) {
+	t.Helper()
+	if err := mm.AddFilter(name, value, false); err != nil {
+		t.Fatalf("AddFilter(%q,%q): %v", name, value, err)
+	}
+}

--- a/test/integration/behavior_test.go
+++ b/test/integration/behavior_test.go
@@ -2,20 +2,39 @@ package integration
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 	"github.com/ffuf/ffuf/v2/pkg/testtarget"
 )
 
-// assertSet fails unless got equals want as a set (both are pre-sorted by
-// runScan / the literal). Result order is nondeterministic, so this is the only
-// correct comparison.
+// assertSet fails unless got equals want as a set. Both sides are sorted here, so
+// callers don't have to pre-sort want and result order (nondeterministic under
+// concurrency) never matters.
 func assertSet(t *testing.T, got, want []string) {
 	t.Helper()
+	sort.Strings(got)
+	sort.Strings(want)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("matched set = %v, want %v", got, want)
 	}
+}
+
+// TestStatusMatcherDecoupled uses /map, where the HTTP status is NOT present in
+// the payload or body ("ok" -> 200 "mapped alpha", "bad" -> 500 "mapped gamma").
+// So a status matcher can be distinguished from a matcher that keyed on the
+// payload or body by mistake.
+func TestStatusMatcherDecoupled(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	got := runScan(t, target.URL+"/map/FUZZ",
+		[]string{"ok", "bad"},
+		nil,
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
+	)
+	assertSet(t, got, []string{"ok"})
 }
 
 func TestStatusMatcher(t *testing.T) {
@@ -138,6 +157,31 @@ func TestRecursion(t *testing.T) {
 		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
 	)
 	assertSet(t, got, []string{"admin", "secret"})
+}
+
+// TestRecursionDefaultStrategy covers the default (redirect-based) recursion
+// strategy, which is a different code path (handleDefaultRecursionJob) from the
+// greedy one: /rdir 301-redirects to /rdir/, which ffuf detects as a directory
+// and descends into, finding /rdir/found. Asserting "found" matched is the
+// version-robust core signal (it is a 404 at the root, so it can only appear via
+// recursion); the /rdir 301 itself is not asserted because a bare 3xx is handled
+// differently across Go versions.
+func TestRecursionDefaultStrategy(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	got := runScan(t, target.URL+"/FUZZ",
+		[]string{"rdir", "found"},
+		func(o *ffuf.ConfigOptions) {
+			o.HTTP.Recursion = true
+			o.HTTP.RecursionStrategy = "default"
+			o.HTTP.RecursionDepth = 1
+		},
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200,301") },
+	)
+	if !contains(got, "found") {
+		t.Errorf("default recursion did not descend into /rdir/ to match 'found'; got %v", got)
+	}
 }
 
 func TestRequestRecorder(t *testing.T) {

--- a/test/integration/behavior_test.go
+++ b/test/integration/behavior_test.go
@@ -22,12 +22,16 @@ func TestStatusMatcher(t *testing.T) {
 	target := testtarget.New()
 	defer target.Close()
 
+	// Non-redirect codes only: a bare 3xx interacts with the http client's
+	// redirect handling in Go-version-dependent ways (a 301 matches on recent Go
+	// but not on the 1.18 floor). Status matching is exercised just as well with
+	// 200/403/404/500, and the test then holds on every supported Go version.
 	got := runScan(t, target.URL+"/status/FUZZ",
-		[]string{"200", "301", "404", "500"},
+		[]string{"200", "403", "404", "500"},
 		nil,
-		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200,301") },
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200,403") },
 	)
-	assertSet(t, got, []string{"200", "301"})
+	assertSet(t, got, []string{"200", "403"})
 }
 
 func TestSizeFilter(t *testing.T) {

--- a/test/integration/encoders_test.go
+++ b/test/integration/encoders_test.go
@@ -1,0 +1,27 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/testtarget"
+)
+
+// TestEncoderApplied checks that -enc transforms the payload before it is sent:
+// with FUZZ:b64encode, "hello" goes on the wire as its base64 form, which the
+// recorder confirms.
+func TestEncoderApplied(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	runScan(t, target.URL+"/reflect/FUZZ",
+		[]string{"hello"},
+		func(o *ffuf.ConfigOptions) { o.Input.Encoders = []string{"FUZZ:b64encode"} },
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "all") },
+	)
+
+	paths := recordedPaths(target.Requests())
+	// base64("hello") == "aGVsbG8="
+	assertContainsAll(t, paths, []string{"/reflect/aGVsbG8="})
+	assertContainsNone(t, paths, []string{"/reflect/hello"})
+}

--- a/test/integration/encoders_test.go
+++ b/test/integration/encoders_test.go
@@ -20,8 +20,9 @@ func TestEncoderApplied(t *testing.T) {
 		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "all") },
 	)
 
-	paths := recordedPaths(target.Requests())
-	// base64("hello") == "aGVsbG8="
-	assertContainsAll(t, paths, []string{"/reflect/aGVsbG8="})
-	assertContainsNone(t, paths, []string{"/reflect/hello"})
+	// base64("hello") == "aGVsbG8="; exactly one request, with the encoded payload.
+	assertSet(t, recordedPaths(target.Requests()), []string{"/reflect/aGVsbG8="})
+	if n := target.Count(); n != 1 {
+		t.Errorf("encoder scan made %d requests, want exactly 1", n)
+	}
 }

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -1,0 +1,139 @@
+// Package integration runs the real ffuf engine end-to-end against the
+// deterministic mock target in pkg/testtarget. It assembles a Job exactly as
+// main.go's prepareJob does (real input provider, real http runner, real
+// matchers and filters) and swaps in a capturing OutputProvider so a test can
+// assert on the exact set of inputs that matched. Nothing here parses argv, so
+// the global flag.CommandLine state is never touched; ConfigOptions are built
+// directly. CLI/flag wiring is covered separately by the black-box e2e layer.
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/filter"
+	"github.com/ffuf/ffuf/v2/pkg/input"
+	"github.com/ffuf/ffuf/v2/pkg/runner"
+)
+
+// runScan runs a full ffuf job against url with the given wordlist. configure
+// tweaks the ConfigOptions (recursion, autocalibration, request options, ...)
+// and setup installs the matchers/filters under test on the MatcherManager. It
+// returns the sorted, de-duplicated set of FUZZ inputs that matched.
+//
+// Result order is nondeterministic (the engine is concurrent), so callers must
+// compare against an expected SET, never an ordered slice. runScan sorts for
+// exactly that reason.
+func runScan(t *testing.T, url string, wordlist []string, configure func(*ffuf.ConfigOptions), setup func(ffuf.MatcherManager)) []string {
+	t.Helper()
+
+	opts := ffuf.NewConfigOptions()
+	opts.HTTP.URL = url
+	opts.HTTP.Method = "GET"
+	opts.Input.Wordlists = []string{writeWordlist(t, wordlist)}
+	opts.General.Quiet = true
+	if configure != nil {
+		configure(opts)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	conf, err := ffuf.ConfigFromOptions(opts, ctx, cancel)
+	if err != nil {
+		t.Fatalf("ConfigFromOptions: %v", err)
+	}
+
+	// Install matchers/filters directly rather than via main.SetupFilters,
+	// which reads the global flag set (flag.Visit) to decide defaults. The test
+	// states its matchers explicitly; SetupFilters' CLI-defaulting logic is the
+	// e2e layer's concern.
+	conf.MatcherManager = filter.NewMatcherManager()
+	if setup != nil {
+		setup(conf.MatcherManager)
+	}
+
+	job := ffuf.NewJob(conf)
+	in, ierr := input.NewInputProvider(conf)
+	if ierr.ErrorOrNil() != nil {
+		t.Fatalf("NewInputProvider: %v", ierr.ErrorOrNil())
+	}
+	job.Input = in
+	job.Runner = runner.NewRunnerByName("http", conf, false)
+	out := &capture{}
+	job.Output = out
+
+	job.Start()
+	return out.inputs()
+}
+
+// writeWordlist writes words to a temp file (cleaned up with the test) and
+// returns its path.
+func writeWordlist(t *testing.T, words []string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "wordlist-*.txt")
+	if err != nil {
+		t.Fatalf("temp wordlist: %v", err)
+	}
+	defer f.Close()
+	for _, w := range words {
+		fmt.Fprintln(f, w)
+	}
+	return f.Name()
+}
+
+// capture is a test OutputProvider that records matched responses. Result is
+// called from worker goroutines, so access is mutex-guarded.
+type capture struct {
+	mu        sync.Mutex
+	responses []ffuf.Response
+	results   []ffuf.Result
+}
+
+func (c *capture) Result(resp ffuf.Response) {
+	c.mu.Lock()
+	c.responses = append(c.responses, resp)
+	c.mu.Unlock()
+}
+
+// inputs returns the sorted, de-duplicated FUZZ payloads that matched.
+func (c *capture) inputs() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	seen := make(map[string]bool)
+	out := make([]string, 0, len(c.responses))
+	for _, r := range c.responses {
+		v := string(r.Request.Input["FUZZ"])
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// --- OutputProvider no-ops (the engine drives these; tests ignore them) ---
+
+func (c *capture) Banner()                       {}
+func (c *capture) Finalize() error               { return nil }
+func (c *capture) Progress(ffuf.Progress)        {}
+func (c *capture) Info(string)                   {}
+func (c *capture) Error(string)                  {}
+func (c *capture) Raw(string)                    {}
+func (c *capture) Warning(string)                {}
+func (c *capture) PrintResult(ffuf.Result)       {}
+func (c *capture) SaveFile(string, string) error { return nil }
+func (c *capture) GetCurrentResults() []ffuf.Result {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.results
+}
+func (c *capture) SetCurrentResults(r []ffuf.Result) { c.mu.Lock(); c.results = r; c.mu.Unlock() }
+func (c *capture) Reset()                            {}
+func (c *capture) Cycle()                            {}

--- a/test/integration/outputformats_test.go
+++ b/test/integration/outputformats_test.go
@@ -1,0 +1,116 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/filter"
+	"github.com/ffuf/ffuf/v2/pkg/input"
+	"github.com/ffuf/ffuf/v2/pkg/output"
+	"github.com/ffuf/ffuf/v2/pkg/runner"
+	"github.com/ffuf/ffuf/v2/pkg/testtarget"
+)
+
+// runScanStdout runs a scan with the real stdout OutputProvider (which
+// accumulates Results and can write them to files), and returns it so a test can
+// SaveFile each format and inspect the output. It mirrors runScan; only the
+// output sink differs.
+func runScanStdout(t *testing.T, url string, wordlist []string, configure func(*ffuf.ConfigOptions), setup func(ffuf.MatcherManager)) ffuf.OutputProvider {
+	t.Helper()
+
+	opts := ffuf.NewConfigOptions()
+	opts.HTTP.URL = url
+	opts.HTTP.Method = "GET"
+	opts.Input.Wordlists = []string{writeWordlist(t, wordlist)}
+	opts.General.Quiet = true
+	if configure != nil {
+		configure(opts)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	conf, err := ffuf.ConfigFromOptions(opts, ctx, cancel)
+	if err != nil {
+		t.Fatalf("ConfigFromOptions: %v", err)
+	}
+	conf.MatcherManager = filter.NewMatcherManager()
+	if setup != nil {
+		setup(conf.MatcherManager)
+	}
+
+	job := ffuf.NewJob(conf)
+	in, ierr := input.NewInputProvider(conf)
+	if ierr.ErrorOrNil() != nil {
+		t.Fatalf("NewInputProvider: %v", ierr.ErrorOrNil())
+	}
+	job.Input = in
+	job.Runner = runner.NewRunnerByName("http", conf, false)
+	out := output.NewOutputProviderByName("stdout", conf)
+	job.Output = out
+
+	job.Start()
+	return out
+}
+
+// TestOutputFormats runs a scan with two known matches and writes each supported
+// file format, checking the writer succeeds and the output actually carries the
+// results. It is the regression net for the pkg/output file writers.
+func TestOutputFormats(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	out := runScanStdout(t, target.URL+"/status/FUZZ",
+		[]string{"200", "201"},
+		nil,
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200,201") },
+	)
+
+	dir := t.TempDir()
+	for _, format := range []string{"json", "ejson", "csv", "ecsv", "md", "html"} {
+		path := filepath.Join(dir, "out."+format)
+		if err := out.SaveFile(path, format); err != nil {
+			t.Errorf("SaveFile(%s): %v", format, err)
+			continue
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v", format, err)
+			continue
+		}
+		if len(b) == 0 {
+			t.Errorf("%s: wrote an empty file", format)
+			continue
+		}
+
+		switch format {
+		case "json", "ejson":
+			// Both are JSON documents with a results array; both matches present.
+			var doc struct {
+				Results []map[string]interface{} `json:"results"`
+			}
+			if err := json.Unmarshal(b, &doc); err != nil {
+				t.Errorf("%s: not valid JSON: %v", format, err)
+			} else if len(doc.Results) != 2 {
+				t.Errorf("%s: %d results, want 2", format, len(doc.Results))
+			}
+		case "csv", "ecsv":
+			// Header line plus one row per result.
+			if lines := strings.Count(strings.TrimRight(string(b), "\n"), "\n") + 1; lines < 3 {
+				t.Errorf("%s: %d lines, want >= 3 (header + 2 rows)", format, lines)
+			}
+		case "md", "html":
+			// Raw (non-encoded) formats: the input values appear verbatim.
+			for _, in := range []string{"200", "201"} {
+				if !strings.Contains(string(b), in) {
+					t.Errorf("%s: output missing input %q", format, in)
+				}
+			}
+		}
+	}
+}

--- a/test/integration/outputformats_test.go
+++ b/test/integration/outputformats_test.go
@@ -70,6 +70,30 @@ func runScanStdout(t *testing.T, url string, wordlist []string, configure func(*
 	return out
 }
 
+// TestOutputConcurrentResultAccumulation drives the real stdout OutputProvider at
+// the default concurrency with many matches and asserts every one is accumulated.
+// Before #908 the unsynchronized append lost results (and raced); this is the
+// multi-threaded coverage that was previously pinned to Threads=1. Run under -race.
+func TestOutputConcurrentResultAccumulation(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	const n = 60
+	words := make([]string, n)
+	for i := range words {
+		words[i] = fmt.Sprintf("w%d", i)
+	}
+
+	out := runScanStdout(t, target.URL+"/reflect/FUZZ",
+		words,
+		nil, // default threads (40)
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "all") },
+	)
+	if got := len(out.GetCurrentResults()); got != n {
+		t.Errorf("accumulated %d results at high concurrency, want %d (results lost?)", got, n)
+	}
+}
+
 // TestOutputFormats runs a scan with two known matches and writes each supported
 // file format, checking the writer succeeds and the output actually carries the
 // results. It is the regression net for the pkg/output file writers.

--- a/test/integration/outputformats_test.go
+++ b/test/integration/outputformats_test.go
@@ -65,9 +65,12 @@ func TestOutputFormats(t *testing.T) {
 	target := testtarget.New()
 	defer target.Close()
 
+	// Single-threaded: the real stdout provider accumulates results without
+	// synchronizing, so under concurrency a result can be lost. This test is
+	// about the file writers, not concurrency, so run it deterministically.
 	out := runScanStdout(t, target.URL+"/status/FUZZ",
 		[]string{"200", "201"},
-		nil,
+		func(o *ffuf.ConfigOptions) { o.General.Threads = 1 },
 		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200,201") },
 	)
 

--- a/test/integration/outputformats_test.go
+++ b/test/integration/outputformats_test.go
@@ -1,8 +1,11 @@
 package integration
 
 import (
+	"bytes"
 	"context"
+	"encoding/csv"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +18,15 @@ import (
 	"github.com/ffuf/ffuf/v2/pkg/runner"
 	"github.com/ffuf/ffuf/v2/pkg/testtarget"
 )
+
+func indexOf(row []string, col string) int {
+	for i, c := range row {
+		if c == col {
+			return i
+		}
+	}
+	return -1
+}
 
 // runScanStdout runs a scan with the real stdout OutputProvider (which
 // accumulates Results and can write them to files), and returns it so a test can
@@ -91,27 +103,67 @@ func TestOutputFormats(t *testing.T) {
 			continue
 		}
 
+		// Assert the actual result FIELDS (status + input), not just that a file
+		// was written or that "200" appears (which the URL would satisfy).
 		switch format {
-		case "json", "ejson":
-			// Both are JSON documents with a results array; both matches present.
+		case "json":
 			var doc struct {
-				Results []map[string]interface{} `json:"results"`
+				Results []struct {
+					Input  map[string]string `json:"input"`
+					Status int64             `json:"status"`
+				} `json:"results"`
 			}
 			if err := json.Unmarshal(b, &doc); err != nil {
-				t.Errorf("%s: not valid JSON: %v", format, err)
-			} else if len(doc.Results) != 2 {
-				t.Errorf("%s: %d results, want 2", format, len(doc.Results))
+				t.Errorf("json: %v", err)
+				continue
 			}
+			var statuses, inputs []string
+			for _, r := range doc.Results {
+				statuses = append(statuses, fmt.Sprintf("%d", r.Status))
+				inputs = append(inputs, r.Input["FUZZ"])
+			}
+			assertSet(t, statuses, []string{"200", "201"})
+			assertSet(t, inputs, []string{"200", "201"})
+		case "ejson":
+			// ejson base64-encodes the input; unmarshalling into []byte decodes it.
+			var doc struct {
+				Results []struct {
+					Input  map[string][]byte `json:"input"`
+					Status int64             `json:"status"`
+				} `json:"results"`
+			}
+			if err := json.Unmarshal(b, &doc); err != nil {
+				t.Errorf("ejson: %v", err)
+				continue
+			}
+			var statuses, inputs []string
+			for _, r := range doc.Results {
+				statuses = append(statuses, fmt.Sprintf("%d", r.Status))
+				inputs = append(inputs, string(r.Input["FUZZ"]))
+			}
+			assertSet(t, statuses, []string{"200", "201"})
+			assertSet(t, inputs, []string{"200", "201"})
 		case "csv", "ecsv":
-			// Header line plus one row per result.
-			if lines := strings.Count(strings.TrimRight(string(b), "\n"), "\n") + 1; lines < 3 {
-				t.Errorf("%s: %d lines, want >= 3 (header + 2 rows)", format, lines)
+			rows, err := csv.NewReader(bytes.NewReader(b)).ReadAll()
+			if err != nil {
+				t.Errorf("%s: not valid CSV: %v", format, err)
+				continue
 			}
+			if len(rows) != 3 {
+				t.Errorf("%s: %d rows, want 3 (header + 2 results)", format, len(rows))
+				continue
+			}
+			col := indexOf(rows[0], "status_code")
+			if col < 0 {
+				t.Errorf("%s: no StatusCode column in header %v", format, rows[0])
+				continue
+			}
+			assertSet(t, []string{rows[1][col], rows[2][col]}, []string{"200", "201"})
 		case "md", "html":
-			// Raw (non-encoded) formats: the input values appear verbatim.
+			// Human formats: both status codes must be present in the rendered output.
 			for _, in := range []string{"200", "201"} {
 				if !strings.Contains(string(b), in) {
-					t.Errorf("%s: output missing input %q", format, in)
+					t.Errorf("%s: output missing status %q", format, in)
 				}
 			}
 		}

--- a/test/integration/phase2_test.go
+++ b/test/integration/phase2_test.go
@@ -1,0 +1,212 @@
+package integration
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/testtarget"
+)
+
+// recordedPaths returns the sorted, de-duplicated set of request paths the target
+// received. Order is nondeterministic (the engine is concurrent), so callers
+// compare as a set.
+func recordedPaths(reqs []testtarget.Recorded) []string {
+	seen := make(map[string]bool)
+	out := make([]string, 0, len(reqs))
+	for _, r := range reqs {
+		if !seen[r.Path] {
+			seen[r.Path] = true
+			out = append(out, r.Path)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func assertContainsAll(t *testing.T, got, want []string) {
+	t.Helper()
+	for _, w := range want {
+		if !contains(got, w) {
+			t.Errorf("missing %q in %v", w, got)
+		}
+	}
+}
+
+func assertContainsNone(t *testing.T, got, unwanted []string) {
+	t.Helper()
+	for _, u := range unwanted {
+		if contains(got, u) {
+			t.Errorf("unexpected %q in %v", u, got)
+		}
+	}
+}
+
+// --- request options, verified through the request recorder ----------------
+
+func TestRequestHeaderSent(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// /needs-header returns 200 only when X-Test: yes is present, else 403.
+	got := runScan(t, target.URL+"/needs-header?p=FUZZ",
+		[]string{"h"},
+		func(o *ffuf.ConfigOptions) { o.HTTP.Headers = []string{"X-Test: yes"} },
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
+	)
+	assertSet(t, got, []string{"h"})
+
+	sent := false
+	for _, r := range target.Requests() {
+		if r.Header.Get("X-Test") == "yes" {
+			sent = true
+		}
+	}
+	if !sent {
+		t.Error("the -H header was not sent on the wire")
+	}
+}
+
+func TestRequestHeaderMissingDoesNotMatch(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// Without the header, /needs-header returns 403, so nothing matches.
+	got := runScan(t, target.URL+"/needs-header?p=FUZZ",
+		[]string{"h"},
+		nil,
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
+	)
+	assertSet(t, got, []string{})
+}
+
+func TestRequestCookieSent(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	got := runScan(t, target.URL+"/needs-cookie?p=FUZZ",
+		[]string{"c"},
+		func(o *ffuf.ConfigOptions) { o.HTTP.Cookies = []string{"SESSION=abc"} },
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
+	)
+	assertSet(t, got, []string{"c"})
+}
+
+func TestRequestMethod(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	got := runScan(t, target.URL+"/needs-method?p=FUZZ",
+		[]string{"m"},
+		func(o *ffuf.ConfigOptions) { o.HTTP.Method = "POST" },
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
+	)
+	assertSet(t, got, []string{"m"})
+}
+
+func TestRequestBody(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// /needs-body returns 200 only when the body contains "token".
+	got := runScan(t, target.URL+"/needs-body?p=FUZZ",
+		[]string{"b"},
+		func(o *ffuf.ConfigOptions) {
+			o.HTTP.Method = "POST"
+			o.HTTP.Data = "token=FUZZ"
+		},
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
+	)
+	assertSet(t, got, []string{"b"})
+}
+
+// --- redirects -------------------------------------------------------------
+
+func TestFollowRedirects(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// /redirect/3 -> /redirect/2 -> /redirect/1 -> /redirect/0 (200). With -r,
+	// the final 200 matches; the recorder proves the whole chain was walked.
+	got := runScan(t, target.URL+"/redirect/FUZZ",
+		[]string{"3"},
+		func(o *ffuf.ConfigOptions) { o.HTTP.FollowRedirects = true },
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
+	)
+	assertSet(t, got, []string{"3"})
+
+	assertContainsAll(t, recordedPaths(target.Requests()),
+		[]string{"/redirect/3", "/redirect/2", "/redirect/1", "/redirect/0"})
+}
+
+// --- matcher/filter combination --------------------------------------------
+
+func TestFilterExcludesStatuses(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// Match everything, then filter out 404 and 500: only 200 survives.
+	got := runScan(t, target.URL+"/status/FUZZ",
+		[]string{"200", "404", "500"},
+		nil,
+		func(mm ffuf.MatcherManager) {
+			mustMatch(t, mm, "status", "all")
+			mustFilter(t, mm, "status", "404,500")
+		},
+	)
+	assertSet(t, got, []string{"200"})
+}
+
+// --- input modes (asserted through the recorder) ---------------------------
+
+func TestInputModeClusterbomb(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	runScan(t, target.URL+"/reflect/KEY1-KEY2",
+		nil,
+		func(o *ffuf.ConfigOptions) {
+			o.Input.InputMode = "clusterbomb"
+			o.Input.Wordlists = []string{
+				writeWordlist(t, []string{"a", "b"}) + ":KEY1",
+				writeWordlist(t, []string{"1", "2"}) + ":KEY2",
+			}
+		},
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "all") },
+	)
+
+	// clusterbomb is the cartesian product: every combination is requested.
+	assertContainsAll(t, recordedPaths(target.Requests()),
+		[]string{"/reflect/a-1", "/reflect/a-2", "/reflect/b-1", "/reflect/b-2"})
+}
+
+func TestInputModePitchfork(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	runScan(t, target.URL+"/reflect/KEY1-KEY2",
+		nil,
+		func(o *ffuf.ConfigOptions) {
+			o.Input.InputMode = "pitchfork"
+			o.Input.Wordlists = []string{
+				writeWordlist(t, []string{"a", "b"}) + ":KEY1",
+				writeWordlist(t, []string{"1", "2"}) + ":KEY2",
+			}
+		},
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "all") },
+	)
+
+	paths := recordedPaths(target.Requests())
+	// pitchfork reads the wordlists in lockstep: a with 1, b with 2 (no cross terms).
+	assertContainsAll(t, paths, []string{"/reflect/a-1", "/reflect/b-2"})
+	assertContainsNone(t, paths, []string{"/reflect/a-2", "/reflect/b-1"})
+}

--- a/test/integration/phase2_test.go
+++ b/test/integration/phase2_test.go
@@ -2,11 +2,24 @@ package integration
 
 import (
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 	"github.com/ffuf/ffuf/v2/pkg/testtarget"
 )
+
+// anyRequest reports whether any recorded request satisfies pred. Used to assert
+// what ffuf actually put on the wire (method, headers, body), not just that a
+// response matched.
+func anyRequest(reqs []testtarget.Recorded, pred func(testtarget.Recorded) bool) bool {
+	for _, r := range reqs {
+		if pred(r) {
+			return true
+		}
+	}
+	return false
+}
 
 // recordedPaths returns the sorted, de-duplicated set of request paths the target
 // received. Order is nondeterministic (the engine is concurrent), so callers
@@ -38,15 +51,6 @@ func assertContainsAll(t *testing.T, got, want []string) {
 	for _, w := range want {
 		if !contains(got, w) {
 			t.Errorf("missing %q in %v", w, got)
-		}
-	}
-}
-
-func assertContainsNone(t *testing.T, got, unwanted []string) {
-	t.Helper()
-	for _, u := range unwanted {
-		if contains(got, u) {
-			t.Errorf("unexpected %q in %v", u, got)
 		}
 	}
 }
@@ -87,6 +91,11 @@ func TestRequestHeaderMissingDoesNotMatch(t *testing.T) {
 		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
 	)
 	assertSet(t, got, []string{})
+	// De-vacuum: the empty result must be because the request was made and got a
+	// 403, not because the engine failed to send anything.
+	if target.Count() == 0 {
+		t.Fatal("engine sent no request; the empty match set is meaningless")
+	}
 }
 
 func TestRequestCookieSent(t *testing.T) {
@@ -99,6 +108,11 @@ func TestRequestCookieSent(t *testing.T) {
 		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
 	)
 	assertSet(t, got, []string{"c"})
+	if !anyRequest(target.Requests(), func(r testtarget.Recorded) bool {
+		return strings.Contains(r.Header.Get("Cookie"), "SESSION=abc")
+	}) {
+		t.Error("the -b cookie was not sent on the wire")
+	}
 }
 
 func TestRequestMethod(t *testing.T) {
@@ -111,6 +125,9 @@ func TestRequestMethod(t *testing.T) {
 		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
 	)
 	assertSet(t, got, []string{"m"})
+	if !anyRequest(target.Requests(), func(r testtarget.Recorded) bool { return r.Method == "POST" }) {
+		t.Error("the -X method was not sent as POST")
+	}
 }
 
 func TestRequestBody(t *testing.T) {
@@ -127,6 +144,11 @@ func TestRequestBody(t *testing.T) {
 		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
 	)
 	assertSet(t, got, []string{"b"})
+	// Verify FUZZ was actually substituted in the body (not just that "token"
+	// from the template survived): the wire body must be "token=b".
+	if !anyRequest(target.Requests(), func(r testtarget.Recorded) bool { return r.Body == "token=b" }) {
+		t.Error("the -d body was not sent with FUZZ substituted (want \"token=b\")")
+	}
 }
 
 // --- redirects -------------------------------------------------------------
@@ -184,9 +206,14 @@ func TestInputModeClusterbomb(t *testing.T) {
 		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "all") },
 	)
 
-	// clusterbomb is the cartesian product: every combination is requested.
-	assertContainsAll(t, recordedPaths(target.Requests()),
+	// clusterbomb is the cartesian product: exactly every combination, no more.
+	// Exact set catches extra paths; the count catches duplicates (recordedPaths
+	// de-duplicates, so a doubled request would slip past a set check alone).
+	assertSet(t, recordedPaths(target.Requests()),
 		[]string{"/reflect/a-1", "/reflect/a-2", "/reflect/b-1", "/reflect/b-2"})
+	if n := target.Count(); n != 4 {
+		t.Errorf("clusterbomb 2x2 made %d requests, want exactly 4 (over-production?)", n)
+	}
 }
 
 func TestInputModePitchfork(t *testing.T) {
@@ -205,8 +232,9 @@ func TestInputModePitchfork(t *testing.T) {
 		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "all") },
 	)
 
-	paths := recordedPaths(target.Requests())
-	// pitchfork reads the wordlists in lockstep: a with 1, b with 2 (no cross terms).
-	assertContainsAll(t, paths, []string{"/reflect/a-1", "/reflect/b-2"})
-	assertContainsNone(t, paths, []string{"/reflect/a-2", "/reflect/b-1"})
+	// pitchfork reads the wordlists in lockstep: exactly a-1 and b-2, no cross terms.
+	assertSet(t, recordedPaths(target.Requests()), []string{"/reflect/a-1", "/reflect/b-2"})
+	if n := target.Count(); n != 2 {
+		t.Errorf("pitchfork made %d requests, want exactly 2 (over-production?)", n)
+	}
 }

--- a/test/integration/phase2b_test.go
+++ b/test/integration/phase2b_test.go
@@ -1,0 +1,61 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/testtarget"
+)
+
+func TestInputModeSniper(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// Sniper fuzzes one marked position at a time, holding the others at their
+	// literal text: /reflect/§a§/§b§ with [x,y] hits /reflect/{x,y}/b (first
+	// position) and /reflect/a/{x,y} (second position).
+	runScan(t, target.URL+"/reflect/§a§/§b§",
+		[]string{"x", "y"},
+		func(o *ffuf.ConfigOptions) { o.Input.InputMode = "sniper" },
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "all") },
+	)
+
+	assertContainsAll(t, recordedPaths(target.Requests()),
+		[]string{"/reflect/x/b", "/reflect/y/b", "/reflect/a/x", "/reflect/a/y"})
+}
+
+func TestMatcherModeAnd(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// Two matchers in "and" mode: a response must be 200 AND contain "keep".
+	// Every /reflect is 200, so the regexp is the discriminator.
+	got := runScan(t, target.URL+"/reflect/FUZZ",
+		[]string{"keep", "drop"},
+		func(o *ffuf.ConfigOptions) { o.Matcher.Mode = "and" },
+		func(mm ffuf.MatcherManager) {
+			mustMatch(t, mm, "status", "200")
+			mustMatch(t, mm, "regexp", "keep")
+		},
+	)
+	assertSet(t, got, []string{"keep"})
+}
+
+func TestFilterModeAnd(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	// Two filters in "and" mode: a response is dropped only if it is 200 AND
+	// contains "secret". Every /reflect is 200, so only /reflect/secret is
+	// dropped; with the default "or" mode the 200 filter would drop everything.
+	got := runScan(t, target.URL+"/reflect/FUZZ",
+		[]string{"secret", "public"},
+		func(o *ffuf.ConfigOptions) { o.Filter.Mode = "and" },
+		func(mm ffuf.MatcherManager) {
+			mustMatch(t, mm, "status", "all")
+			mustFilter(t, mm, "status", "200")
+			mustFilter(t, mm, "regexp", "secret")
+		},
+	)
+	assertSet(t, got, []string{"public"})
+}

--- a/test/integration/phase2b_test.go
+++ b/test/integration/phase2b_test.go
@@ -20,8 +20,11 @@ func TestInputModeSniper(t *testing.T) {
 		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "all") },
 	)
 
-	assertContainsAll(t, recordedPaths(target.Requests()),
+	assertSet(t, recordedPaths(target.Requests()),
 		[]string{"/reflect/x/b", "/reflect/y/b", "/reflect/a/x", "/reflect/a/y"})
+	if n := target.Count(); n != 4 {
+		t.Errorf("sniper made %d requests, want exactly 4 (2 positions x 2 words)", n)
+	}
 }
 
 func TestMatcherModeAnd(t *testing.T) {

--- a/test/integration/timing_test.go
+++ b/test/integration/timing_test.go
@@ -1,0 +1,57 @@
+//go:build timing
+
+// These tests make wall-clock assertions (response-time matching, rate limiting),
+// which are inherently noisy on shared CI runners. They live behind the `timing`
+// build tag so they never gate the main suite; run them with:
+//
+//	go test -tags=timing ./test/integration/...
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/testtarget"
+)
+
+// TestTimeMatcher: /sleep/500 responds well over 200ms, /sleep/5 well under, so
+// a "time > 200" matcher keeps only the slow one. Wide margins keep it stable.
+func TestTimeMatcher(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	got := runScan(t, target.URL+"/sleep/FUZZ",
+		[]string{"5", "500"},
+		nil,
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "time", ">200") },
+	)
+	assertSet(t, got, []string{"500"})
+}
+
+// TestRateLimit: N requests at -rate R should take at least ~N/R seconds. A wide
+// lower bound absorbs runner noise while still catching a throttle that stops
+// throttling entirely.
+func TestRateLimit(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	words := make([]string, 30)
+	for i := range words {
+		words[i] = fmt.Sprintf("w%d", i)
+	}
+
+	start := time.Now()
+	runScan(t, target.URL+"/status/FUZZ",
+		words,
+		func(o *ffuf.ConfigOptions) { o.General.Rate = 20 }, // 20 req/s
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "all") },
+	)
+	elapsed := time.Since(start)
+
+	// 30 requests at 20/s is ~1.5s; require at least 800ms to allow for noise.
+	if elapsed < 800*time.Millisecond {
+		t.Errorf("rate limiting too fast: 30 requests at -rate 20 took %v, want >= ~800ms", elapsed)
+	}
+}

--- a/test/integration/timing_test.go
+++ b/test/integration/timing_test.go
@@ -16,18 +16,19 @@ import (
 	"github.com/ffuf/ffuf/v2/pkg/testtarget"
 )
 
-// TestTimeMatcher: /sleep/500 responds well over 200ms, /sleep/5 well under, so
-// a "time > 200" matcher keeps only the slow one. Wide margins keep it stable.
+// TestTimeMatcher: /sleep/1000 responds ~1s, /sleep/1 near-instant, so a
+// "time > 500" matcher keeps only the slow one. The 500ms gap is wide enough to
+// stay stable even on a loaded CI runner.
 func TestTimeMatcher(t *testing.T) {
 	target := testtarget.New()
 	defer target.Close()
 
 	got := runScan(t, target.URL+"/sleep/FUZZ",
-		[]string{"5", "500"},
+		[]string{"1", "1000"},
 		nil,
-		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "time", ">200") },
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "time", ">500") },
 	)
-	assertSet(t, got, []string{"500"})
+	assertSet(t, got, []string{"1000"})
 }
 
 // TestRateLimit: N requests at -rate R should take at least ~N/R seconds. A wide


### PR DESCRIPTION
Adds a real-engine test suite for ffuf, so a change that alters existing behavior fails CI instead of shipping silently. Also fixes the data races the suite surfaced in the engine.

## Approach

The suite runs the actual engine (real input provider, HTTP runner, matchers, filters, job loop) against a deterministic mock target reached over real TCP. Only the target, and where needed the output sink, are test doubles. Assertions compare result sets because the engine is concurrent.

## What's in it

**Mock target (`pkg/testtarget`)** - a deterministic `httptest` server modeling every dimension the engine keys on: status code, body size, word/line counts, latency, reflection, a soft-404 tree for autocalibration, greedy and redirect-based directory trees for recursion, request-gated endpoints (header/cookie/method/body), redirects, and a request recorder. It has its own tests, and its size/word/line helpers are checked against independently computed values (not ffuf's counters), so a symmetric off-by-one can't hide.

**Integration (`test/integration`)** - a capturing OutputProvider plus a harness that assembles the real Job against the mock. Covers:
- matchers and filters (status/size/words/lines/regexp/time) and and-mode combinations
- autocalibration (single-threaded deterministic case, plus a concurrent invariant check)
- recursion (greedy and default redirect-based strategies)
- request options verified on the wire via the recorder (`-H`/`-b`/`-X`/`-d`, including keyword substitution in the body)
- input modes (clusterbomb/pitchfork/sniper) asserted as exact request sets and counts, so over-production is caught
- output writers (json/ejson/csv/ecsv/md/html), asserting the result fields, not just counts
- encoders (`-enc`)

**Property tests (`pkg/ffuf`)** - `testing/quick` (fixed seed, 1000 iterations) over the range/value parsers behind every numeric matcher.

**Black-box e2e (`test/e2e`)** - builds the real binary and runs it against the mock. Covers `-json` output, the default matcher and its suppression (the only coverage of `main.SetupFilters`), and a FFUFHASH round-trip that reconstructs recursed URLs and `-H`/`-X`/`-d` via `-search`.

**CI (`.github/workflows/test.yml`)** - build/vet/test across ubuntu + macos x go 1.18/stable with `-race`, a gating timing job (wide wall-clock margins), an informational coverage job, and the existing characterization golden check.

## Engine fix included

Running the engine end to end under `-race` surfaced data races the previous tests never reached: `Job.Counter`, the run-state flags, the error counters and the `Error` string were read by the progress and interrupt goroutines while the exec loop and workers mutated them, and `RateThrottle.CurrentRate`/`ChangeRate` read the ring buffer `Tick` writes under a lock without taking it. Fixed here (`pkg/ffuf/job.go`, `pkg/ffuf/rate.go`) via leaf accessors on the existing mutex; no exported types change.

Two further bugs the suite found were fixed in their own PRs and are already merged: #907 (autocalibration mutated the caller's input map) and #908 (Stdoutput result accumulation was unsynchronized). This branch merges master, so those fixes are present and their concurrency cases are now tested here.

## Notes

- Determinism: set-based assertions; single-thread only where a test targets correctness rather than concurrency; hermetic calibration and history (no dependence on the runner's home dir).
- Windows is intentionally left out of the matrix for now: a few existing tests are not Windows-clean (the help-golden test deadlocks on Windows' small stdout pipe buffer, and a couple of output tests assume POSIX terminal control). Enabling it needs those fixed first.