### PR TITLE
Fix: autocalibration mutates the caller's input map (wrong result attribution)

### DIFF
--- a/pkg/ffuf/autocalibration.go
+++ b/pkg/ffuf/autocalibration.go
@@ -142,11 +142,21 @@ func (j *Job) Calibrate(input map[string][]byte) error {
 	}
 	cInputs := j.autoCalibrationStrings()
 
+	// Copy the caller's inputs before overwriting the calibration keyword below.
+	// SimpleRunner.Prepare sets req.Input to the map it is given, so the map the
+	// caller passes here is the same one used for result attribution; mutating it
+	// in place makes a later matched result report the calibration string instead
+	// of the real payload. CalibrateForHost copies for the same reason.
+	cinput := make(map[string][]byte, len(input))
+	for k, v := range input {
+		cinput[k] = v
+	}
+
 	for _, v := range cInputs {
 		responses := make([]Response, 0)
 		for _, cs := range v {
-			input[j.Config.AutoCalibrationKeyword] = []byte(cs)
-			resp, err := j.calibrationRequest(input)
+			cinput[j.Config.AutoCalibrationKeyword] = []byte(cs)
+			resp, err := j.calibrationRequest(cinput)
 			if err != nil {
 				continue
 			}

--- a/pkg/ffuf/autocalibration_mutation_test.go
+++ b/pkg/ffuf/autocalibration_mutation_test.go
@@ -1,0 +1,47 @@
+package ffuf
+
+import (
+	"errors"
+	"testing"
+)
+
+// stubRunner is a RunnerProvider whose calls fail. It is enough to drive
+// Calibrate's loop without real HTTP: the mutation under test happens in
+// Calibrate before the request is ever prepared.
+type stubRunner struct{}
+
+func (stubRunner) Prepare(map[string][]byte, *Request) (Request, error) {
+	return Request{}, errors.New("stub")
+}
+func (stubRunner) Execute(*Request) (Response, error) { return Response{}, errors.New("stub") }
+func (stubRunner) Dump(*Request) ([]byte, error)      { return nil, nil }
+
+// TestCalibrate_DoesNotMutateInput locks the fix for an input-map aliasing bug.
+// SimpleRunner.Prepare sets req.Input = input (the same map), so resp.Request.Input
+// aliases the caller's input map. Calibrate overwrote input[keyword] with each
+// calibration string in place, so a result matched and reported after
+// autocalibration showed the calibration string (e.g. ".htaccessXXXX") instead of
+// the real payload. Calibrate must copy the map before overwriting, exactly as
+// CalibrateForHost already does.
+func TestCalibrate_DoesNotMutateInput(t *testing.T) {
+	job := &Job{
+		Config: &Config{
+			Url:                    "http://localhost/FUZZ",
+			Method:                 "GET",
+			AutoCalibration:        true,
+			AutoCalibrationKeyword: "FUZZ",
+			AutoCalibrationStrings: []string{"probe-a", "probe-b"},
+			MatcherManager:         &fakeMatcherManager{},
+		},
+		Output: NewNullOutput(),
+		Runner: stubRunner{},
+	}
+	input := map[string][]byte{"FUZZ": []byte("realpayload")}
+
+	if err := job.Calibrate(input); err != nil {
+		t.Fatalf("Calibrate: %v", err)
+	}
+	if got := string(input["FUZZ"]); got != "realpayload" {
+		t.Errorf("Calibrate mutated the caller's input map: FUZZ = %q, want \"realpayload\"", got)
+	}
+}


### PR DESCRIPTION
## Bug

`SimpleRunner.Prepare` sets `req.Input = input` (the same map it is handed), so `resp.Request.Input` aliases the worker's input map, and that map is what output uses for result attribution.

`Job.Calibrate` overwrote that map in place, one calibration string at a time:

```go
for _, cs := range v {
    input[j.Config.AutoCalibrationKeyword] = []byte(cs) // mutates the caller's map
    ...
}
```

`CalibrateIfNeeded` is called from `runTask` with the worker's live input map. So after autocalibration runs, a result that matches and is reported shows the last calibration string (e.g. `.htaccessXXXX`) as the payload instead of the real wordlist entry. `CalibrateForHost` already copies the map before mutating; `Calibrate` did not.

## Fix

Copy the input map in `Calibrate` before overwriting the keyword, exactly as `CalibrateForHost` does. Calibration behavior is unchanged (the copy carries identical values); only the caller's map is left intact.

## Test

Adds `TestCalibrate_DoesNotMutateInput`, which drives `Calibrate` with a stub runner (the mutation happens before the request is prepared, so no HTTP is needed) and asserts the caller's map is untouched. It fails on the current code (`FUZZ = "probe-b"`) and passes with the fix.

`go test -race ./...` stays green across the tree.
