### PR TITLE
Fix: synchronize Stdoutput result accumulation (results lost under concurrency)

### DIFF
--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
@@ -29,6 +30,7 @@ const (
 type Stdoutput struct {
 	config           *ffuf.Config
 	fuzzkeywords     []string
+	resultMutex      sync.Mutex // guards Results and CurrentResults; Result is called from worker goroutines
 	Results          []ffuf.Result
 	CurrentResults   []ffuf.Result
 	stdoutIsTerminal bool
@@ -189,23 +191,33 @@ func (s *Stdoutput) Banner() {
 
 // Reset resets the result slice
 func (s *Stdoutput) Reset() {
+	s.resultMutex.Lock()
 	s.CurrentResults = make([]ffuf.Result, 0)
+	s.resultMutex.Unlock()
 }
 
 // Cycle moves the CurrentResults to Results and resets the results slice
 func (s *Stdoutput) Cycle() {
+	s.resultMutex.Lock()
 	s.Results = append(s.Results, s.CurrentResults...)
-	s.Reset()
+	s.CurrentResults = make([]ffuf.Result, 0)
+	s.resultMutex.Unlock()
 }
 
 // GetResults returns the result slice
 func (s *Stdoutput) GetCurrentResults() []ffuf.Result {
-	return s.CurrentResults
+	s.resultMutex.Lock()
+	defer s.resultMutex.Unlock()
+	out := make([]ffuf.Result, len(s.CurrentResults))
+	copy(out, s.CurrentResults)
+	return out
 }
 
 // SetResults sets the result slice
 func (s *Stdoutput) SetCurrentResults(results []ffuf.Result) {
+	s.resultMutex.Lock()
 	s.CurrentResults = results
+	s.resultMutex.Unlock()
 }
 
 func (s *Stdoutput) Progress(status ffuf.Progress) {
@@ -322,25 +334,33 @@ func (s *Stdoutput) writeToAll(filename string, config *ffuf.Config, res []ffuf.
 // SaveFile saves the current results to a file of a given type
 func (s *Stdoutput) SaveFile(filename, format string) error {
 	var err error
-	if s.config.OutputSkipEmptyFile && len(s.Results) == 0 && len(s.CurrentResults) == 0 {
+	// Snapshot the results under the lock so a concurrent Result() cannot race the
+	// file writers, then write outside the lock.
+	s.resultMutex.Lock()
+	all := make([]ffuf.Result, 0, len(s.Results)+len(s.CurrentResults))
+	all = append(all, s.Results...)
+	all = append(all, s.CurrentResults...)
+	s.resultMutex.Unlock()
+
+	if s.config.OutputSkipEmptyFile && len(all) == 0 {
 		s.Info("No results and -or defined, output file not written.")
 		return err
 	}
 	switch format {
 	case "all":
-		err = s.writeToAll(filename, s.config, append(s.Results, s.CurrentResults...))
+		err = s.writeToAll(filename, s.config, all)
 	case "json":
-		err = writeJSON(filename, s.config, append(s.Results, s.CurrentResults...))
+		err = writeJSON(filename, s.config, all)
 	case "ejson":
-		err = writeEJSON(filename, s.config, append(s.Results, s.CurrentResults...))
+		err = writeEJSON(filename, s.config, all)
 	case "html":
-		err = writeHTML(filename, s.config, append(s.Results, s.CurrentResults...))
+		err = writeHTML(filename, s.config, all)
 	case "md":
-		err = writeMarkdown(filename, s.config, append(s.Results, s.CurrentResults...))
+		err = writeMarkdown(filename, s.config, all)
 	case "csv":
-		err = writeCSV(filename, s.config, append(s.Results, s.CurrentResults...), false)
+		err = writeCSV(filename, s.config, all, false)
 	case "ecsv":
-		err = writeCSV(filename, s.config, append(s.Results, s.CurrentResults...), true)
+		err = writeCSV(filename, s.config, all, true)
 	}
 	return err
 }
@@ -385,7 +405,9 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 		ResultFile:       resp.ResultFile,
 		Host:             resp.Request.Host,
 	}
+	s.resultMutex.Lock()
 	s.CurrentResults = append(s.CurrentResults, sResult)
+	s.resultMutex.Unlock()
 	// Output the result
 	s.PrintResult(sResult)
 }

--- a/pkg/output/stdout_race_test.go
+++ b/pkg/output/stdout_race_test.go
@@ -1,0 +1,41 @@
+package output
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+// TestStdoutput_ConcurrentResult locks the fix for an unsynchronized append:
+// Result is called from the engine's worker goroutines, and it appended to
+// CurrentResults without a lock, so under concurrency results were silently
+// lost (and -race flagged the write). Every result must survive.
+//
+// Run with -race to also catch the data race directly.
+func TestStdoutput_ConcurrentResult(t *testing.T) {
+	conf := &ffuf.Config{}
+	s := NewStdoutput(conf)
+
+	const n = 200
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s.Result(ffuf.Response{
+				StatusCode: 200,
+				Request: &ffuf.Request{
+					Input: map[string][]byte{"FUZZ": []byte(fmt.Sprintf("w%d", i))},
+					Url:   fmt.Sprintf("http://example/%d", i),
+				},
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	if got := len(s.GetCurrentResults()); got != n {
+		t.Errorf("got %d results, want %d (results lost to the unsynchronized append)", got, n)
+	}
+}


### PR DESCRIPTION
## Bug

`Stdoutput.Result` is called from the engine's worker goroutines (`job.go` runTask -> `j.Output.Result`), and it appended to `CurrentResults` with no synchronization:

```go
s.CurrentResults = append(s.CurrentResults, sResult)
```

Under the default concurrency (`-t 40`), concurrent appends race: `go test -race` flags the write, and results can be silently dropped, so a run's saved output (or `GetCurrentResults`) can hold fewer results than actually matched.

## Fix

Guard `Results`/`CurrentResults` with a mutex across every accessor (`Result`, `Reset`, `Cycle`, `GetCurrentResults`, `SetCurrentResults`). `SaveFile` snapshots the combined slice under the lock and writes outside it, so the file writers never race a live `Result`. `GetCurrentResults` returns a copy (both callers only iterate).

## Test

`TestStdoutput_ConcurrentResult` drives `Result` from 200 goroutines and asserts every result survives. It fails under `-race` without the lock (DATA RACE) and passes with it.
