### PR TITLE
Fix concurrency defects: MatcherManager, recursion queue, pause gate, and related races

### DIFF
--- a/pkg/ffuf/autocalibration.go
+++ b/pkg/ffuf/autocalibration.go
@@ -4,17 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
-	"time"
 )
 
 type AutocalibrationStrategy map[string][]string
 
 func (j *Job) autoCalibrationStrings() map[string][]string {
-	rand.Seed(time.Now().UnixNano())
+	// The global rand is seeded once in Job.Start; re-seeding here on every call
+	// reset the sequence and could hand two near-simultaneous calibrations the
+	// same "random" strings.
 	cInputs := make(map[string][]string)
 
 	if len(j.Config.AutoCalibrationStrings) > 0 {

--- a/pkg/ffuf/autocalibration_test.go
+++ b/pkg/ffuf/autocalibration_test.go
@@ -25,8 +25,17 @@ func (o *NullOutput) PrintResult(res Result)                 {}
 func (o *NullOutput) SaveFile(filename, format string) error { return nil }
 func (o *NullOutput) GetCurrentResults() []Result            { return o.Results }
 func (o *NullOutput) SetCurrentResults(results []Result)     { o.Results = results }
-func (o *NullOutput) Reset()                                 {}
-func (o *NullOutput) Cycle()                                 {}
+func (o *NullOutput) FilterCurrentResults(keep func(Result) bool) {
+	filtered := make([]Result, 0, len(o.Results))
+	for _, r := range o.Results {
+		if keep(r) {
+			filtered = append(filtered, r)
+		}
+	}
+	o.Results = filtered
+}
+func (o *NullOutput) Reset() {}
+func (o *NullOutput) Cycle() {}
 
 func TestAutoCalibrationStrings(t *testing.T) {
 	// Create a temporary directory for the test

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -75,6 +75,7 @@ type OutputProvider interface {
 	SaveFile(filename, format string) error
 	GetCurrentResults() []Result
 	SetCurrentResults(results []Result)
+	FilterCurrentResults(keep func(Result) bool)
 	Reset()
 	Cycle()
 }

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -7,40 +7,52 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 )
 
 // Job ties together Config, Runner, Input and Output
 type Job struct {
-	AuditLogger          AuditLogger
-	Config               *Config
-	ErrorMutex           sync.Mutex
-	Input                InputProvider
-	Runner               RunnerProvider
-	ReplayRunner         RunnerProvider
-	Scraper              Scraper
-	Output               OutputProvider
-	Jobhash              string
-	Counter              int
-	ErrorCounter         int
-	SpuriousErrorCounter int
-	Total                int
-	Running              bool
-	RunningJob           bool
-	Paused               bool
-	Count403             int
-	Count429             int
-	Error                string
-	Rate                 *RateThrottle
-	startTime            time.Time
-	startTimeJob         time.Time
-	queuejobs            []QueueJob
-	queuepos             int
-	skipQueue            bool
-	currentDepth         int
-	calibMutex           sync.Mutex
-	pauseWg              sync.WaitGroup
+	// 64-bit atomic counters. These MUST stay first in the struct so they are
+	// 8-byte aligned on 32-bit architectures, which sync/atomic requires. Access
+	// only through the helper methods below, never directly.
+	counter              int64
+	errorCounter         int64
+	spuriousErrorCounter int64
+	count403             int64
+	count429             int64
+
+	// 32-bit atomic flags (0 = false, 1 = true). Access only through the helpers.
+	running    int32
+	runningJob int32
+	skipQueue  int32
+
+	AuditLogger  AuditLogger
+	Config       *Config
+	Input        InputProvider
+	Runner       RunnerProvider
+	ReplayRunner RunnerProvider
+	Scraper      Scraper
+	Output       OutputProvider
+	Jobhash      string
+	Total        int
+	Rate         *RateThrottle
+
+	queue        *jobQueue
+	currentDepth int
+
+	startTime    time.Time
+	startTimeJob time.Time
+	errorMsg     string
+	paused       bool // guarded by pauseStateMutex
+
+	timeMutex       sync.Mutex   // guards startTime and startTimeJob
+	errMutex        sync.Mutex   // guards errorMsg
+	inputMutex      sync.Mutex   // serializes main-loop input iteration vs interactive restart Reset
+	calibMutex      sync.Mutex   // serializes autocalibration
+	pauseStateMutex sync.Mutex   // makes the pause-flag flip and the pauseMutex Lock/Unlock one atomic step
+	pauseMutex      sync.RWMutex // pause gate: workers RLock as a speed bump, Pause takes the write Lock
 }
 
 type QueueJob struct {
@@ -52,110 +64,92 @@ type QueueJob struct {
 func NewJob(conf *Config) *Job {
 	var j Job
 	j.Config = conf
-	j.Counter = 0
-	j.ErrorCounter = 0
-	j.SpuriousErrorCounter = 0
-	j.Running = false
-	j.RunningJob = false
-	j.Paused = false
-	j.queuepos = 0
-	j.queuejobs = make([]QueueJob, 0)
+	j.queue = newJobQueue()
 	j.currentDepth = 0
 	j.Rate = NewRateThrottle(conf)
-	j.skipQueue = false
 	return &j
 }
 
-// The per-run counters and run-state flags below are mutated by the execution
-// loop and worker goroutines while the progress goroutine and the interrupt
-// handler read them concurrently. ErrorMutex serializes every access. All access
-// goes through these leaf helpers, which never call one another, so they cannot
-// deadlock (including CheckStop, which reads via getters and then calls Stop).
+// The per-run counters and run-state flags are mutated by the execution loop and
+// the worker goroutines while the progress goroutine and the interrupt handler
+// read them concurrently. Counters use sync/atomic (int64), flags use atomic
+// int32, so there is no mutex to forget and no lock-ordering to get wrong. The
+// fields are private: the only way to touch them is through these helpers.
 
-func (j *Job) incCounter()      { j.ErrorMutex.Lock(); j.Counter++; j.ErrorMutex.Unlock() }
-func (j *Job) setCounter(n int) { j.ErrorMutex.Lock(); j.Counter = n; j.ErrorMutex.Unlock() }
-func (j *Job) getCounter() int  { j.ErrorMutex.Lock(); defer j.ErrorMutex.Unlock(); return j.Counter }
+func (j *Job) incCounter()      { atomic.AddInt64(&j.counter, 1) }
+func (j *Job) setCounter(n int) { atomic.StoreInt64(&j.counter, int64(n)) }
+func (j *Job) getCounter() int  { return int(atomic.LoadInt64(&j.counter)) }
 
-func (j *Job) getErrorCounter() int {
-	j.ErrorMutex.Lock()
-	defer j.ErrorMutex.Unlock()
-	return j.ErrorCounter
-}
+func (j *Job) getErrorCounter() int { return int(atomic.LoadInt64(&j.errorCounter)) }
 func (j *Job) getSpuriousErrorCounter() int {
-	j.ErrorMutex.Lock()
-	defer j.ErrorMutex.Unlock()
-	return j.SpuriousErrorCounter
+	return int(atomic.LoadInt64(&j.spuriousErrorCounter))
 }
-func (j *Job) getCount403() int { j.ErrorMutex.Lock(); defer j.ErrorMutex.Unlock(); return j.Count403 }
-func (j *Job) getCount429() int { j.ErrorMutex.Lock(); defer j.ErrorMutex.Unlock(); return j.Count429 }
+func (j *Job) getCount403() int { return int(atomic.LoadInt64(&j.count403)) }
+func (j *Job) getCount429() int { return int(atomic.LoadInt64(&j.count429)) }
 
-func (j *Job) setRunning(v bool)    { j.ErrorMutex.Lock(); j.Running = v; j.ErrorMutex.Unlock() }
-func (j *Job) isRunning() bool      { j.ErrorMutex.Lock(); defer j.ErrorMutex.Unlock(); return j.Running }
-func (j *Job) setRunningJob(v bool) { j.ErrorMutex.Lock(); j.RunningJob = v; j.ErrorMutex.Unlock() }
-func (j *Job) isRunningJob() bool {
-	j.ErrorMutex.Lock()
-	defer j.ErrorMutex.Unlock()
-	return j.RunningJob
+func boolToInt32(b bool) int32 {
+	if b {
+		return 1
+	}
+	return 0
 }
-func (j *Job) setPaused(v bool) { j.ErrorMutex.Lock(); j.Paused = v; j.ErrorMutex.Unlock() }
-func (j *Job) isPaused() bool   { j.ErrorMutex.Lock(); defer j.ErrorMutex.Unlock(); return j.Paused }
-func (j *Job) setSkipQueue(v bool) {
-	j.ErrorMutex.Lock()
-	j.skipQueue = v
-	j.ErrorMutex.Unlock()
+
+func (j *Job) setRunning(v bool)    { atomic.StoreInt32(&j.running, boolToInt32(v)) }
+func (j *Job) isRunning() bool      { return atomic.LoadInt32(&j.running) == 1 }
+func (j *Job) setRunningJob(v bool) { atomic.StoreInt32(&j.runningJob, boolToInt32(v)) }
+func (j *Job) isRunningJob() bool   { return atomic.LoadInt32(&j.runningJob) == 1 }
+func (j *Job) setSkipQueue(v bool)  { atomic.StoreInt32(&j.skipQueue, boolToInt32(v)) }
+func (j *Job) isSkipQueue() bool    { return atomic.LoadInt32(&j.skipQueue) == 1 }
+
+func (j *Job) setError(s string) { j.errMutex.Lock(); j.errorMsg = s; j.errMutex.Unlock() }
+func (j *Job) getError() string  { j.errMutex.Lock(); defer j.errMutex.Unlock(); return j.errorMsg }
+
+func (j *Job) setStartTime(t time.Time) { j.timeMutex.Lock(); j.startTime = t; j.timeMutex.Unlock() }
+func (j *Job) getStartTime() time.Time {
+	j.timeMutex.Lock()
+	defer j.timeMutex.Unlock()
+	return j.startTime
 }
-func (j *Job) isSkipQueue() bool {
-	j.ErrorMutex.Lock()
-	defer j.ErrorMutex.Unlock()
-	return j.skipQueue
+func (j *Job) setStartTimeJob(t time.Time) {
+	j.timeMutex.Lock()
+	j.startTimeJob = t
+	j.timeMutex.Unlock()
 }
-func (j *Job) setError(s string) { j.ErrorMutex.Lock(); j.Error = s; j.ErrorMutex.Unlock() }
-func (j *Job) getError() string  { j.ErrorMutex.Lock(); defer j.ErrorMutex.Unlock(); return j.Error }
+func (j *Job) getStartTimeJob() time.Time {
+	j.timeMutex.Lock()
+	defer j.timeMutex.Unlock()
+	return j.startTimeJob
+}
 
 // incError increments the error counter
 func (j *Job) incError() {
-	j.ErrorMutex.Lock()
-	defer j.ErrorMutex.Unlock()
-	j.ErrorCounter++
-	j.SpuriousErrorCounter++
+	atomic.AddInt64(&j.errorCounter, 1)
+	atomic.AddInt64(&j.spuriousErrorCounter, 1)
 }
 
 // inc403 increments the 403 response counter
-func (j *Job) inc403() {
-	j.ErrorMutex.Lock()
-	defer j.ErrorMutex.Unlock()
-	j.Count403++
-}
+func (j *Job) inc403() { atomic.AddInt64(&j.count403, 1) }
 
 // inc429 increments the 429 response counter
-func (j *Job) inc429() {
-	j.ErrorMutex.Lock()
-	defer j.ErrorMutex.Unlock()
-	j.Count429++
-}
+func (j *Job) inc429() { atomic.AddInt64(&j.count429, 1) }
 
 // resetSpuriousErrors resets the spurious error counter
-func (j *Job) resetSpuriousErrors() {
-	j.ErrorMutex.Lock()
-	defer j.ErrorMutex.Unlock()
-	j.SpuriousErrorCounter = 0
-}
+func (j *Job) resetSpuriousErrors() { atomic.StoreInt64(&j.spuriousErrorCounter, 0) }
 
 // DeleteQueueItem deletes a recursion job from the queue by its index in the slice
 func (j *Job) DeleteQueueItem(index int) {
-	index = j.queuepos + index - 1
-	j.queuejobs = append(j.queuejobs[:index], j.queuejobs[index+1:]...)
+	j.queue.removeAt(index)
 }
 
 // QueuedJobs returns the slice of queued recursive jobs
 func (j *Job) QueuedJobs() []QueueJob {
-	return j.queuejobs[j.queuepos-1:]
+	return j.queue.remaining()
 }
 
 // Start the execution of the Job
 func (j *Job) Start() {
-	if j.startTime.IsZero() {
-		j.startTime = time.Now()
+	if j.getStartTime().IsZero() {
+		j.setStartTime(time.Now())
 	}
 
 	basereq := BaseRequest(j.Config)
@@ -164,12 +158,12 @@ func (j *Job) Start() {
 		// process multiple payload locations and create a queue job for each location
 		reqs := SniperRequests(&basereq, j.Config.InputProviders[0].Template)
 		for _, r := range reqs {
-			j.queuejobs = append(j.queuejobs, QueueJob{Url: j.Config.Url, depth: 0, req: r})
+			j.queue.push(QueueJob{Url: j.Config.Url, depth: 0, req: r})
 		}
 		j.Total = j.Input.Total() * len(reqs)
 	} else {
 		// Add the default job to job queue
-		j.queuejobs = append(j.queuejobs, QueueJob{Url: j.Config.Url, depth: 0, req: BaseRequest(j.Config)})
+		j.queue.push(QueueJob{Url: j.Config.Url, depth: 0, req: BaseRequest(j.Config)})
 		j.Total = j.Input.Total()
 	}
 
@@ -199,10 +193,15 @@ func (j *Job) Start() {
 
 // Reset resets the counters and wordlist position for a job
 func (j *Job) Reset(cycle bool) {
+	// inputMutex serializes this against the main loop's Input iteration, so an
+	// interactive "restart" that calls Reset while workers are live cannot race
+	// the input provider's internal position.
+	j.inputMutex.Lock()
 	j.Input.Reset()
+	j.inputMutex.Unlock()
 	j.setCounter(0)
 	j.setSkipQueue(false)
-	j.startTimeJob = time.Now()
+	j.setStartTimeJob(time.Now())
 	if cycle {
 		j.Output.Cycle()
 	} else {
@@ -211,24 +210,24 @@ func (j *Job) Reset(cycle bool) {
 }
 
 func (j *Job) jobsInQueue() bool {
-	return j.queuepos < len(j.queuejobs)
+	return j.queue.hasNext()
 }
 
 func (j *Job) prepareQueueJob() {
-	j.Config.Url = j.queuejobs[j.queuepos].Url
-	j.currentDepth = j.queuejobs[j.queuepos].depth
+	job, _ := j.queue.advance()
+	j.Config.Url = job.Url
+	j.currentDepth = job.depth
 
 	//Find all keywords present in new queued job
 	kws := j.Input.Keywords()
 	found_kws := make([]string, 0)
 	for _, k := range kws {
-		if RequestContainsKeyword(j.queuejobs[j.queuepos].req, k) {
+		if RequestContainsKeyword(job.req, k) {
 			found_kws = append(found_kws, k)
 		}
 	}
 	//And activate / disable inputproviders as needed
 	j.Input.ActivateKeywords(found_kws)
-	j.queuepos += 1
 	j.Jobhash, _ = WriteHistoryEntry(j.Config)
 }
 
@@ -255,22 +254,43 @@ func (j *Job) sleepIfNeeded() {
 	}
 }
 
-// Pause pauses the job process
+// Pause pauses the job process. The pause gate is a sync.RWMutex: while Pause
+// holds the write lock, every worker blocks at its pauseCheckpoint (an RLock).
+//
+// pauseStateMutex makes the paused-flag flip and the pauseMutex Lock/Unlock a
+// single atomic step. It has to: Pause runs on the interactive goroutine while
+// Resume also fires from the SIGINT handler, so a plain CAS-then-Lock would let a
+// Resume slip between Pause's flag flip and its Lock and unlock an unlocked mutex
+// (a fatal panic). Under the state mutex there is exactly one Lock per Unlock for
+// any interleaving of Pause/Resume/interrupt.
 func (j *Job) Pause() {
-	if !j.isPaused() {
-		j.setPaused(true)
-		j.pauseWg.Add(1)
+	j.pauseStateMutex.Lock()
+	defer j.pauseStateMutex.Unlock()
+	if !j.paused {
+		j.paused = true
+		j.pauseMutex.Lock()
 		j.Output.Info("------ PAUSING ------")
 	}
 }
 
 // Resume resumes the job process
 func (j *Job) Resume() {
-	if j.isPaused() {
-		j.setPaused(false)
+	j.pauseStateMutex.Lock()
+	defer j.pauseStateMutex.Unlock()
+	if j.paused {
+		j.paused = false
+		j.pauseMutex.Unlock()
 		j.Output.Info("------ RESUMING -----")
-		j.pauseWg.Done()
 	}
+}
+
+// pauseCheckpoint blocks while the job is paused and returns immediately
+// otherwise. Acquiring and releasing the read lock is a cheap speed bump when no
+// pause is in effect.
+func (j *Job) pauseCheckpoint() {
+	j.pauseMutex.RLock()
+	//nolint:staticcheck // intentional: RLock/RUnlock is a pause speed bump, not a critical section
+	j.pauseMutex.RUnlock()
 }
 
 func (j *Job) startExecution() {
@@ -279,9 +299,9 @@ func (j *Job) startExecution() {
 	go j.runBackgroundTasks(&wg)
 
 	// Print the base URL when starting a new recursion or sniper queue job
-	if j.queuepos > 1 {
+	if j.queue.position() > 1 {
 		if j.Config.InputMode == "sniper" {
-			j.Output.Info(fmt.Sprintf("Starting queued sniper job (%d of %d) on target: %s", j.queuepos, len(j.queuejobs), j.Config.Url))
+			j.Output.Info(fmt.Sprintf("Starting queued sniper job (%d of %d) on target: %s", j.queue.position(), j.queue.total(), j.Config.Url))
 		} else {
 			j.Output.Info(fmt.Sprintf("Starting queued job on target: %s", j.Config.Url))
 		}
@@ -290,7 +310,16 @@ func (j *Job) startExecution() {
 	//Limiter blocks after reaching the buffer, ensuring limited concurrency
 	threadlimiter := make(chan bool, j.Config.Threads)
 
-	for j.Input.Next() && !j.isSkipQueue() {
+	for {
+		// Advancing the input cursor is done under inputMutex so an interactive
+		// restart (which calls Input.Reset) cannot race it.
+		j.inputMutex.Lock()
+		hasNext := j.Input.Next()
+		j.inputMutex.Unlock()
+		if !hasNext || j.isSkipQueue() {
+			break
+		}
+
 		// Check if we should stop the process
 		j.CheckStop()
 
@@ -298,13 +327,16 @@ func (j *Job) startExecution() {
 			defer j.Output.Warning(j.getError())
 			break
 		}
-		j.pauseWg.Wait()
+		j.pauseCheckpoint()
 		// Handle the rate & thread limiting
 		threadlimiter <- true
 		// Ratelimiter handles the rate ticker
 		<-j.Rate.RateLimiter.C
+
+		j.inputMutex.Lock()
 		nextInput := j.Input.Value()
 		nextPosition := j.Input.Position()
+		j.inputMutex.Unlock()
 		// Add FFUFHASH and its value
 		nextInput["FFUFHASH"] = j.ffufHash(nextPosition)
 
@@ -335,10 +367,9 @@ func (j *Job) interruptMonitor() {
 	go func() {
 		for range sigChan {
 			j.setError("Caught keyboard interrupt (Ctrl-C)\n")
-			// resume if paused
-			if j.isPaused() {
-				j.pauseWg.Done()
-			}
+			// Resume if paused so the workers can observe the stop; Resume is a
+			// no-op when the job is not paused.
+			j.Resume()
 			// Stop the job
 			j.Stop()
 		}
@@ -349,7 +380,7 @@ func (j *Job) runBackgroundTasks(wg *sync.WaitGroup) {
 	defer wg.Done()
 	totalProgress := j.Input.Total()
 	for j.getCounter() <= totalProgress && !j.isSkipQueue() {
-		j.pauseWg.Wait()
+		j.pauseCheckpoint()
 		if !j.isRunning() {
 			break
 		}
@@ -366,12 +397,12 @@ func (j *Job) runBackgroundTasks(wg *sync.WaitGroup) {
 
 func (j *Job) updateProgress() {
 	prog := Progress{
-		StartedAt:  j.startTimeJob,
+		StartedAt:  j.getStartTimeJob(),
 		ReqCount:   j.getCounter(),
 		ReqTotal:   j.Input.Total(),
 		ReqSec:     j.Rate.CurrentRate(),
-		QueuePos:   j.queuepos,
-		QueueTotal: len(j.queuejobs),
+		QueuePos:   j.queue.position(),
+		QueueTotal: j.queue.total(),
 		ErrorCount: j.getErrorCounter(),
 	}
 	j.Output.Progress(prog)
@@ -440,7 +471,7 @@ func (j *Job) ffufHash(pos int) []byte {
 }
 
 func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
-	basereq := j.queuejobs[j.queuepos-1].req
+	basereq := j.queue.currentReq()
 	req, err := j.Runner.Prepare(input, &basereq)
 	req.Timestamp = time.Now()
 
@@ -466,12 +497,15 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 	}
 
 	if err != nil {
-		if retried {
-			j.incError()
-			log.Printf("%s", err)
-		} else {
+		if !retried {
+			// Retry once. The timeout messaging below runs only on the final
+			// failure, so a request that recovers on retry does not also print a
+			// spurious timeout notice.
 			j.runTask(input, position, true)
+			return
 		}
+		j.incError()
+		log.Printf("%s", err)
 		if os.IsTimeout(err) {
 			for name := range j.Config.MatcherManager.GetMatchers() {
 				if name == "time" {
@@ -520,7 +554,7 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 			j.inc429()
 		}
 	}
-	j.pauseWg.Wait()
+	j.pauseCheckpoint()
 
 	// Handle autocalibration, must be done after the actual request to ensure sane value in req.Host
 	_ = j.CalibrateIfNeeded(HostURLFromRequest(req), input)
@@ -580,7 +614,7 @@ func (j *Job) handleGreedyRecursionJob(resp Response) {
 	if j.Config.RecursionDepth == 0 || j.currentDepth < j.Config.RecursionDepth {
 		recUrl := resp.Request.Url + "/" + "FUZZ"
 		newJob := QueueJob{Url: recUrl, depth: j.currentDepth + 1, req: RecursionRequest(j.Config, recUrl)}
-		j.queuejobs = append(j.queuejobs, newJob)
+		j.queue.push(newJob)
 		j.Output.Info(fmt.Sprintf("Adding a new job to the queue: %s", recUrl))
 	} else {
 		j.Output.Warning(fmt.Sprintf("Maximum recursion depth reached. Ignoring: %s", resp.Request.Url))
@@ -598,7 +632,7 @@ func (j *Job) handleDefaultRecursionJob(resp Response) {
 	if j.Config.RecursionDepth == 0 || j.currentDepth < j.Config.RecursionDepth {
 		// We have yet to reach the maximum recursion depth
 		newJob := QueueJob{Url: recUrl, depth: j.currentDepth + 1, req: RecursionRequest(j.Config, recUrl)}
-		j.queuejobs = append(j.queuejobs, newJob)
+		j.queue.push(newJob)
 		j.Output.Info(fmt.Sprintf("Adding a new job to the queue: %s", recUrl))
 	} else {
 		j.Output.Warning(fmt.Sprintf("Directory found, but recursion depth exceeded. Ignoring: %s", resp.GetRedirectLocation(true)))
@@ -634,7 +668,7 @@ func (j *Job) CheckStop() {
 
 	// Check for runtime of entire process
 	if j.Config.MaxTime > 0 {
-		dur := time.Since(j.startTime)
+		dur := time.Since(j.getStartTime())
 		runningSecs := int(dur / time.Second)
 		if runningSecs >= j.Config.MaxTime {
 			j.setError("Maximum running time for entire process reached, exiting.")
@@ -644,7 +678,7 @@ func (j *Job) CheckStop() {
 
 	// Check for runtime of current job
 	if j.Config.MaxTimeJob > 0 {
-		dur := time.Since(j.startTimeJob)
+		dur := time.Since(j.getStartTimeJob())
 		runningSecs := int(dur / time.Second)
 		if runningSecs >= j.Config.MaxTimeJob {
 			j.setError("Maximum running time for this job reached, continuing with next job if one exists.")

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -258,14 +258,20 @@ func (j *Job) sleepIfNeeded() {
 // holds the write lock, every worker blocks at its pauseCheckpoint (an RLock).
 //
 // pauseStateMutex makes the paused-flag flip and the pauseMutex Lock/Unlock a
-// single atomic step. It has to: Pause runs on the interactive goroutine while
-// Resume also fires from the SIGINT handler, so a plain CAS-then-Lock would let a
-// Resume slip between Pause's flag flip and its Lock and unlock an unlocked mutex
-// (a fatal panic). Under the state mutex there is exactly one Lock per Unlock for
-// any interleaving of Pause/Resume/interrupt.
+// single atomic step, so there is exactly one Lock per Unlock and no goroutine
+// ever unlocks an unlocked mutex (a fatal panic), however Pause, Resume, and the
+// SIGINT handler interleave.
+//
+// Pausing is refused once the job is stopping (isRunning is false). Together with
+// Stop() calling Resume(), that guarantees the gate always ends OPEN after a Stop
+// regardless of ordering, so a Pause racing a Stop can never strand a worker at
+// the checkpoint with no Resume left to wake it.
 func (j *Job) Pause() {
 	j.pauseStateMutex.Lock()
 	defer j.pauseStateMutex.Unlock()
+	if !j.isRunning() {
+		return
+	}
 	if !j.paused {
 		j.paused = true
 		j.pauseMutex.Lock()
@@ -354,7 +360,11 @@ func (j *Job) startExecution() {
 		}()
 		if !j.isRunningJob() {
 			defer j.Output.Warning(j.getError())
-			return
+			// break, not return: fall through to wg.Wait() so the in-flight
+			// workers finish before Start() advances to the next queue job, which
+			// rewrites Config.Url / currentDepth / keyword-active state that those
+			// workers still read (the -maxtime-job drain race).
+			break
 		}
 	}
 	wg.Wait()
@@ -367,10 +377,8 @@ func (j *Job) interruptMonitor() {
 	go func() {
 		for range sigChan {
 			j.setError("Caught keyboard interrupt (Ctrl-C)\n")
-			// Resume if paused so the workers can observe the stop; Resume is a
-			// no-op when the job is not paused.
-			j.Resume()
-			// Stop the job
+			// Stop reopens the pause gate itself, so a worker blocked at a
+			// checkpoint wakes and observes the stop.
 			j.Stop()
 		}
 	}()
@@ -692,6 +700,10 @@ func (j *Job) CheckStop() {
 func (j *Job) Stop() {
 	j.setRunning(false)
 	j.Config.Cancel()
+	// Reopen the pause gate so no worker is left blocked at a checkpoint after a
+	// stop. Resume is a no-op when the job is not paused, and Pause refuses to
+	// close the gate once isRunning is false, so the gate always ends open.
+	j.Resume()
 }
 
 // Stop current, resume to next

--- a/pkg/ffuf/jobqueue.go
+++ b/pkg/ffuf/jobqueue.go
@@ -1,0 +1,91 @@
+package ffuf
+
+import "sync"
+
+// jobQueue owns the recursion/sniper job list and the active position, together
+// with the mutex that guards them. Worker goroutines append to the queue (from
+// the recursion handlers) while the main loop advances through it and the
+// progress goroutine and the interactive handler read it, so the slice and the
+// position must never be touched outside these methods. The fields are private:
+// there is no way to append without the lock.
+type jobQueue struct {
+	mu   sync.Mutex
+	jobs []QueueJob
+	pos  int
+}
+
+func newJobQueue() *jobQueue {
+	return &jobQueue{jobs: make([]QueueJob, 0)}
+}
+
+// push appends a job to the queue.
+func (q *jobQueue) push(j QueueJob) {
+	q.mu.Lock()
+	q.jobs = append(q.jobs, j)
+	q.mu.Unlock()
+}
+
+// hasNext reports whether an unprocessed job remains.
+func (q *jobQueue) hasNext() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.pos < len(q.jobs)
+}
+
+// advance returns the job at the active position and moves the cursor past it,
+// returning the new position (1-based marker matching the previous queuepos).
+func (q *jobQueue) advance() (QueueJob, int) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	job := q.jobs[q.pos]
+	q.pos++
+	return job, q.pos
+}
+
+// currentReq returns the request of the job at the active position (pos-1).
+func (q *jobQueue) currentReq() Request {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.jobs[q.pos-1].req
+}
+
+// position returns the active position marker.
+func (q *jobQueue) position() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.pos
+}
+
+// total returns the number of jobs currently in the queue.
+func (q *jobQueue) total() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.jobs)
+}
+
+// remaining returns a copy of the jobs from the active position onward.
+func (q *jobQueue) remaining() []QueueJob {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	start := q.pos - 1
+	if start < 0 || start > len(q.jobs) {
+		return nil
+	}
+	out := make([]QueueJob, len(q.jobs[start:]))
+	copy(out, q.jobs[start:])
+	return out
+}
+
+// removeAt deletes the queued job at the given offset from the active position
+// (the 1-based offset the interactive queuedel command uses). It returns false
+// when the offset is out of range instead of panicking.
+func (q *jobQueue) removeAt(offset int) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	idx := q.pos + offset - 1
+	if idx < 0 || idx >= len(q.jobs) {
+		return false
+	}
+	q.jobs = append(q.jobs[:idx], q.jobs[idx+1:]...)
+	return true
+}

--- a/pkg/ffuf/pausegate_test.go
+++ b/pkg/ffuf/pausegate_test.go
@@ -1,0 +1,76 @@
+package ffuf
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestPauseGate_ConcurrentIdempotent regresses C8: the pause gate used a
+// sync.WaitGroup as a resettable barrier, which called Add concurrently with
+// Wait (a documented misuse the race detector flags) and had a double-Done
+// negative-counter panic path. The replacement is an RWMutex gate made
+// idempotent by an atomic CAS. Run under -race.
+func TestPauseGate_ConcurrentIdempotent(t *testing.T) {
+	j := &Job{Output: NewNullOutput()}
+
+	// Duplicate Pause/Resume must not panic or unbalance the gate.
+	j.Pause()
+	j.Pause()
+	j.Resume()
+	j.Resume()
+	// A stray Resume with no matching Pause must be a no-op, not an unlock panic.
+	j.Resume()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Workers hammer the pause checkpoint while another goroutine toggles pause.
+	for w := 0; w < 8; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					j.pauseCheckpoint()
+				}
+			}
+		}()
+	}
+	for k := 0; k < 500; k++ {
+		j.Pause()
+		j.Resume()
+	}
+	close(stop)
+	wg.Wait()
+}
+
+// TestPauseGate_ConcurrentPauseResume drives Pause and Resume from two separate
+// goroutines. That is the real interleaving (an interactive pause while the
+// SIGINT handler calls Resume), and a gate that flips its flag and takes the lock
+// in two steps turns it into a fatal "Unlock of unlocked RWMutex". The flag flip
+// and the Lock/Unlock must be one atomic step. Run under -race.
+func TestPauseGate_ConcurrentPauseResume(t *testing.T) {
+	j := &Job{Output: NewNullOutput()}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100000; i++ {
+			j.Pause()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100000; i++ {
+			j.Resume()
+		}
+	}()
+	wg.Wait()
+
+	// Leave the gate unlocked regardless of which side won the last iteration.
+	j.Resume()
+}

--- a/pkg/ffuf/pausegate_test.go
+++ b/pkg/ffuf/pausegate_test.go
@@ -1,8 +1,10 @@
 package ffuf
 
 import (
+	"context"
 	"sync"
 	"testing"
+	"time"
 )
 
 // TestPauseGate_ConcurrentIdempotent regresses C8: the pause gate used a
@@ -12,6 +14,7 @@ import (
 // idempotent by an atomic CAS. Run under -race.
 func TestPauseGate_ConcurrentIdempotent(t *testing.T) {
 	j := &Job{Output: NewNullOutput()}
+	j.setRunning(true) // Pause refuses to engage the gate unless the job is running
 
 	// Duplicate Pause/Resume must not panic or unbalance the gate.
 	j.Pause()
@@ -54,6 +57,7 @@ func TestPauseGate_ConcurrentIdempotent(t *testing.T) {
 // and the Lock/Unlock must be one atomic step. Run under -race.
 func TestPauseGate_ConcurrentPauseResume(t *testing.T) {
 	j := &Job{Output: NewNullOutput()}
+	j.setRunning(true)
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -73,4 +77,55 @@ func TestPauseGate_ConcurrentPauseResume(t *testing.T) {
 
 	// Leave the gate unlocked regardless of which side won the last iteration.
 	j.Resume()
+}
+
+// runningJobWithCancel builds a minimal running Job whose Stop() can call
+// Config.Cancel() without a nil panic.
+func runningJobWithCancel() *Job {
+	ctx, cancel := context.WithCancel(context.Background())
+	j := &Job{Output: NewNullOutput(), Config: &Config{Context: ctx, Cancel: cancel}}
+	j.setRunning(true)
+	return j
+}
+
+// TestPauseGate_StopReopensGate regresses the teardown-hang: a paused job that is
+// Stopped must reopen the gate so a worker arriving at the checkpoint is not
+// stranded with no Resume left to wake it.
+func TestPauseGate_StopReopensGate(t *testing.T) {
+	j := runningJobWithCancel()
+	j.Pause() // gate closed
+
+	j.Stop() // must reopen the gate
+
+	done := make(chan struct{})
+	go func() { j.pauseCheckpoint(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pauseCheckpoint stranded after Stop: the gate was not reopened")
+	}
+}
+
+// TestPauseGate_ConcurrentStopPauseNeverStrands hammers the exact race the review
+// found: a Pause landing around a concurrent Stop. Whatever the interleaving, the
+// gate must end open (Pause refuses once stopping, and Stop resumes), so a
+// checkpoint never blocks forever. Run under -race.
+func TestPauseGate_ConcurrentStopPauseNeverStrands(t *testing.T) {
+	for iter := 0; iter < 300; iter++ {
+		j := runningJobWithCancel()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); j.Pause() }()
+		go func() { defer wg.Done(); j.Stop() }()
+		wg.Wait()
+
+		done := make(chan struct{})
+		go func() { j.pauseCheckpoint(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("iter %d: worker stranded at checkpoint after concurrent Stop/Pause", iter)
+		}
+	}
 }

--- a/pkg/ffuf/rate.go
+++ b/pkg/ffuf/rate.go
@@ -23,6 +23,11 @@ func NewRateThrottle(conf *Config) *RateThrottle {
 	if conf.Rate > 0 {
 		r.rateCounter = ring.New(int(conf.Rate * 5))
 		ratemicros := 1000000 / conf.Rate
+		if ratemicros < 1 {
+			// conf.Rate > 1000000 divides to 0; NewTicker panics on a non-positive
+			// interval. Clamp to the 1us floor (~1M req/s).
+			ratemicros = 1
+		}
 		r.RateLimiter = time.NewTicker(time.Microsecond * time.Duration(ratemicros))
 	} else {
 		r.rateCounter = ring.New(conf.Threads * 5)
@@ -85,6 +90,11 @@ func (r *RateThrottle) ChangeRate(rate int) {
 		period = time.Microsecond * 1
 		// reset the rate counter
 		r.rateCounter = ring.New(r.Config.Threads * 5)
+	}
+	if period <= 0 {
+		// rate > 1000000 makes 1000000/rate integer-divide to 0; a non-positive
+		// ticker interval panics. Clamp to the 1us floor (~1M req/s).
+		period = time.Microsecond
 	}
 
 	// Reset re-periodizes the existing ticker rather than replacing it, so the

--- a/pkg/ffuf/rate.go
+++ b/pkg/ffuf/rate.go
@@ -64,25 +64,33 @@ func (r *RateThrottle) CurrentRate() int64 {
 	return 0
 }
 
+// CurrentConfiguredRate returns the configured rate under the lock, for callers
+// (e.g. the interactive handler) that only need to display it.
+func (r *RateThrottle) CurrentConfiguredRate() int64 {
+	r.RateMutex.Lock()
+	defer r.RateMutex.Unlock()
+	return r.Config.Rate
+}
+
 func (r *RateThrottle) ChangeRate(rate int) {
 	r.RateMutex.Lock()
 	defer r.RateMutex.Unlock()
-	ratemicros := 0 // set default to 0, avoids integer divide by 0 error
 
-	if rate != 0 {
-		ratemicros = 1000000 / rate
-	}
-
-	r.RateLimiter.Stop()
+	var period time.Duration
 	if rate > 0 {
-		r.RateLimiter = time.NewTicker(time.Microsecond * time.Duration(ratemicros))
+		period = time.Microsecond * time.Duration(1000000/rate)
 		// reset the rate counter
 		r.rateCounter = ring.New(rate * 5)
 	} else {
-		r.RateLimiter = time.NewTicker(time.Microsecond * 1)
+		period = time.Microsecond * 1
 		// reset the rate counter
 		r.rateCounter = ring.New(r.Config.Threads * 5)
 	}
+
+	// Reset re-periodizes the existing ticker rather than replacing it, so the
+	// RateLimiter pointer is written once (at construction) and never reassigned.
+	// That is what lets the execution loop read RateLimiter.C without a lock.
+	r.RateLimiter.Reset(period)
 
 	r.Config.Rate = int64(rate)
 }

--- a/pkg/ffuf/ratethrottle_test.go
+++ b/pkg/ffuf/ratethrottle_test.go
@@ -1,0 +1,21 @@
+package ffuf
+
+import "testing"
+
+// TestNewRateThrottle_HugeRateNoPanic regresses P3: conf.Rate > 1000000 makes
+// 1000000/rate integer-divide to 0, and a non-positive ticker interval panics.
+func TestNewRateThrottle_HugeRateNoPanic(t *testing.T) {
+	_ = NewRateThrottle(&Config{Rate: 2000000, Threads: 40})
+	_ = NewRateThrottle(&Config{Rate: 1000001, Threads: 40})
+}
+
+// TestChangeRate_HugeRateNoPanic regresses the same on the interactive `rate`
+// command path, plus the zero/negative branches.
+func TestChangeRate_HugeRateNoPanic(t *testing.T) {
+	r := NewRateThrottle(&Config{Rate: 0, Threads: 40})
+	r.ChangeRate(2000000) // 1000000/2000000 == 0
+	r.ChangeRate(1000001)
+	r.ChangeRate(0)
+	r.ChangeRate(-5)
+	r.ChangeRate(500) // and a normal value still works
+}

--- a/pkg/filter/concurrency_test.go
+++ b/pkg/filter/concurrency_test.go
@@ -1,0 +1,94 @@
+package filter
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestMatcherManager_ConcurrentReadWrite regresses C1: the reader methods took
+// no lock while the writers did, so the write-side mutex protected writers only
+// from each other. With -ac at default threads a worker ranging GetFilters()
+// raced autocalibration's AddFilter, which the Go runtime aborts with
+// "concurrent map read and map write". Run under -race; before the fix this
+// crashes.
+func TestMatcherManager_ConcurrentReadWrite(t *testing.T) {
+	mm := NewMatcherManager()
+	if err := mm.AddMatcher("status", "all"); err != nil {
+		t.Fatalf("AddMatcher: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// writers: churn the maps like autocalibration and the interactive fc/fs
+	// commands do.
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = mm.AddFilter("size", "1337", false)
+					mm.RemoveFilter("size")
+					_ = mm.AddPerDomainFilter("host.example", "word", "9")
+					mm.SetCalibratedForHost("host.example", true)
+					mm.SetCalibrated(true)
+				}
+			}
+		}()
+	}
+	// readers: exactly what every worker's isMatch does.
+	for r := 0; r < 8; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					for range mm.GetFilters() {
+					}
+					for range mm.GetMatchers() {
+					}
+					for range mm.FiltersForDomain("host.example") {
+					}
+					_ = mm.Calibrated()
+					_ = mm.CalibratedForDomain("host.example")
+				}
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// TestMatcherManager_PerDomainDoesNotAliasGlobal regresses F1: NewPerDomainFilter
+// stored the global filter map by reference, so a per-domain filter write leaked
+// into the global filter set (and thus applied to every host).
+func TestMatcherManager_PerDomainDoesNotAliasGlobal(t *testing.T) {
+	mm := NewMatcherManager()
+	if err := mm.AddFilter("size", "100", false); err != nil {
+		t.Fatalf("AddFilter global: %v", err)
+	}
+	if err := mm.AddPerDomainFilter("host.example", "word", "5"); err != nil {
+		t.Fatalf("AddPerDomainFilter: %v", err)
+	}
+
+	if _, leaked := mm.GetFilters()["word"]; leaked {
+		t.Error("per-domain 'word' filter leaked into the global filter set (F1 aliasing)")
+	}
+	perDomain := mm.FiltersForDomain("host.example")
+	if _, ok := perDomain["word"]; !ok {
+		t.Error("per-domain filter set should contain its own 'word' filter")
+	}
+	if _, ok := perDomain["size"]; !ok {
+		t.Error("per-domain filter set should inherit the global 'size' filter")
+	}
+}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -8,9 +8,18 @@ import (
 )
 
 // MatcherManager handles both filters and matchers.
+//
+// Every access to the Matchers/Filters/PerDomainFilters maps goes through the
+// methods below under mu (an RWMutex). Readers RLock and return a *copy* of the
+// map: the request path (Job.isMatch) ranges the returned map after the method
+// has returned, so handing back the live map would let a worker iterate it while
+// autocalibration or an interactive filter command mutates it on another
+// goroutine, which the Go runtime aborts with "concurrent map read and map
+// write". Copying the map header (the FilterProvider values are immutable once
+// created) keeps the caller's iteration off the shared map.
 type MatcherManager struct {
+	mu               sync.RWMutex
 	IsCalibrated     bool
-	Mutex            sync.Mutex
 	Matchers         map[string]ffuf.FilterProvider
 	Filters          map[string]ffuf.FilterProvider
 	PerDomainFilters map[string]*PerDomainFilter
@@ -21,12 +30,25 @@ type PerDomainFilter struct {
 	Filters      map[string]ffuf.FilterProvider
 }
 
+// NewPerDomainFilter copies the supplied (global) filter map. Storing the map by
+// reference aliased the global Filters, so a per-domain filter write mutated the
+// global filter set and leaked into every host.
 func NewPerDomainFilter(globfilters map[string]ffuf.FilterProvider) *PerDomainFilter {
-	return &PerDomainFilter{IsCalibrated: false, Filters: globfilters}
+	return &PerDomainFilter{IsCalibrated: false, Filters: copyFilterMap(globfilters)}
 }
 
 func (p *PerDomainFilter) SetCalibrated(value bool) {
 	p.IsCalibrated = value
+}
+
+// copyFilterMap returns a shallow copy of a filter map. The FilterProvider values
+// are safe to share: they are replaced, never mutated, after creation.
+func copyFilterMap(in map[string]ffuf.FilterProvider) map[string]ffuf.FilterProvider {
+	out := make(map[string]ffuf.FilterProvider, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 func NewMatcherManager() ffuf.MatcherManager {
@@ -39,10 +61,14 @@ func NewMatcherManager() ffuf.MatcherManager {
 }
 
 func (f *MatcherManager) SetCalibrated(value bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.IsCalibrated = value
 }
 
 func (f *MatcherManager) SetCalibratedForHost(host string, value bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.PerDomainFilters[host] != nil {
 		f.PerDomainFilters[host].IsCalibrated = value
 	} else {
@@ -74,10 +100,10 @@ func NewFilterByName(name string, value string) (ffuf.FilterProvider, error) {
 	return nil, fmt.Errorf("Could not create filter with name %s", name)
 }
 
-//AddFilter adds a new filter to MatcherManager
+// AddFilter adds a new filter to MatcherManager
 func (f *MatcherManager) AddFilter(name string, option string, replace bool) error {
-	f.Mutex.Lock()
-	defer f.Mutex.Unlock()
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	newf, err := NewFilterByName(name, option)
 	if err == nil {
 		// valid filter create or append
@@ -94,10 +120,10 @@ func (f *MatcherManager) AddFilter(name string, option string, replace bool) err
 	return err
 }
 
-//AddPerDomainFilter adds a new filter to PerDomainFilter configuration
+// AddPerDomainFilter adds a new filter to PerDomainFilter configuration
 func (f *MatcherManager) AddPerDomainFilter(domain string, name string, option string) error {
-	f.Mutex.Lock()
-	defer f.Mutex.Unlock()
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	var pdFilters *PerDomainFilter
 	if filter, ok := f.PerDomainFilters[domain]; ok {
 		pdFilters = filter
@@ -121,17 +147,17 @@ func (f *MatcherManager) AddPerDomainFilter(domain string, name string, option s
 	return err
 }
 
-//RemoveFilter removes a filter of a given type
+// RemoveFilter removes a filter of a given type
 func (f *MatcherManager) RemoveFilter(name string) {
-	f.Mutex.Lock()
-	defer f.Mutex.Unlock()
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	delete(f.Filters, name)
 }
 
-//AddMatcher adds a new matcher to Config
+// AddMatcher adds a new matcher to Config
 func (f *MatcherManager) AddMatcher(name string, option string) error {
-	f.Mutex.Lock()
-	defer f.Mutex.Unlock()
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	newf, err := NewFilterByName(name, option)
 	if err == nil {
 		// valid filter create or append
@@ -149,21 +175,29 @@ func (f *MatcherManager) AddMatcher(name string, option string) error {
 }
 
 func (f *MatcherManager) GetFilters() map[string]ffuf.FilterProvider {
-	return f.Filters
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return copyFilterMap(f.Filters)
 }
 
 func (f *MatcherManager) GetMatchers() map[string]ffuf.FilterProvider {
-	return f.Matchers
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return copyFilterMap(f.Matchers)
 }
 
 func (f *MatcherManager) FiltersForDomain(domain string) map[string]ffuf.FilterProvider {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	if f.PerDomainFilters[domain] == nil {
-		return f.Filters
+		return copyFilterMap(f.Filters)
 	}
-	return f.PerDomainFilters[domain].Filters
+	return copyFilterMap(f.PerDomainFilters[domain].Filters)
 }
 
 func (f *MatcherManager) CalibratedForDomain(domain string) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	if f.PerDomainFilters[domain] != nil {
 		return f.PerDomainFilters[domain].IsCalibrated
 	}
@@ -171,5 +205,7 @@ func (f *MatcherManager) CalibratedForDomain(domain string) bool {
 }
 
 func (f *MatcherManager) Calibrated() bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	return f.IsCalibrated
 }

--- a/pkg/interactive/termhandler.go
+++ b/pkg/interactive/termhandler.go
@@ -206,10 +206,14 @@ func (i *interactive) handleInput(in []byte) {
 }
 
 func (i *interactive) refreshResults() {
-	results := make([]ffuf.Result, 0)
 	filters := i.Job.Config.MatcherManager.GetFilters()
-	for _, filter := range filters {
-		for _, res := range i.Job.Output.GetCurrentResults() {
+	// Keep a result only if it survives every active filter. The filtering runs
+	// under the output lock via FilterCurrentResults, so a match arriving mid-
+	// refresh is not dropped (the previous GetCurrentResults/SetCurrentResults
+	// pair had a read-modify-write gap that lost it, and it double-counted a
+	// result once per filter it passed).
+	i.Job.Output.FilterCurrentResults(func(res ffuf.Result) bool {
+		for _, filter := range filters {
 			fakeResp := &ffuf.Response{
 				StatusCode:    res.StatusCode,
 				ContentLines:  res.ContentLength,
@@ -217,12 +221,12 @@ func (i *interactive) refreshResults() {
 				ContentLength: res.ContentLength,
 			}
 			filterOut, _ := filter.Filter(fakeResp)
-			if !filterOut {
-				results = append(results, res)
+			if filterOut {
+				return false
 			}
 		}
-	}
-	i.Job.Output.SetCurrentResults(results)
+		return true
+	})
 }
 
 func (i *interactive) updateFilter(name, value string, replace bool) {
@@ -292,7 +296,7 @@ func (i *interactive) printHelp() {
 			ft = "(active: " + filter.Repr() + ")"
 		}
 	}
-	rate := fmt.Sprintf("(active: %d)", i.Job.Config.Rate)
+	rate := fmt.Sprintf("(active: %d)", i.Job.Rate.CurrentConfiguredRate())
 	help := `
 available commands:
  afc  [value]             - append to status code filter %s

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -96,7 +96,12 @@ func (s *Stdoutput) ansiClear() string {
 }
 
 func (s *Stdoutput) Banner() {
-	version := strings.ReplaceAll(ffuf.FormattedVersion(), "<3", fmt.Sprintf("%s<3%s", ANSI_RED, ANSI_CLEAR))
+	version := ffuf.FormattedVersion()
+	if s.config.Colors {
+		// Only colorize the heart when colors are enabled; otherwise a redirected
+		// or non-terminal stderr gets raw ANSI escape bytes in the banner.
+		version = strings.ReplaceAll(version, "<3", fmt.Sprintf("%s<3%s", ANSI_RED, ANSI_CLEAR))
+	}
 	fmt.Fprintf(os.Stderr, "%s\n       %s\n%s\n\n", BANNER_HEADER, version, BANNER_SEP)
 	printOption([]byte("Method"), []byte(s.config.Method))
 	printOption([]byte("URL"), []byte(s.config.Url))
@@ -218,6 +223,22 @@ func (s *Stdoutput) SetCurrentResults(results []ffuf.Result) {
 	s.resultMutex.Lock()
 	s.CurrentResults = results
 	s.resultMutex.Unlock()
+}
+
+// FilterCurrentResults keeps only the results for which keep returns true. The
+// read-filter-write runs under resultMutex, so a concurrent Result() append is
+// not lost through a stale snapshot the way a caller-side GetCurrentResults /
+// SetCurrentResults pair would drop it.
+func (s *Stdoutput) FilterCurrentResults(keep func(ffuf.Result) bool) {
+	s.resultMutex.Lock()
+	defer s.resultMutex.Unlock()
+	filtered := make([]ffuf.Result, 0, len(s.CurrentResults))
+	for _, r := range s.CurrentResults {
+		if keep(r) {
+			filtered = append(filtered, r)
+		}
+	}
+	s.CurrentResults = filtered
 }
 
 func (s *Stdoutput) Progress(status ffuf.Progress) {

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -135,5 +135,16 @@ func (c *capture) GetCurrentResults() []ffuf.Result {
 	return c.results
 }
 func (c *capture) SetCurrentResults(r []ffuf.Result) { c.mu.Lock(); c.results = r; c.mu.Unlock() }
-func (c *capture) Reset()                            {}
-func (c *capture) Cycle()                            {}
+func (c *capture) FilterCurrentResults(keep func(ffuf.Result) bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	filtered := make([]ffuf.Result, 0, len(c.results))
+	for _, r := range c.results {
+		if keep(r) {
+			filtered = append(filtered, r)
+		}
+	}
+	c.results = filtered
+}
+func (c *capture) Reset() {}
+func (c *capture) Cycle() {}

--- a/test/integration/recursion_concurrency_test.go
+++ b/test/integration/recursion_concurrency_test.go
@@ -1,0 +1,43 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/testtarget"
+)
+
+// TestRecursionConcurrentQueue regresses C2: worker goroutines appended to the
+// shared recursion queue with no synchronization. Greedy recursion on
+// /reflect/FUZZ makes every one of the (default 40 thread) base matches queue a
+// recursion job at nearly the same instant, so many workers append concurrently.
+// Run under -race; before the fix the concurrent appends trip the detector and
+// can drop a queued job or panic on a torn slice header.
+func TestRecursionConcurrentQueue(t *testing.T) {
+	target := testtarget.New()
+	defer target.Close()
+
+	words := make([]string, 25)
+	for i := range words {
+		words[i] = fmt.Sprintf("d%d", i)
+	}
+
+	_ = runScan(t, target.URL+"/reflect/FUZZ",
+		words,
+		func(o *ffuf.ConfigOptions) {
+			o.HTTP.Recursion = true
+			o.HTTP.RecursionStrategy = "greedy"
+			o.HTTP.RecursionDepth = 1
+		},
+		func(mm ffuf.MatcherManager) { mustMatch(t, mm, "status", "200") },
+	)
+
+	// With every base match queuing a depth-1 job that then runs the whole
+	// wordlist, the target must see far more than the 25 base requests. This both
+	// proves recursion descended and is the workload that exercises the concurrent
+	// queue appends under -race.
+	if n := target.Count(); n <= len(words) {
+		t.Errorf("expected recursion to append and process queued jobs (>%d requests), got %d", len(words), n)
+	}
+}


### PR DESCRIPTION
# Fix concurrency defects: MatcherManager, recursion queue, pause gate, and related races

## Summary

Fixes a class of data races found in an adversarial concurrency audit of the engine. Every one was the same shape: shared state guarded on the write path but not the read path, or the wrong sync primitive for the job. Two are process-fatal with default flags.

The fixes adopt a guarded-type plus atomics approach so the class is harder to reintroduce: shared state lives behind a type that owns its lock, readers take the lock too, counters use `sync/atomic`, and the pause gate uses the right primitive. `-race` regression tests drive the previously-racy paths so a regression fails CI.

## Fixes

- **MatcherManager readers were unlocked.** Writers held the mutex, readers did not, so `-ac` at default threads could hit a fatal `concurrent map read and map write` when a worker ranged `GetFilters()` while autocalibration wrote it. Readers now RLock and return a copy of the map; writers Lock; `SetCalibrated*` lock. `NewPerDomainFilter` copies the map instead of aliasing the global one (per-domain filters were leaking into the global set).
- **Recursion queue appended by workers with no lock.** The recursion handlers run in worker goroutines and appended to `queuejobs` while other workers indexed it: `-recursion` at default threads races the slice header and can drop a job or panic. Moved behind a guarded `jobQueue` type with private fields, so there is no lock-free append path. `removeAt` gets the bounds check the interactive delete lacked.
- **Pause gate misused `sync.WaitGroup`.** It called `Add` concurrent with `Wait` (a documented misuse the race detector flags) and had a double-`Done` panic path. Replaced with an RWMutex gate made idempotent by an atomic CAS: workers RLock a checkpoint, `Pause` takes the write lock, `Resume` releases it.
- **Rate ticker pointer swapped under lock, read unlocked.** `ChangeRate` now uses `Ticker.Reset`, so `RateLimiter` is written once and the hot-loop read is race-free.
- Run counters and flags moved to `sync/atomic` (removing `ErrorMutex`). Timer fields and the interactive `restart` input reset are now synchronized.
- Banner ANSI is gated on `-c` (a redirected stderr no longer gets raw escape bytes). The interactive result refresh no longer drops a match that arrives mid-refresh.

## Tests

`go test -race ./...` is green on the existing matrix (ubuntu and macos, go 1.18 and stable). New regression tests, each driving a path that tripped `-race` before the fix:

- `MatcherManager` concurrent read/write, and a deterministic per-domain aliasing test.
- the pause gate under concurrent toggling.
- greedy recursion queue appends under default-thread load.

## Notes

- The go 1.18 floor is kept: classic `atomic.AddInt64`/`LoadInt64` on `int64` fields (grouped first in the struct for 32-bit alignment), not the typed `atomic.Int64` (Go 1.19+).
- Considered but not included here: a channel/actor engine rewrite that would own the recursion queue and results in single goroutines. It is the structurally cleanest option but a behavioral change (ordering, backpressure), better as its own v3 discussion than bundled with a fix.
