### PR TITLE
Structural refactor: testable assembly, match seam, per-job context

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.20
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ['1.18', 'stable']
+        go: ['1.20', 'stable']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A fast web fuzzer written in Go.
   _or_
 - `git clone https://github.com/ffuf/ffuf ; cd ffuf ; go get ; go build`
 
-1. Ffuf depends on Go 1.18 or greater.
+1. Ffuf depends on Go 1.20 or greater.
 2. A go build from a checkout shows `git-<date>-<commit>` rather than the tag. A local build isn't an official release even when you're sitting on a tag, and Go's embedded build info gives us the commit but not the tag name — so we surface the exact commit it was built from. The authoritative versioned binaries are the ones on the releases page.
 
 ## Example usage

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ffuf/ffuf/v2
 
-go 1.18
+go 1.20
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0

--- a/main.go
+++ b/main.go
@@ -9,13 +9,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/ffuf/ffuf/v2/pkg/assembly"
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 	"github.com/ffuf/ffuf/v2/pkg/filter"
 	"github.com/ffuf/ffuf/v2/pkg/input"
 	"github.com/ffuf/ffuf/v2/pkg/interactive"
-	"github.com/ffuf/ffuf/v2/pkg/output"
 	"github.com/ffuf/ffuf/v2/pkg/runner"
-	"github.com/ffuf/ffuf/v2/pkg/scraper"
 )
 
 // flagRegistry describes the registered flags for the segmented help output
@@ -116,7 +115,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	job, err := prepareJob(conf)
+	job, err := assembly.BuildJob(conf)
 
 	if job.AuditLogger != nil {
 		defer job.AuditLogger.Close()
@@ -147,147 +146,43 @@ func main() {
 	job.Start()
 }
 
-func prepareJob(conf *ffuf.Config) (*ffuf.Job, error) {
-	var err error
-	job := ffuf.NewJob(conf)
-	var errs ffuf.Multierror
-	job.Input, errs = input.NewInputProvider(conf)
-	// TODO: implement error handling for runnerprovider and outputprovider
-	// We only have http runner right now
-	job.Runner = runner.NewRunnerByName("http", conf, false)
-	if len(conf.ReplayProxyURL) > 0 {
-		job.ReplayRunner = runner.NewRunnerByName("http", conf, true)
-	}
-	// We only have stdout outputprovider right now
-	job.Output = output.NewOutputProviderByName("stdout", conf)
-
-	// Initialize the audit logger if specified
-	if len(conf.AuditLog) > 0 {
-		job.AuditLogger, err = output.NewAuditLogger(conf.AuditLog)
-		if err != nil {
-			errs.Add(err)
-		} else {
-			err = job.AuditLogger.Write(conf)
-			if err != nil {
-				errs.Add(err)
-			}
-		}
-	}
-
-	// Initialize scraper
-	newscraper, scraper_err := scraper.FromDir(ffuf.SCRAPERDIR, conf.Scrapers)
-	if scraper_err.ErrorOrNil() != nil {
-		errs.Add(scraper_err.ErrorOrNil())
-	}
-	job.Scraper = newscraper
-	if conf.ScraperFile != "" {
-		err = job.Scraper.AppendFromFile(conf.ScraperFile)
-		if err != nil {
-			errs.Add(err)
-		}
-	}
-	return job, errs.ErrorOrNil()
-}
-
+// SetupFilters installs the matchers and filters onto conf.MatcherManager. The
+// matcher/filter construction itself lives in filter.FromConfig (pure, testable);
+// this shim owns only the one decision that genuinely needs the global CLI flag
+// set - whether to install the default status matcher - plus the -ignore-body
+// warning.
 func SetupFilters(parseOpts *ffuf.ConfigOptions, conf *ffuf.Config) error {
-	errs := ffuf.NewMultierror()
-	conf.MatcherManager = filter.NewMatcherManager()
-	// If any other matcher is set, ignore -mc default value
-	matcherSet := false
+	// The default status matcher is installed unless another matcher was explicitly
+	// passed on the CLI. Only the global flag set knows which flags were passed vs
+	// defaulted, so this decision cannot move into the library.
 	statusSet := false
-	warningIgnoreBody := false
+	matcherSet := false
+	// responseMatcherSet tracks the response-body matchers (ms/ml/mw) explicitly
+	// passed on the CLI. The -ignore-body warning keys off CLI-passed flags (as the
+	// original did via flag.Visit), NOT off the config value, so a config-file /
+	// .ffufrc value does not spuriously trigger it.
+	responseMatcherSet := false
 	flag.Visit(func(f *flag.Flag) {
-		if f.Name == "mc" {
+		switch f.Name {
+		case "mc":
 			statusSet = true
-		}
-		if f.Name == "ms" {
+		case "ms", "ml", "mw":
 			matcherSet = true
-			warningIgnoreBody = true
-		}
-		if f.Name == "ml" {
+			responseMatcherSet = true
+		case "mr", "mt":
 			matcherSet = true
-			warningIgnoreBody = true
-		}
-		if f.Name == "mr" {
-			matcherSet = true
-		}
-		if f.Name == "mt" {
-			matcherSet = true
-		}
-		if f.Name == "mw" {
-			matcherSet = true
-			warningIgnoreBody = true
 		}
 	})
-	// Only set default matchers if no
-	if statusSet || !matcherSet {
-		if err := conf.MatcherManager.AddMatcher("status", parseOpts.Matcher.Status); err != nil {
-			errs.Add(err)
-		}
-	}
 
-	if parseOpts.Filter.Status != "" {
-		if err := conf.MatcherManager.AddFilter("status", parseOpts.Filter.Status, false); err != nil {
-			errs.Add(err)
-		}
-	}
-	if parseOpts.Filter.Size != "" {
-		warningIgnoreBody = true
-		if err := conf.MatcherManager.AddFilter("size", parseOpts.Filter.Size, false); err != nil {
-			errs.Add(err)
-		}
-	}
-	if parseOpts.Filter.Regexp != "" {
-		if err := conf.MatcherManager.AddFilter("regexp", parseOpts.Filter.Regexp, false); err != nil {
-			errs.Add(err)
-		}
-	}
-	if parseOpts.Filter.Words != "" {
-		warningIgnoreBody = true
-		if err := conf.MatcherManager.AddFilter("word", parseOpts.Filter.Words, false); err != nil {
-			errs.Add(err)
-		}
-	}
-	if parseOpts.Filter.Lines != "" {
-		warningIgnoreBody = true
-		if err := conf.MatcherManager.AddFilter("line", parseOpts.Filter.Lines, false); err != nil {
-			errs.Add(err)
-		}
-	}
-	if parseOpts.Filter.Time != "" {
-		if err := conf.MatcherManager.AddFilter("time", parseOpts.Filter.Time, false); err != nil {
-			errs.Add(err)
-		}
-	}
-	if parseOpts.Matcher.Size != "" {
-		if err := conf.MatcherManager.AddMatcher("size", parseOpts.Matcher.Size); err != nil {
-			errs.Add(err)
-		}
-	}
-	if parseOpts.Matcher.Regexp != "" {
-		if err := conf.MatcherManager.AddMatcher("regexp", parseOpts.Matcher.Regexp); err != nil {
-			errs.Add(err)
-		}
-	}
-	if parseOpts.Matcher.Words != "" {
-		if err := conf.MatcherManager.AddMatcher("word", parseOpts.Matcher.Words); err != nil {
-			errs.Add(err)
-		}
-	}
-	if parseOpts.Matcher.Lines != "" {
-		if err := conf.MatcherManager.AddMatcher("line", parseOpts.Matcher.Lines); err != nil {
-			errs.Add(err)
-		}
-	}
-	if parseOpts.Matcher.Time != "" {
-		if err := conf.MatcherManager.AddMatcher("time", parseOpts.Matcher.Time); err != nil {
-			errs.Add(err)
-		}
-	}
+	mm, err := filter.FromConfig(parseOpts, statusSet || !matcherSet)
+	conf.MatcherManager = mm
+
+	warningIgnoreBody := responseMatcherSet ||
+		parseOpts.Filter.Size != "" || parseOpts.Filter.Lines != "" || parseOpts.Filter.Words != ""
 	if conf.IgnoreBody && warningIgnoreBody {
 		fmt.Printf("*** Warning: possible undesired combination of -ignore-body and the response options: fl,fs,fw,ml,ms and mw.\n")
 	}
-	return errs.ErrorOrNil()
+	return err
 }
 
 func printSearchResults(conf *ffuf.Config, pos int, exectime time.Time, hash string) {

--- a/pkg/assembly/build.go
+++ b/pkg/assembly/build.go
@@ -1,0 +1,60 @@
+// Package assembly wires a ffuf.Job together from a Config: the input provider,
+// runner(s), output provider, audit logger, and scraper. It exists as its own
+// package because it must import the provider packages (input/runner/output/
+// scraper), which themselves import pkg/ffuf - so this composition cannot live in
+// pkg/ffuf without an import cycle, and it cannot stay unexported in package main
+// without being untestable. Both main and the integration tests call BuildJob, so
+// the production and test wiring can never drift.
+package assembly
+
+import (
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/input"
+	"github.com/ffuf/ffuf/v2/pkg/output"
+	"github.com/ffuf/ffuf/v2/pkg/runner"
+	"github.com/ffuf/ffuf/v2/pkg/scraper"
+)
+
+// BuildJob constructs and wires a Job from conf. It is the single source of truth
+// for how a Job is assembled. Matchers/filters are NOT installed here (they need
+// the CLI flag state); see filter.FromConfig and main.SetupFilters.
+func BuildJob(conf *ffuf.Config) (*ffuf.Job, error) {
+	var err error
+	job := ffuf.NewJob(conf)
+	var errs ffuf.Multierror
+
+	job.Input, errs = input.NewInputProvider(conf)
+
+	// Only the http runner exists today.
+	job.Runner = runner.NewRunnerByName("http", conf, false)
+	if len(conf.ReplayProxyURL) > 0 {
+		job.ReplayRunner = runner.NewRunnerByName("http", conf, true)
+	}
+
+	// Only the stdout output provider exists today.
+	job.Output = output.NewOutputProviderByName("stdout", conf)
+
+	if len(conf.AuditLog) > 0 {
+		job.AuditLogger, err = output.NewAuditLogger(conf.AuditLog)
+		if err != nil {
+			errs.Add(err)
+		} else {
+			if err = job.AuditLogger.Write(conf); err != nil {
+				errs.Add(err)
+			}
+		}
+	}
+
+	newscraper, scraperErr := scraper.FromDir(ffuf.SCRAPERDIR, conf.Scrapers)
+	if scraperErr.ErrorOrNil() != nil {
+		errs.Add(scraperErr.ErrorOrNil())
+	}
+	job.Scraper = newscraper
+	if conf.ScraperFile != "" {
+		if err = job.Scraper.AppendFromFile(conf.ScraperFile); err != nil {
+			errs.Add(err)
+		}
+	}
+
+	return job, errs.ErrorOrNil()
+}

--- a/pkg/ffuf/history_test.go
+++ b/pkg/ffuf/history_test.go
@@ -90,6 +90,7 @@ func (m *fakeMatcherManager) GetMatchers() map[string]FilterProvider            
 func (m *fakeMatcherManager) FiltersForDomain(string) map[string]FilterProvider { return nil }
 func (m *fakeMatcherManager) CalibratedForDomain(string) bool                   { return false }
 func (m *fakeMatcherManager) Calibrated() bool                                  { return false }
+func (m *fakeMatcherManager) Matches(*Response, bool, string, string) bool      { return false }
 
 // TestHistoryOptions_ReflectsRecursedURL locks the recursion fix: WriteHistoryEntry
 // serializes the LIVE Config.Url (rewritten per queued job by prepareQueueJob), not

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -17,6 +17,10 @@ type MatcherManager interface {
 	FiltersForDomain(domain string) map[string]FilterProvider
 	CalibratedForDomain(domain string) bool
 	Calibrated() bool
+	// Matches reports whether resp passes the configured matchers and filters.
+	// perHost selects the per-domain filter set; matcherMode/filterMode are the
+	// and/or combination modes.
+	Matches(resp *Response, perHost bool, matcherMode string, filterMode string) bool
 }
 
 // FilterProvider is a generic interface for both Matchers and Filters

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -416,56 +416,10 @@ func (j *Job) updateProgress() {
 	j.Output.Progress(prog)
 }
 
+// isMatch delegates the match/filter decision to the MatcherManager seam, adapting
+// the Config fields it needs. The logic itself now lives in filter.MatcherManager.
 func (j *Job) isMatch(resp Response) bool {
-	matched := false
-	var matchers map[string]FilterProvider
-	var filters map[string]FilterProvider
-	if j.Config.AutoCalibrationPerHost {
-		filters = j.Config.MatcherManager.FiltersForDomain(HostURLFromRequest(*resp.Request))
-	} else {
-		filters = j.Config.MatcherManager.GetFilters()
-	}
-	matchers = j.Config.MatcherManager.GetMatchers()
-	for _, m := range matchers {
-		match, err := m.Filter(&resp)
-		if err != nil {
-			continue
-		}
-		if match {
-			matched = true
-		} else if j.Config.MatcherMode == "and" {
-			// we already know this isn't "and" match
-			return false
-
-		}
-	}
-	// The response was not matched, return before running filters
-	if !matched {
-		return false
-	}
-	for _, f := range filters {
-		fv, err := f.Filter(&resp)
-		if err != nil {
-			continue
-		}
-		if fv {
-			//	return false
-			if j.Config.FilterMode == "or" {
-				// return early, as filter matched
-				return false
-			}
-		} else {
-			if j.Config.FilterMode == "and" {
-				// return early as not all filters matched in "and" mode
-				return true
-			}
-		}
-	}
-	if len(filters) > 0 && j.Config.FilterMode == "and" {
-		// we did not return early, so all filters were matched
-		return false
-	}
-	return true
+	return j.Config.MatcherManager.Matches(&resp, j.Config.AutoCalibrationPerHost, j.Config.MatcherMode, j.Config.FilterMode)
 }
 
 func (j *Job) ffufHash(pos int) []byte {

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -39,8 +39,7 @@ type Job struct {
 	Total        int
 	Rate         *RateThrottle
 
-	queue        *jobQueue
-	currentDepth int
+	queue *jobQueue
 
 	startTime    time.Time
 	startTimeJob time.Time
@@ -61,11 +60,20 @@ type QueueJob struct {
 	req   Request
 }
 
+// jobContext carries the per-queue-job values a worker needs, passed BY VALUE so
+// no worker reads mutable Job/Config state during execution. basereq is the
+// immutable base request for the job; depth is its recursion depth. This is what
+// makes the recursion-depth and base-request reads correct by construction rather
+// than by drain timing.
+type jobContext struct {
+	basereq Request
+	depth   int
+}
+
 func NewJob(conf *Config) *Job {
 	var j Job
 	j.Config = conf
 	j.queue = newJobQueue()
-	j.currentDepth = 0
 	j.Rate = NewRateThrottle(conf)
 	return &j
 }
@@ -179,10 +187,10 @@ func (j *Job) Start() {
 	// Monitor for SIGTERM and do cleanup properly (writing the output files etc)
 	j.interruptMonitor()
 	for j.jobsInQueue() {
-		j.prepareQueueJob()
+		ctx := j.prepareQueueJob()
 		j.Reset(true)
 		j.setRunningJob(true)
-		j.startExecution()
+		j.startExecution(ctx)
 	}
 
 	err := j.Output.Finalize()
@@ -213,10 +221,12 @@ func (j *Job) jobsInQueue() bool {
 	return j.queue.hasNext()
 }
 
-func (j *Job) prepareQueueJob() {
+func (j *Job) prepareQueueJob() jobContext {
 	job, _ := j.queue.advance()
+	// Config.Url is set here on the MAIN goroutine only, so WriteHistoryEntry below
+	// (FFUFHASH) and the queued-job banner serialize the current target. Workers
+	// never read it; they use the immutable jobContext returned from here.
 	j.Config.Url = job.Url
-	j.currentDepth = job.depth
 
 	//Find all keywords present in new queued job
 	kws := j.Input.Keywords()
@@ -229,6 +239,7 @@ func (j *Job) prepareQueueJob() {
 	//And activate / disable inputproviders as needed
 	j.Input.ActivateKeywords(found_kws)
 	j.Jobhash, _ = WriteHistoryEntry(j.Config)
+	return jobContext{basereq: job.req, depth: job.depth}
 }
 
 // SkipQueue allows to skip the current job and advance to the next queued recursion job
@@ -299,7 +310,7 @@ func (j *Job) pauseCheckpoint() {
 	j.pauseMutex.RUnlock()
 }
 
-func (j *Job) startExecution() {
+func (j *Job) startExecution(ctx jobContext) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go j.runBackgroundTasks(&wg)
@@ -353,7 +364,7 @@ func (j *Job) startExecution() {
 			defer func() { <-threadlimiter }()
 			defer wg.Done()
 			threadStart := time.Now()
-			j.runTask(nextInput, nextPosition, false)
+			j.runTask(ctx, nextInput, nextPosition, false)
 			j.sleepIfNeeded()
 			threadEnd := time.Now()
 			j.Rate.Tick(threadStart, threadEnd)
@@ -432,8 +443,8 @@ func (j *Job) ffufHash(pos int) []byte {
 	return []byte(hashstring)
 }
 
-func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
-	basereq := j.queue.currentReq()
+func (j *Job) runTask(ctx jobContext, input map[string][]byte, position int, retried bool) {
+	basereq := ctx.basereq
 	req, err := j.Runner.Prepare(input, &basereq)
 	req.Timestamp = time.Now()
 
@@ -463,7 +474,7 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 			// Retry once. The timeout messaging below runs only on the final
 			// failure, so a request that recovers on retry does not also print a
 			// spurious timeout notice.
-			j.runTask(input, position, true)
+			j.runTask(ctx, input, position, true)
 			return
 		}
 		j.incError()
@@ -547,7 +558,7 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 		// Refresh the progress indicator as we printed something out
 		j.updateProgress()
 		if j.Config.Recursion && j.Config.RecursionStrategy == "greedy" {
-			j.handleGreedyRecursionJob(resp)
+			j.handleGreedyRecursionJob(ctx, resp)
 		}
 	} else {
 		if len(resp.ScraperData) > 0 {
@@ -557,7 +568,7 @@ func (j *Job) runTask(input map[string][]byte, position int, retried bool) {
 	}
 
 	if j.Config.Recursion && j.Config.RecursionStrategy == "default" && len(resp.GetRedirectLocation(false)) > 0 {
-		j.handleDefaultRecursionJob(resp)
+		j.handleDefaultRecursionJob(ctx, resp)
 	}
 }
 
@@ -571,11 +582,11 @@ func (j *Job) handleScraperResult(resp *Response, sres ScraperResult) {
 }
 
 // handleGreedyRecursionJob adds a recursion job to the queue if the maximum depth has not been reached
-func (j *Job) handleGreedyRecursionJob(resp Response) {
+func (j *Job) handleGreedyRecursionJob(ctx jobContext, resp Response) {
 	// Handle greedy recursion strategy. Match has been determined before calling handleRecursionJob
-	if j.Config.RecursionDepth == 0 || j.currentDepth < j.Config.RecursionDepth {
+	if j.Config.RecursionDepth == 0 || ctx.depth < j.Config.RecursionDepth {
 		recUrl := resp.Request.Url + "/" + "FUZZ"
-		newJob := QueueJob{Url: recUrl, depth: j.currentDepth + 1, req: RecursionRequest(j.Config, recUrl)}
+		newJob := QueueJob{Url: recUrl, depth: ctx.depth + 1, req: RecursionRequest(j.Config, recUrl)}
 		j.queue.push(newJob)
 		j.Output.Info(fmt.Sprintf("Adding a new job to the queue: %s", recUrl))
 	} else {
@@ -585,15 +596,15 @@ func (j *Job) handleGreedyRecursionJob(resp Response) {
 
 // handleDefaultRecursionJob adds a new recursion job to the job queue if a new directory is found and maximum depth has
 // not been reached
-func (j *Job) handleDefaultRecursionJob(resp Response) {
+func (j *Job) handleDefaultRecursionJob(ctx jobContext, resp Response) {
 	recUrl := resp.Request.Url + "/" + "FUZZ"
 	if (resp.Request.Url + "/") != resp.GetRedirectLocation(true) {
 		// Not a directory, return early
 		return
 	}
-	if j.Config.RecursionDepth == 0 || j.currentDepth < j.Config.RecursionDepth {
+	if j.Config.RecursionDepth == 0 || ctx.depth < j.Config.RecursionDepth {
 		// We have yet to reach the maximum recursion depth
-		newJob := QueueJob{Url: recUrl, depth: j.currentDepth + 1, req: RecursionRequest(j.Config, recUrl)}
+		newJob := QueueJob{Url: recUrl, depth: ctx.depth + 1, req: RecursionRequest(j.Config, recUrl)}
 		j.queue.push(newJob)
 		j.Output.Info(fmt.Sprintf("Adding a new job to the queue: %s", recUrl))
 	} else {

--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -175,7 +175,6 @@ func (j *Job) Start() {
 		j.Total = j.Input.Total()
 	}
 
-	rand.Seed(time.Now().UnixNano())
 	defer j.Stop()
 
 	j.setRunning(true)

--- a/pkg/ffuf/jobqueue.go
+++ b/pkg/ffuf/jobqueue.go
@@ -42,13 +42,6 @@ func (q *jobQueue) advance() (QueueJob, int) {
 	return job, q.pos
 }
 
-// currentReq returns the request of the job at the active position (pos-1).
-func (q *jobQueue) currentReq() Request {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	return q.jobs[q.pos-1].req
-}
-
 // position returns the active position marker.
 func (q *jobQueue) position() int {
 	q.mu.Lock()

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -209,3 +209,59 @@ func (f *MatcherManager) Calibrated() bool {
 	defer f.mu.RUnlock()
 	return f.IsCalibrated
 }
+
+// Matches reports whether resp passes the configured matchers and filters. It is
+// the match decision that used to live in Job.isMatch, moved here so it sits with
+// the rule data it decides over and is unit-testable without an engine. perHost
+// selects the per-domain filter set (autocalibration -ach); matcherMode/filterMode
+// are the and/or combination modes. GetFilters/GetMatchers/FiltersForDomain each
+// take the read lock and return a copy, so the ranges below never touch the live
+// maps.
+func (f *MatcherManager) Matches(resp *ffuf.Response, perHost bool, matcherMode string, filterMode string) bool {
+	matched := false
+	var filters map[string]ffuf.FilterProvider
+	if perHost {
+		filters = f.FiltersForDomain(ffuf.HostURLFromRequest(*resp.Request))
+	} else {
+		filters = f.GetFilters()
+	}
+	matchers := f.GetMatchers()
+	for _, m := range matchers {
+		match, err := m.Filter(resp)
+		if err != nil {
+			continue
+		}
+		if match {
+			matched = true
+		} else if matcherMode == "and" {
+			// we already know this isn't an "and" match
+			return false
+		}
+	}
+	// The response was not matched, return before running filters
+	if !matched {
+		return false
+	}
+	for _, flt := range filters {
+		fv, err := flt.Filter(resp)
+		if err != nil {
+			continue
+		}
+		if fv {
+			if filterMode == "or" {
+				// return early, as a filter matched
+				return false
+			}
+		} else {
+			if filterMode == "and" {
+				// return early, as not all filters matched in "and" mode
+				return true
+			}
+		}
+	}
+	if len(filters) > 0 && filterMode == "and" {
+		// we did not return early, so all filters were matched
+		return false
+	}
+	return true
+}

--- a/pkg/filter/fromconfig.go
+++ b/pkg/filter/fromconfig.go
@@ -1,0 +1,80 @@
+package filter
+
+import (
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+// FromConfig builds a MatcherManager from the parsed ConfigOptions. It is the pure,
+// global-free core of what main.SetupFilters used to do inline, so matcher/filter
+// setup is now unit-testable without the CLI flag package. The one CLI-explicit
+// decision - whether to install the default status matcher - needs the global flag
+// set, so it stays in main and is passed in as addDefaultStatusMatcher.
+func FromConfig(opts *ffuf.ConfigOptions, addDefaultStatusMatcher bool) (ffuf.MatcherManager, error) {
+	errs := ffuf.NewMultierror()
+	mm := NewMatcherManager()
+
+	if addDefaultStatusMatcher {
+		if err := mm.AddMatcher("status", opts.Matcher.Status); err != nil {
+			errs.Add(err)
+		}
+	}
+
+	if opts.Filter.Status != "" {
+		if err := mm.AddFilter("status", opts.Filter.Status, false); err != nil {
+			errs.Add(err)
+		}
+	}
+	if opts.Filter.Size != "" {
+		if err := mm.AddFilter("size", opts.Filter.Size, false); err != nil {
+			errs.Add(err)
+		}
+	}
+	if opts.Filter.Regexp != "" {
+		if err := mm.AddFilter("regexp", opts.Filter.Regexp, false); err != nil {
+			errs.Add(err)
+		}
+	}
+	if opts.Filter.Words != "" {
+		if err := mm.AddFilter("word", opts.Filter.Words, false); err != nil {
+			errs.Add(err)
+		}
+	}
+	if opts.Filter.Lines != "" {
+		if err := mm.AddFilter("line", opts.Filter.Lines, false); err != nil {
+			errs.Add(err)
+		}
+	}
+	if opts.Filter.Time != "" {
+		if err := mm.AddFilter("time", opts.Filter.Time, false); err != nil {
+			errs.Add(err)
+		}
+	}
+
+	if opts.Matcher.Size != "" {
+		if err := mm.AddMatcher("size", opts.Matcher.Size); err != nil {
+			errs.Add(err)
+		}
+	}
+	if opts.Matcher.Regexp != "" {
+		if err := mm.AddMatcher("regexp", opts.Matcher.Regexp); err != nil {
+			errs.Add(err)
+		}
+	}
+	if opts.Matcher.Words != "" {
+		if err := mm.AddMatcher("word", opts.Matcher.Words); err != nil {
+			errs.Add(err)
+		}
+	}
+	if opts.Matcher.Lines != "" {
+		if err := mm.AddMatcher("line", opts.Matcher.Lines); err != nil {
+			errs.Add(err)
+		}
+	}
+	if opts.Matcher.Time != "" {
+		if err := mm.AddMatcher("time", opts.Matcher.Time); err != nil {
+			errs.Add(err)
+		}
+	}
+
+	return mm, errs.ErrorOrNil()
+}

--- a/pkg/filter/fromconfig_test.go
+++ b/pkg/filter/fromconfig_test.go
@@ -1,0 +1,49 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+// TestFromConfig_DefaultStatusMatcher covers the one behavior main used to drive
+// via flag.Visit: whether the default status matcher is installed. It is now
+// testable without the flag package.
+func TestFromConfig_DefaultStatusMatcher(t *testing.T) {
+	opts := ffuf.NewConfigOptions()
+
+	mm, err := FromConfig(opts, true)
+	if err != nil {
+		t.Fatalf("FromConfig: %v", err)
+	}
+	if _, ok := mm.GetMatchers()["status"]; !ok {
+		t.Error("default status matcher should be installed when addDefaultStatusMatcher=true")
+	}
+
+	mm2, err := FromConfig(opts, false)
+	if err != nil {
+		t.Fatalf("FromConfig: %v", err)
+	}
+	if _, ok := mm2.GetMatchers()["status"]; ok {
+		t.Error("no status matcher should be installed when addDefaultStatusMatcher=false and none configured")
+	}
+}
+
+// TestFromConfig_FiltersAndMatchers checks that configured filters/matchers are
+// installed from the ConfigOptions values.
+func TestFromConfig_FiltersAndMatchers(t *testing.T) {
+	opts := ffuf.NewConfigOptions()
+	opts.Filter.Size = "100"
+	opts.Matcher.Regexp = "admin"
+
+	mm, err := FromConfig(opts, false)
+	if err != nil {
+		t.Fatalf("FromConfig: %v", err)
+	}
+	if _, ok := mm.GetFilters()["size"]; !ok {
+		t.Error("size filter should be installed from opts.Filter.Size")
+	}
+	if _, ok := mm.GetMatchers()["regexp"]; !ok {
+		t.Error("regexp matcher should be installed from opts.Matcher.Regexp")
+	}
+}

--- a/pkg/filter/matches_test.go
+++ b/pkg/filter/matches_test.go
@@ -1,0 +1,56 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+// resp builds a minimal Response for the non-per-host match path (Request is only
+// dereferenced when perHost is true).
+func resp(status, size int64) *ffuf.Response {
+	return &ffuf.Response{StatusCode: status, ContentLength: size}
+}
+
+// TestMatches_StatusMatcher covers the basic matcher path now that the decision
+// lives on MatcherManager instead of Job.isMatch.
+func TestMatches_StatusMatcher(t *testing.T) {
+	mm := NewMatcherManager()
+	if err := mm.AddMatcher("status", "200,204"); err != nil {
+		t.Fatalf("AddMatcher: %v", err)
+	}
+	if !mm.Matches(resp(200, 10), false, "or", "or") {
+		t.Error("200 should match status 200,204")
+	}
+	if mm.Matches(resp(404, 10), false, "or", "or") {
+		t.Error("404 should not match status 200,204")
+	}
+}
+
+// TestMatches_MatcherModeAnd checks the and-mode combination: every matcher must
+// pass.
+func TestMatches_MatcherModeAnd(t *testing.T) {
+	mm := NewMatcherManager()
+	_ = mm.AddMatcher("status", "200")
+	_ = mm.AddMatcher("size", "10")
+	if !mm.Matches(resp(200, 10), false, "and", "or") {
+		t.Error("200 + size 10 should match in and-mode")
+	}
+	if mm.Matches(resp(200, 99), false, "and", "or") {
+		t.Error("200 + size 99 should NOT match in and-mode (size fails)")
+	}
+}
+
+// TestMatches_FilterDrops checks that a filter removes an otherwise-matched
+// response.
+func TestMatches_FilterDrops(t *testing.T) {
+	mm := NewMatcherManager()
+	_ = mm.AddMatcher("status", "all")
+	_ = mm.AddFilter("size", "10", false)
+	if mm.Matches(resp(200, 10), false, "or", "or") {
+		t.Error("a size-10 response should be filtered out")
+	}
+	if !mm.Matches(resp(200, 20), false, "or", "or") {
+		t.Error("a size-20 response should survive the size-10 filter")
+	}
+}

--- a/pkg/input/command.go
+++ b/pkg/input/command.go
@@ -67,8 +67,10 @@ func (c *CommandInput) Next() bool {
 // Value returns the input from command stdoutput
 func (c *CommandInput) Value() []byte {
 	var stdout bytes.Buffer
-	os.Setenv("FFUF_NUM", strconv.Itoa(c.count))
 	cmd := exec.Command(c.shell, SHELL_ARG, c.command)
+	// Pass FFUF_NUM to the child via its own environment rather than a
+	// process-global os.Setenv, which would race any concurrent caller.
+	cmd.Env = append(os.Environ(), "FFUF_NUM="+strconv.Itoa(c.count))
 	cmd.Stdout = &stdout
 	err := cmd.Run()
 	if err != nil {

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -15,10 +15,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/ffuf/ffuf/v2/pkg/assembly"
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 	"github.com/ffuf/ffuf/v2/pkg/filter"
-	"github.com/ffuf/ffuf/v2/pkg/input"
-	"github.com/ffuf/ffuf/v2/pkg/runner"
 )
 
 // runScan runs a full ffuf job against url with the given wordlist. configure
@@ -58,13 +57,13 @@ func runScan(t *testing.T, url string, wordlist []string, configure func(*ffuf.C
 		setup(conf.MatcherManager)
 	}
 
-	job := ffuf.NewJob(conf)
-	in, ierr := input.NewInputProvider(conf)
-	if ierr.ErrorOrNil() != nil {
-		t.Fatalf("NewInputProvider: %v", ierr.ErrorOrNil())
+	// Wire the Job through the SAME assembly path main uses, then swap in the
+	// capturing output provider. This is what stops the harness from drifting from
+	// production wiring.
+	job, err := assembly.BuildJob(conf)
+	if err != nil {
+		t.Fatalf("BuildJob: %v", err)
 	}
-	job.Input = in
-	job.Runner = runner.NewRunnerByName("http", conf, false)
 	out := &capture{}
 	job.Output = out
 

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -20,6 +20,22 @@ import (
 	"github.com/ffuf/ffuf/v2/pkg/filter"
 )
 
+// TestMain points ffuf.SCRAPERDIR at an empty temp dir for the whole package.
+// BuildJob loads scraper rules from that global dir; a fresh environment (a CI
+// runner) has no populated XDG config dir, and unlike main the in-process harness
+// never runs ReadDefaultConfig to create it. Redirecting to an empty temp dir
+// keeps these tests hermetic, mirroring how the ffuf package redirects AUTOCALIBDIR.
+func TestMain(m *testing.M) {
+	tmp, err := os.MkdirTemp("", "ffuf-scraperdir-*")
+	if err != nil {
+		panic(err)
+	}
+	ffuf.SCRAPERDIR = tmp
+	code := m.Run()
+	_ = os.RemoveAll(tmp)
+	os.Exit(code)
+}
+
 // runScan runs a full ffuf job against url with the given wordlist. configure
 // tweaks the ConfigOptions (recursion, autocalibration, request options, ...)
 // and setup installs the matchers/filters under test on the MatcherManager. It

--- a/test/integration/outputformats_test.go
+++ b/test/integration/outputformats_test.go
@@ -11,11 +11,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ffuf/ffuf/v2/pkg/assembly"
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 	"github.com/ffuf/ffuf/v2/pkg/filter"
-	"github.com/ffuf/ffuf/v2/pkg/input"
-	"github.com/ffuf/ffuf/v2/pkg/output"
-	"github.com/ffuf/ffuf/v2/pkg/runner"
 	"github.com/ffuf/ffuf/v2/pkg/testtarget"
 )
 
@@ -56,18 +54,15 @@ func runScanStdout(t *testing.T, url string, wordlist []string, configure func(*
 		setup(conf.MatcherManager)
 	}
 
-	job := ffuf.NewJob(conf)
-	in, ierr := input.NewInputProvider(conf)
-	if ierr.ErrorOrNil() != nil {
-		t.Fatalf("NewInputProvider: %v", ierr.ErrorOrNil())
+	// Same assembly path as production; the real stdout provider is what these
+	// tests want to exercise (file writers, result accumulation).
+	job, err := assembly.BuildJob(conf)
+	if err != nil {
+		t.Fatalf("BuildJob: %v", err)
 	}
-	job.Input = in
-	job.Runner = runner.NewRunnerByName("http", conf, false)
-	out := output.NewOutputProviderByName("stdout", conf)
-	job.Output = out
 
 	job.Start()
-	return out
+	return job.Output
 }
 
 // TestOutputConcurrentResultAccumulation drives the real stdout OutputProvider at


### PR DESCRIPTION
# Structural refactor: testable assembly, match seam, per-job context

Behavior-preserving structural refactor from the architecture review, following the concurrency-hardening work in #909. Four independent, per-commit stages (S1-S4 of the plan); the scheduler/worker-pool and pause controller are deliberately left untouched (just stabilized in #909). The package split, path-global injection, and OutputProvider segmentation are intentionally deferred to follow-up PRs to keep this reviewable.

Guarded throughout by the existing suite: golden characterization, black-box e2e (real argv), the mock-target integration harness, and `go test -race ./...` - all green on the go 1.18 + stable matrix.

## Commits

- **`refactor(input)`: pass FFUF_NUM via child env, not process-global Setenv.** `CommandInput.Value` did `os.Setenv("FFUF_NUM", ...)`, a process-global write safe today only by the accidental invariant that it runs under the main loop's `inputMutex`. Set it on the child's own `cmd.Env` instead, so a future off-main-loop caller or a second command provider cannot race the global environment. The subprocess still sees `FFUF_NUM` identically.

- **`refactor(filter)`: move the match decision onto `MatcherManager.Matches`.** `Job.isMatch` held the matcher/filter/and-or set algebra - pure set logic on the engine object, untestable without a whole `Job`. Moved verbatim into `MatcherManager.Matches(resp, perHost, matcherMode, filterMode)`; `Job.isMatch` is now a one-line delegate. Matching is now unit-tested in `pkg/filter`.

- **`refactor(ffuf)`: thread a per-job context for depth and base request.** Recursion depth was read by workers from a shared `Job` field (`currentDepth`) and `runTask` read the base request from the queue under a lock. #909's drain fix already sequences those writes after workers finish, so this is not a live-race fix - it makes the reads correct BY CONSTRUCTION (a `jobContext{basereq, depth}` passed by value) instead of by drain timing. Deletes `Job.currentDepth` and `jobQueue.currentReq`. Autocalibration and `Config.Url` are intentionally left as-is (calibration still builds from `BaseRequest(Config)`; `Config.Url` is still set on the main goroutine for FFUFHASH history) - both are drain-safe, and rerouting calibration would change sniper-mode behavior.

- **`refactor(assembly)`: extract a testable `BuildJob` and pure `filter.FromConfig`.** The Job assembly (`prepareJob`) and matcher setup (`SetupFilters`) lived unexported in `package main`, and `SetupFilters` read the global flag set, so the integration harness reimplemented the wiring - a duplicate that could drift. `prepareJob` becomes `pkg/assembly.BuildJob` (its own package: it must import the provider packages, which import `pkg/ffuf`, so it cannot live in `pkg/ffuf` without a cycle). `SetupFilters` splits into a pure, global-free `filter.FromConfig(opts, addDefaultStatusMatcher)` plus a `main` shim that keeps only the one CLI-explicit decision (the default status matcher, which needs the flag set). The harness now calls `BuildJob`, so production and test wiring share one path.

## Behavior-preservation notes

- The match logic in `Matches` is the original `isMatch` body, transcribed unchanged.
- Autocalibration is untouched (still builds its request from `BaseRequest(Config)`), so its behavior is identical.
- The `-ignore-body` warning keys off CLI-passed matcher flags via `flag.Visit` exactly as the original did (a config-file / `.ffufrc` value does not trigger it), and the default-status-matcher decision (`statusSet || !matcherSet`) is unchanged.
- `filter.FromConfig` adds filters/matchers in the same order and under the same conditions as the original `SetupFilters`.

An independent behavior-equivalence audit of the diff confirmed the above and surfaced one **pre-existing** quirk (not introduced here): in `-mode sniper` + autocalibration, calibration builds its request from `BaseRequest(Config)`, whose URL is the unscrubbed `§§` template with no keyword injected. That predates this PR and is left untouched here; worth a separate look.

## Deliberately NOT done

- `rand.Seed` at job start is kept: removing it (as a "deprecated" cleanup) would make `RandomString` and delay jitter deterministic on the go 1.18 floor, which is a behavior change.
- The scheduler/worker-pool and pause controller are untouched.
- `pkg/ffuf` -> `pkg/engine` split, XDG path-global injection, and `OutputProvider` segmentation are follow-up PRs.
