### PR TITLE
refactor(ffuf): extract recursion policy into a recursionManager

### DIFF
--- a/pkg/ffuf/job.go
+++ b/pkg/ffuf/job.go
@@ -39,7 +39,8 @@ type Job struct {
 	Total        int
 	Rate         *RateThrottle
 
-	queue *jobQueue
+	queue     *jobQueue
+	recursion *recursionManager
 
 	startTime    time.Time
 	startTimeJob time.Time
@@ -159,6 +160,9 @@ func (j *Job) Start() {
 	if j.getStartTime().IsZero() {
 		j.setStartTime(time.Now())
 	}
+	// Output is wired by the assembly before Start, so the recursion manager can
+	// capture it here.
+	j.recursion = newRecursionManager(j.Config, j.queue, j.Output)
 
 	basereq := BaseRequest(j.Config)
 
@@ -557,7 +561,7 @@ func (j *Job) runTask(ctx jobContext, input map[string][]byte, position int, ret
 		// Refresh the progress indicator as we printed something out
 		j.updateProgress()
 		if j.Config.Recursion && j.Config.RecursionStrategy == "greedy" {
-			j.handleGreedyRecursionJob(ctx, resp)
+			j.recursion.handleGreedy(ctx, resp)
 		}
 	} else {
 		if len(resp.ScraperData) > 0 {
@@ -567,7 +571,7 @@ func (j *Job) runTask(ctx jobContext, input map[string][]byte, position int, ret
 	}
 
 	if j.Config.Recursion && j.Config.RecursionStrategy == "default" && len(resp.GetRedirectLocation(false)) > 0 {
-		j.handleDefaultRecursionJob(ctx, resp)
+		j.recursion.handleDefault(ctx, resp)
 	}
 }
 
@@ -577,37 +581,6 @@ func (j *Job) handleScraperResult(resp *Response, sres ScraperResult) {
 		case "output":
 			resp.ScraperData[sres.Name] = sres.Results
 		}
-	}
-}
-
-// handleGreedyRecursionJob adds a recursion job to the queue if the maximum depth has not been reached
-func (j *Job) handleGreedyRecursionJob(ctx jobContext, resp Response) {
-	// Handle greedy recursion strategy. Match has been determined before calling handleRecursionJob
-	if j.Config.RecursionDepth == 0 || ctx.depth < j.Config.RecursionDepth {
-		recUrl := resp.Request.Url + "/" + "FUZZ"
-		newJob := QueueJob{Url: recUrl, depth: ctx.depth + 1, req: RecursionRequest(j.Config, recUrl)}
-		j.queue.push(newJob)
-		j.Output.Info(fmt.Sprintf("Adding a new job to the queue: %s", recUrl))
-	} else {
-		j.Output.Warning(fmt.Sprintf("Maximum recursion depth reached. Ignoring: %s", resp.Request.Url))
-	}
-}
-
-// handleDefaultRecursionJob adds a new recursion job to the job queue if a new directory is found and maximum depth has
-// not been reached
-func (j *Job) handleDefaultRecursionJob(ctx jobContext, resp Response) {
-	recUrl := resp.Request.Url + "/" + "FUZZ"
-	if (resp.Request.Url + "/") != resp.GetRedirectLocation(true) {
-		// Not a directory, return early
-		return
-	}
-	if j.Config.RecursionDepth == 0 || ctx.depth < j.Config.RecursionDepth {
-		// We have yet to reach the maximum recursion depth
-		newJob := QueueJob{Url: recUrl, depth: ctx.depth + 1, req: RecursionRequest(j.Config, recUrl)}
-		j.queue.push(newJob)
-		j.Output.Info(fmt.Sprintf("Adding a new job to the queue: %s", recUrl))
-	} else {
-		j.Output.Warning(fmt.Sprintf("Directory found, but recursion depth exceeded. Ignoring: %s", resp.GetRedirectLocation(true)))
 	}
 }
 

--- a/pkg/ffuf/recursion.go
+++ b/pkg/ffuf/recursion.go
@@ -1,0 +1,51 @@
+package ffuf
+
+import "fmt"
+
+// recursionManager owns the recursion policy: deciding whether a matched response
+// should spawn a deeper queue job and enqueuing it. It was lifted out of Job so the
+// greedy/default recursion logic lives in one place and is testable without a full
+// engine. It holds only what it needs: the config (for the depth limit and to build
+// recursion requests), the queue to push onto, and the output for its messages.
+type recursionManager struct {
+	config *Config
+	queue  *jobQueue
+	output OutputProvider
+}
+
+func newRecursionManager(conf *Config, queue *jobQueue, output OutputProvider) *recursionManager {
+	return &recursionManager{config: conf, queue: queue, output: output}
+}
+
+// handleGreedy queues a recursion job for a matched response (greedy strategy: a
+// match is enough), if the recursion depth allows. The match has been determined
+// by the caller.
+func (r *recursionManager) handleGreedy(ctx jobContext, resp Response) {
+	if r.config.RecursionDepth == 0 || ctx.depth < r.config.RecursionDepth {
+		recUrl := resp.Request.Url + "/" + "FUZZ"
+		newJob := QueueJob{Url: recUrl, depth: ctx.depth + 1, req: RecursionRequest(r.config, recUrl)}
+		r.queue.push(newJob)
+		r.output.Info(fmt.Sprintf("Adding a new job to the queue: %s", recUrl))
+	} else {
+		r.output.Warning(fmt.Sprintf("Maximum recursion depth reached. Ignoring: %s", resp.Request.Url))
+	}
+}
+
+// handleDefault queues a recursion job when a matched response is a directory
+// (default strategy: the response redirects to its own path with a trailing
+// slash), if the recursion depth allows.
+func (r *recursionManager) handleDefault(ctx jobContext, resp Response) {
+	recUrl := resp.Request.Url + "/" + "FUZZ"
+	if (resp.Request.Url + "/") != resp.GetRedirectLocation(true) {
+		// Not a directory, return early
+		return
+	}
+	if r.config.RecursionDepth == 0 || ctx.depth < r.config.RecursionDepth {
+		// We have yet to reach the maximum recursion depth
+		newJob := QueueJob{Url: recUrl, depth: ctx.depth + 1, req: RecursionRequest(r.config, recUrl)}
+		r.queue.push(newJob)
+		r.output.Info(fmt.Sprintf("Adding a new job to the queue: %s", recUrl))
+	} else {
+		r.output.Warning(fmt.Sprintf("Directory found, but recursion depth exceeded. Ignoring: %s", resp.GetRedirectLocation(true)))
+	}
+}

--- a/pkg/ffuf/recursion_test.go
+++ b/pkg/ffuf/recursion_test.go
@@ -1,0 +1,70 @@
+package ffuf
+
+import "testing"
+
+func TestRecursionManager_GreedyQueuesWithinDepth(t *testing.T) {
+	q := newJobQueue()
+	rm := newRecursionManager(&Config{Method: "GET", RecursionDepth: 2}, q, NewNullOutput())
+	resp := Response{Request: &Request{Url: "http://x/admin"}}
+
+	rm.handleGreedy(jobContext{depth: 0}, resp)
+
+	if !q.hasNext() {
+		t.Fatal("expected a recursion job to be queued")
+	}
+	job, _ := q.advance()
+	if job.Url != "http://x/admin/FUZZ" {
+		t.Errorf("queued url = %q, want http://x/admin/FUZZ", job.Url)
+	}
+	if job.depth != 1 {
+		t.Errorf("queued depth = %d, want 1 (parent depth + 1)", job.depth)
+	}
+}
+
+func TestRecursionManager_GreedyRespectsMaxDepth(t *testing.T) {
+	q := newJobQueue()
+	rm := newRecursionManager(&Config{Method: "GET", RecursionDepth: 1}, q, NewNullOutput())
+	resp := Response{Request: &Request{Url: "http://x/admin"}}
+
+	// depth == RecursionDepth: at the limit, nothing more is queued.
+	rm.handleGreedy(jobContext{depth: 1}, resp)
+
+	if q.total() != 0 {
+		t.Errorf("expected no queued job at max depth, got %d", q.total())
+	}
+}
+
+func TestRecursionManager_DefaultSkipsNonDirectory(t *testing.T) {
+	q := newJobQueue()
+	rm := newRecursionManager(&Config{Method: "GET", RecursionDepth: 0}, q, NewNullOutput())
+
+	// A 200 with no redirect is not a directory, so the default strategy queues
+	// nothing.
+	resp := Response{Request: &Request{Url: "http://x/file"}, StatusCode: 200}
+	rm.handleDefault(jobContext{depth: 0}, resp)
+
+	if q.total() != 0 {
+		t.Errorf("non-directory response should not queue a job, got %d", q.total())
+	}
+}
+
+func TestRecursionManager_DefaultQueuesDirectory(t *testing.T) {
+	q := newJobQueue()
+	rm := newRecursionManager(&Config{Method: "GET", RecursionDepth: 0}, q, NewNullOutput())
+
+	// A 301 redirecting to url + "/" is a directory; the default strategy descends.
+	resp := Response{
+		Request:    &Request{Url: "http://x/dir"},
+		StatusCode: 301,
+		Headers:    map[string][]string{"Location": {"http://x/dir/"}},
+	}
+	rm.handleDefault(jobContext{depth: 0}, resp)
+
+	if q.total() != 1 {
+		t.Fatalf("directory response should queue a recursion job, got %d", q.total())
+	}
+	job, _ := q.advance()
+	if job.Url != "http://x/dir/FUZZ" {
+		t.Errorf("queued url = %q, want http://x/dir/FUZZ", job.Url)
+	}
+}


### PR DESCRIPTION
Follow-up to #910 (stage S5 of the architecture plan). Behavior-preserving.

Extracts the greedy/default recursion handlers and the depth policy out of the ~700-line `Job` into a small `recursionManager` that holds only what it needs (config, queue, output). `Job` delegates at its two call sites; the manager is created in `Start` once the output provider is wired. The logic is moved verbatim.

Payoff: the recursion policy is one cohesive unit and is now unit-testable without standing up a full engine (added tests cover the greedy depth limit and the default directory detection).

Verification: integration recursion tests (both strategies, end-to-end) and the full `go test -race ./...` suite pass on the go 1.20 + stable matrix.

Deferred (future PRs, per the plan): the `pkg/ffuf` -> `pkg/engine` package split, XDG path-global injection, and `OutputProvider` segmentation.