### PR TITLE
fix(scraper): FromDir reads its dirname argument, not the global SCRAPERDIR

### DIFF
--- a/pkg/scraper/scraper.go
+++ b/pkg/scraper/scraper.go
@@ -47,7 +47,10 @@ func FromDir(dirname string, activestr string) (ffuf.Scraper, ffuf.Multierror) {
 	scr := Scraper{Rules: make([]*ScraperRule, 0)}
 	errs := ffuf.NewMultierror()
 	activegrps := parseActiveGroups(activestr)
-	all_files, err := os.ReadDir(ffuf.SCRAPERDIR)
+	// Enumerate the directory that was passed in; the entries below are opened
+	// relative to dirname, so reading a different directory (the global
+	// ffuf.SCRAPERDIR) here would mismatch the two.
+	all_files, err := os.ReadDir(dirname)
 	if err != nil {
 		errs.Add(err)
 		return &scr, errs

--- a/pkg/scraper/scraper_test.go
+++ b/pkg/scraper/scraper_test.go
@@ -1,0 +1,25 @@
+package scraper
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+// TestFromDir_UsesDirnameNotGlobal proves FromDir enumerates the directory it is
+// given rather than the package-global ffuf.SCRAPERDIR. Before the fix it read the
+// global for the directory listing while opening the entries relative to dirname,
+// so a valid dirname combined with a missing global still errored.
+func TestFromDir_UsesDirnameNotGlobal(t *testing.T) {
+	orig := ffuf.SCRAPERDIR
+	defer func() { ffuf.SCRAPERDIR = orig }()
+
+	valid := t.TempDir() // exists, empty
+	ffuf.SCRAPERDIR = filepath.Join(t.TempDir(), "does-not-exist")
+
+	_, errs := FromDir(valid, "all")
+	if errs.ErrorOrNil() != nil {
+		t.Errorf("FromDir should read its dirname argument (a valid dir), not the global (missing): %v", errs.ErrorOrNil())
+	}
+}


### PR DESCRIPTION
Latent bug found while scoping the S6 path-globals work.

`scraper.FromDir(dirname, ...)` listed the package-global `ffuf.SCRAPERDIR` (`os.ReadDir`) but opened each entry relative to its `dirname` parameter (`filepath.Join(dirname, ...)`). When `dirname` and the global differ, the listing and the opens point at different directories. The only caller passes `SCRAPERDIR`, so it was latent - but the function ignoring its own argument is a footgun (and is what forced the `SCRAPERDIR` TestMain redirect in #910).

Fix: read `dirname` consistently. Adds a regression test (a valid `dirname` with a missing global must not error - verified to fail before the fix). Behavior-preserving for the current caller; full `go test -race ./...` green.