### PR TITLE
refactor: split pkg/ffuf into a kernel + pkg/engine

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ffuf/ffuf/v2/pkg/assembly"
+	"github.com/ffuf/ffuf/v2/pkg/engine"
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 	"github.com/ffuf/ffuf/v2/pkg/filter"
 	"github.com/ffuf/ffuf/v2/pkg/input"
@@ -45,7 +46,7 @@ func main() {
 
 	// Handle searchhash functionality and exit
 	if opts.General.Searchhash != "" {
-		coptions, pos, err := ffuf.SearchHash(opts.General.Searchhash)
+		coptions, pos, err := engine.SearchHash(opts.General.Searchhash)
 		if err != nil {
 			fmt.Printf("[ERR] %s\n", err)
 			os.Exit(1)
@@ -58,7 +59,7 @@ func main() {
 			if err != nil {
 				continue
 			}
-			ok, reason := ffuf.HistoryReplayable(conf)
+			ok, reason := engine.HistoryReplayable(conf)
 			if ok {
 				printSearchResults(conf, pos, copt.Time, opts.General.Searchhash)
 			} else {

--- a/pkg/assembly/build.go
+++ b/pkg/assembly/build.go
@@ -8,6 +8,7 @@
 package assembly
 
 import (
+	"github.com/ffuf/ffuf/v2/pkg/engine"
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 	"github.com/ffuf/ffuf/v2/pkg/input"
 	"github.com/ffuf/ffuf/v2/pkg/output"
@@ -18,9 +19,9 @@ import (
 // BuildJob constructs and wires a Job from conf. It is the single source of truth
 // for how a Job is assembled. Matchers/filters are NOT installed here (they need
 // the CLI flag state); see filter.FromConfig and main.SetupFilters.
-func BuildJob(conf *ffuf.Config) (*ffuf.Job, error) {
+func BuildJob(conf *ffuf.Config) (*engine.Job, error) {
 	var err error
-	job := ffuf.NewJob(conf)
+	job := engine.NewJob(conf)
 	var errs ffuf.Multierror
 
 	job.Input, errs = input.NewInputProvider(conf)

--- a/pkg/engine/autocalibration.go
+++ b/pkg/engine/autocalibration.go
@@ -1,4 +1,4 @@
-package ffuf
+package engine
 
 import (
 	"encoding/json"
@@ -7,9 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-)
 
-type AutocalibrationStrategy map[string][]string
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
 
 func (j *Job) autoCalibrationStrings() map[string][]string {
 	// The global rand is seeded once in Job.Start; re-seeding here on every call
@@ -24,13 +24,13 @@ func (j *Job) autoCalibrationStrings() map[string][]string {
 	}
 
 	for _, strategy := range j.Config.AutoCalibrationStrategies {
-		jsonStrategy, err := os.ReadFile(filepath.Join(AUTOCALIBDIR, strategy+".json"))
+		jsonStrategy, err := os.ReadFile(filepath.Join(ffuf.AUTOCALIBDIR, strategy+".json"))
 		if err != nil {
 			j.Output.Warning(fmt.Sprintf("Skipping strategy \"%s\" because of error: %s\n", strategy, err))
 			continue
 		}
 
-		tmpStrategy := AutocalibrationStrategy{}
+		tmpStrategy := ffuf.AutocalibrationStrategy{}
 		err = json.Unmarshal(jsonStrategy, &tmpStrategy)
 		if err != nil {
 			j.Output.Warning(fmt.Sprintf("Skipping strategy \"%s\" because of error: %s\n", strategy, err))
@@ -43,58 +43,41 @@ func (j *Job) autoCalibrationStrings() map[string][]string {
 	return cInputs
 }
 
-func setupDefaultAutocalibrationStrategies() error {
-	basic_strategy := AutocalibrationStrategy{
-		"basic_admin":  []string{"admin" + RandomString(16), "admin" + RandomString(8)},
-		"htaccess":     []string{".htaccess" + RandomString(16), ".htaccess" + RandomString(8)},
-		"basic_random": []string{RandomString(16), RandomString(8)},
+func mergeMaps(m1 map[string][]string, m2 map[string][]string) map[string][]string {
+	merged := make(map[string][]string)
+	for k, v := range m1 {
+		merged[k] = v
 	}
-	basic_strategy_json, err := json.Marshal(basic_strategy)
-	if err != nil {
-		return err
+	for key, value := range m2 {
+		if _, ok := merged[key]; !ok {
+			// Key not found, add it
+			merged[key] = value
+			continue
+		}
+		for _, entry := range value {
+			if !ffuf.StrInSlice(entry, merged[key]) {
+				merged[key] = append(merged[key], entry)
+			}
+		}
 	}
-
-	advanced_strategy := AutocalibrationStrategy{
-		"basic_admin":  []string{"admin" + RandomString(16), "admin" + RandomString(8)},
-		"htaccess":     []string{".htaccess" + RandomString(16), ".htaccess" + RandomString(8)},
-		"basic_random": []string{RandomString(16), RandomString(8)},
-		"admin_dir":    []string{"admin" + RandomString(16) + "/", "admin" + RandomString(8) + "/"},
-		"random_dir":   []string{RandomString(16) + "/", RandomString(8) + "/"},
-	}
-	advanced_strategy_json, err := json.Marshal(advanced_strategy)
-	if err != nil {
-		return err
-	}
-
-	basic_strategy_file := filepath.Join(AUTOCALIBDIR, "basic.json")
-	if !FileExists(basic_strategy_file) {
-		err = os.WriteFile(filepath.Join(AUTOCALIBDIR, "basic.json"), basic_strategy_json, 0640)
-		return err
-	}
-	advanced_strategy_file := filepath.Join(AUTOCALIBDIR, "advanced.json")
-	if !FileExists(advanced_strategy_file) {
-		err = os.WriteFile(filepath.Join(AUTOCALIBDIR, "advanced.json"), advanced_strategy_json, 0640)
-		return err
-	}
-
-	return nil
+	return merged
 }
 
-func (j *Job) calibrationRequest(inputs map[string][]byte) (Response, error) {
-	basereq := BaseRequest(j.Config)
+func (j *Job) calibrationRequest(inputs map[string][]byte) (ffuf.Response, error) {
+	basereq := ffuf.BaseRequest(j.Config)
 	req, err := j.Runner.Prepare(inputs, &basereq)
 	if err != nil {
 		j.Output.Error(fmt.Sprintf("Encountered an error while preparing autocalibration request: %s\n", err))
 		j.incError()
 		log.Printf("%s", err)
-		return Response{}, err
+		return ffuf.Response{}, err
 	}
 	resp, err := j.Runner.Execute(&req)
 	if err != nil {
 		j.Output.Error(fmt.Sprintf("Encountered an error while executing autocalibration request: %s\n", err))
 		j.incError()
 		log.Printf("%s", err)
-		return Response{}, err
+		return ffuf.Response{}, err
 	}
 	// Only calibrate on responses that would be matched otherwise
 	if j.isMatch(resp) {
@@ -117,7 +100,7 @@ func (j *Job) CalibrateForHost(host string, baseinput map[string][]byte) error {
 		input[k] = v
 	}
 	for _, v := range cStrings {
-		responses := make([]Response, 0)
+		responses := make([]ffuf.Response, 0)
 		for _, cs := range v {
 			input[j.Config.AutoCalibrationKeyword] = []byte(cs)
 			resp, err := j.calibrationRequest(input)
@@ -153,7 +136,7 @@ func (j *Job) Calibrate(input map[string][]byte) error {
 	}
 
 	for _, v := range cInputs {
-		responses := make([]Response, 0)
+		responses := make([]ffuf.Response, 0)
 		for _, cs := range v {
 			cinput[j.Config.AutoCalibrationKeyword] = []byte(cs)
 			resp, err := j.calibrationRequest(cinput)
@@ -183,7 +166,7 @@ func (j *Job) CalibrateIfNeeded(host string, input map[string][]byte) error {
 	return j.Calibrate(input)
 }
 
-func (j *Job) calibrateFilters(responses []Response, perHost bool) error {
+func (j *Job) calibrateFilters(responses []ffuf.Response, perHost bool) error {
 	// Work down from the most specific common denominator
 	if len(responses) > 0 {
 		// Content length
@@ -197,14 +180,14 @@ func (j *Job) calibrateFilters(responses []Response, perHost bool) error {
 		if sizeMatch {
 			if perHost {
 				// Check if already filtered
-				for _, f := range j.Config.MatcherManager.FiltersForDomain(HostURLFromRequest(*responses[0].Request)) {
+				for _, f := range j.Config.MatcherManager.FiltersForDomain(ffuf.HostURLFromRequest(*responses[0].Request)) {
 					match, _ := f.Filter(&responses[0])
 					if match {
 						// Already filtered
 						return nil
 					}
 				}
-				_ = j.Config.MatcherManager.AddPerDomainFilter(HostURLFromRequest(*responses[0].Request), "size", strconv.FormatInt(baselineSize, 10))
+				_ = j.Config.MatcherManager.AddPerDomainFilter(ffuf.HostURLFromRequest(*responses[0].Request), "size", strconv.FormatInt(baselineSize, 10))
 				return nil
 			} else {
 				// Check if already filtered
@@ -231,14 +214,14 @@ func (j *Job) calibrateFilters(responses []Response, perHost bool) error {
 		if wordsMatch {
 			if perHost {
 				// Check if already filtered
-				for _, f := range j.Config.MatcherManager.FiltersForDomain(HostURLFromRequest(*responses[0].Request)) {
+				for _, f := range j.Config.MatcherManager.FiltersForDomain(ffuf.HostURLFromRequest(*responses[0].Request)) {
 					match, _ := f.Filter(&responses[0])
 					if match {
 						// Already filtered
 						return nil
 					}
 				}
-				_ = j.Config.MatcherManager.AddPerDomainFilter(HostURLFromRequest(*responses[0].Request), "word", strconv.FormatInt(baselineWords, 10))
+				_ = j.Config.MatcherManager.AddPerDomainFilter(ffuf.HostURLFromRequest(*responses[0].Request), "word", strconv.FormatInt(baselineWords, 10))
 				return nil
 			} else {
 				// Check if already filtered
@@ -265,14 +248,14 @@ func (j *Job) calibrateFilters(responses []Response, perHost bool) error {
 		if linesMatch {
 			if perHost {
 				// Check if already filtered
-				for _, f := range j.Config.MatcherManager.FiltersForDomain(HostURLFromRequest(*responses[0].Request)) {
+				for _, f := range j.Config.MatcherManager.FiltersForDomain(ffuf.HostURLFromRequest(*responses[0].Request)) {
 					match, _ := f.Filter(&responses[0])
 					if match {
 						// Already filtered
 						return nil
 					}
 				}
-				_ = j.Config.MatcherManager.AddPerDomainFilter(HostURLFromRequest(*responses[0].Request), "line", strconv.FormatInt(baselineLines, 10))
+				_ = j.Config.MatcherManager.AddPerDomainFilter(ffuf.HostURLFromRequest(*responses[0].Request), "line", strconv.FormatInt(baselineLines, 10))
 				return nil
 			} else {
 				// Check if already filtered

--- a/pkg/engine/autocalibration_mutation_test.go
+++ b/pkg/engine/autocalibration_mutation_test.go
@@ -1,8 +1,10 @@
-package ffuf
+package engine
 
 import (
 	"errors"
 	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 // stubRunner is a RunnerProvider whose calls fail. It is enough to drive
@@ -10,11 +12,13 @@ import (
 // Calibrate before the request is ever prepared.
 type stubRunner struct{}
 
-func (stubRunner) Prepare(map[string][]byte, *Request) (Request, error) {
-	return Request{}, errors.New("stub")
+func (stubRunner) Prepare(map[string][]byte, *ffuf.Request) (ffuf.Request, error) {
+	return ffuf.Request{}, errors.New("stub")
 }
-func (stubRunner) Execute(*Request) (Response, error) { return Response{}, errors.New("stub") }
-func (stubRunner) Dump(*Request) ([]byte, error)      { return nil, nil }
+func (stubRunner) Execute(*ffuf.Request) (ffuf.Response, error) {
+	return ffuf.Response{}, errors.New("stub")
+}
+func (stubRunner) Dump(*ffuf.Request) ([]byte, error) { return nil, nil }
 
 // TestCalibrate_DoesNotMutateInput locks the fix for an input-map aliasing bug.
 // SimpleRunner.Prepare sets req.Input = input (the same map), so resp.Request.Input
@@ -25,7 +29,7 @@ func (stubRunner) Dump(*Request) ([]byte, error)      { return nil, nil }
 // CalibrateForHost already does.
 func TestCalibrate_DoesNotMutateInput(t *testing.T) {
 	job := &Job{
-		Config: &Config{
+		Config: &ffuf.Config{
 			Url:                    "http://localhost/FUZZ",
 			Method:                 "GET",
 			AutoCalibration:        true,

--- a/pkg/engine/autocalibration_test.go
+++ b/pkg/engine/autocalibration_test.go
@@ -1,32 +1,34 @@
-package ffuf
+package engine
 
 import (
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 // NullOutput is a dummy output provider that does nothing
 type NullOutput struct {
-	Results []Result
+	Results []ffuf.Result
 }
 
-func NewNullOutput() *NullOutput                             { return &NullOutput{} }
-func (o *NullOutput) Banner()                                {}
-func (o *NullOutput) Finalize() error                        { return nil }
-func (o *NullOutput) Progress(status Progress)               {}
-func (o *NullOutput) Info(infostring string)                 {}
-func (o *NullOutput) Error(errstring string)                 {}
-func (o *NullOutput) Raw(output string)                      {}
-func (o *NullOutput) Warning(warnstring string)              {}
-func (o *NullOutput) Result(resp Response)                   {}
-func (o *NullOutput) PrintResult(res Result)                 {}
-func (o *NullOutput) SaveFile(filename, format string) error { return nil }
-func (o *NullOutput) GetCurrentResults() []Result            { return o.Results }
-func (o *NullOutput) SetCurrentResults(results []Result)     { o.Results = results }
-func (o *NullOutput) FilterCurrentResults(keep func(Result) bool) {
-	filtered := make([]Result, 0, len(o.Results))
+func NewNullOutput() *NullOutput                              { return &NullOutput{} }
+func (o *NullOutput) Banner()                                 {}
+func (o *NullOutput) Finalize() error                         { return nil }
+func (o *NullOutput) Progress(status ffuf.Progress)           {}
+func (o *NullOutput) Info(infostring string)                  {}
+func (o *NullOutput) Error(errstring string)                  {}
+func (o *NullOutput) Raw(output string)                       {}
+func (o *NullOutput) Warning(warnstring string)               {}
+func (o *NullOutput) Result(resp ffuf.Response)               {}
+func (o *NullOutput) PrintResult(res ffuf.Result)             {}
+func (o *NullOutput) SaveFile(filename, format string) error  { return nil }
+func (o *NullOutput) GetCurrentResults() []ffuf.Result        { return o.Results }
+func (o *NullOutput) SetCurrentResults(results []ffuf.Result) { o.Results = results }
+func (o *NullOutput) FilterCurrentResults(keep func(ffuf.Result) bool) {
+	filtered := make([]ffuf.Result, 0, len(o.Results))
 	for _, r := range o.Results {
 		if keep(r) {
 			filtered = append(filtered, r)
@@ -40,14 +42,14 @@ func (o *NullOutput) Cycle() {}
 func TestAutoCalibrationStrings(t *testing.T) {
 	// Create a temporary directory for the test
 	tmpDir, err := os.MkdirTemp("", "ffuf-test")
-	AUTOCALIBDIR = tmpDir
+	ffuf.AUTOCALIBDIR = tmpDir
 	if err != nil {
 		t.Fatalf("Failed to create temporary directory: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
 	// Create a test strategy file
-	strategy := AutocalibrationStrategy{
+	strategy := ffuf.AutocalibrationStrategy{
 		"test": {"foo", "bar"},
 	}
 	strategyJSON, err := json.Marshal(strategy)
@@ -62,7 +64,7 @@ func TestAutoCalibrationStrings(t *testing.T) {
 
 	// Create a test job with the strategy
 	job := &Job{
-		Config: &Config{
+		Config: &ffuf.Config{
 			AutoCalibrationStrategies: []string{"test"},
 		},
 		Output: NewNullOutput(),
@@ -87,7 +89,7 @@ func TestAutoCalibrationStrings(t *testing.T) {
 
 	// Verify that a missing strategy is skipped
 	job = &Job{
-		Config: &Config{
+		Config: &ffuf.Config{
 			AutoCalibrationStrategies: []string{"missing"},
 		},
 		Output: NewNullOutput(),
@@ -105,7 +107,7 @@ func TestAutoCalibrationStrings(t *testing.T) {
 		t.Fatalf("Failed to write malformed strategy file: %v", err)
 	}
 	job = &Job{
-		Config: &Config{
+		Config: &ffuf.Config{
 			AutoCalibrationStrategies: []string{"malformed"},
 		},
 		Output: NewNullOutput(),

--- a/pkg/engine/history.go
+++ b/pkg/engine/history.go
@@ -1,4 +1,4 @@
-package ffuf
+package engine
 
 import (
 	"crypto/sha256"
@@ -10,14 +10,16 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type ConfigOptionsHistory struct {
-	ConfigOptions
+	ffuf.ConfigOptions
 	Time time.Time `json:"time"`
 }
 
-func WriteHistoryEntry(conf *Config) (string, error) {
+func WriteHistoryEntry(conf *ffuf.Config) (string, error) {
 	if conf.Options == nil {
 		return "", errors.New("cannot write history entry: config has no source options")
 	}
@@ -30,11 +32,11 @@ func WriteHistoryEntry(conf *Config) (string, error) {
 		return "", err
 	}
 	hashstr := calculateHistoryHash(jsonoptions)
-	err = createConfigDir(filepath.Join(HISTORYDIR, hashstr))
+	err = ffuf.CreateConfigDir(filepath.Join(ffuf.HISTORYDIR, hashstr))
 	if err != nil {
 		return "", err
 	}
-	err = os.WriteFile(filepath.Join(HISTORYDIR, hashstr, "options"), jsonoptions, 0640)
+	err = os.WriteFile(filepath.Join(ffuf.HISTORYDIR, hashstr, "options"), jsonoptions, 0640)
 	return hashstr, err
 }
 
@@ -46,7 +48,7 @@ func WriteHistoryEntry(conf *Config) (string, error) {
 //     so the frozen snapshot would report the base URL, not the recursed path.
 //   - Filter/Matcher.*: autocalibration installs filters at runtime, absent from
 //     the raw input. Rebuilt from MatcherManager exactly as the old ToOptions did.
-func historyOptions(conf *Config) ConfigOptions {
+func historyOptions(conf *ffuf.Config) ffuf.ConfigOptions {
 	o := *conf.Options
 	o.HTTP.URL = conf.Url
 	if conf.MatcherManager != nil {
@@ -106,7 +108,7 @@ func SearchHash(hash string) ([]ConfigOptionsHistory, int, error) {
 	if err != nil {
 		return coptions, 0, errors.New("bad positional value in FFUFHASH")
 	}
-	all_dirs, err := os.ReadDir(HISTORYDIR)
+	all_dirs, err := os.ReadDir(ffuf.HISTORYDIR)
 	if err != nil {
 		return coptions, 0, err
 	}
@@ -119,7 +121,7 @@ func SearchHash(hash string) ([]ConfigOptionsHistory, int, error) {
 		}
 	}
 	for _, dirname := range matched_dirs {
-		copts, err := configFromHistory(filepath.Join(HISTORYDIR, dirname))
+		copts, err := configFromHistory(filepath.Join(ffuf.HISTORYDIR, dirname))
 		if err != nil {
 			continue
 		}
@@ -129,7 +131,7 @@ func SearchHash(hash string) ([]ConfigOptionsHistory, int, error) {
 	return coptions, int(position), err
 }
 
-func HistoryReplayable(conf *Config) (bool, string) {
+func HistoryReplayable(conf *ffuf.Config) (bool, string) {
 	for _, w := range conf.Wordlists {
 		if w == "-" || strings.HasPrefix(w, "-:") {
 			return false, "stdin input was used for one of the wordlists"

--- a/pkg/engine/history_test.go
+++ b/pkg/engine/history_test.go
@@ -1,9 +1,11 @@
-package ffuf
+package engine
 
 import (
 	"context"
 	"encoding/json"
 	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 // TestConfigOptions_SerializationRoundTrip locks the serialize/deserialize path
@@ -13,7 +15,7 @@ import (
 // replacement for the former hand-maintained ToOptions reverse mapper — adding a
 // ConfigOptions field is picked up here for free, with no marshaller to update.
 func TestConfigOptions_SerializationRoundTrip(t *testing.T) {
-	opts := NewConfigOptions()
+	opts := ffuf.NewConfigOptions()
 	opts.HTTP.URL = "https://example.org/FUZZ"
 	opts.HTTP.Method = "POST"
 	opts.HTTP.Data = "name=FUZZ"
@@ -22,7 +24,7 @@ func TestConfigOptions_SerializationRoundTrip(t *testing.T) {
 	opts.General.Threads = 7
 	opts.General.Delay = "0.1-0.8"
 
-	conf, err := ConfigFromOptions(opts, context.Background(), func() {})
+	conf, err := ffuf.ConfigFromOptions(opts, context.Background(), func() {})
 	if err != nil {
 		t.Fatalf("ConfigFromOptions: %v", err)
 	}
@@ -35,13 +37,13 @@ func TestConfigOptions_SerializationRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal source options: %v", err)
 	}
-	var restored ConfigOptions
+	var restored ffuf.ConfigOptions
 	if err := json.Unmarshal(blob, &restored); err != nil {
 		t.Fatalf("unmarshal options: %v", err)
 	}
 
 	// Rebuilding from the restored options must reproduce the request.
-	conf2, err := ConfigFromOptions(&restored, context.Background(), func() {})
+	conf2, err := ffuf.ConfigFromOptions(&restored, context.Background(), func() {})
 	if err != nil {
 		t.Fatalf("ConfigFromOptions (rebuild): %v", err)
 	}
@@ -70,36 +72,36 @@ func TestConfigOptions_SerializationRoundTrip(t *testing.T) {
 
 type fakeFilter struct{ repr string }
 
-func (f fakeFilter) Filter(*Response) (bool, error) { return false, nil }
-func (f fakeFilter) Repr() string                   { return f.repr }
-func (f fakeFilter) ReprVerbose() string            { return f.repr }
+func (f fakeFilter) Filter(*ffuf.Response) (bool, error) { return false, nil }
+func (f fakeFilter) Repr() string                        { return f.repr }
+func (f fakeFilter) ReprVerbose() string                 { return f.repr }
 
 type fakeMatcherManager struct {
-	filters  map[string]FilterProvider
-	matchers map[string]FilterProvider
+	filters  map[string]ffuf.FilterProvider
+	matchers map[string]ffuf.FilterProvider
 }
 
-func (m *fakeMatcherManager) SetCalibrated(bool)                                {}
-func (m *fakeMatcherManager) SetCalibratedForHost(string, bool)                 {}
-func (m *fakeMatcherManager) AddFilter(string, string, bool) error              { return nil }
-func (m *fakeMatcherManager) AddPerDomainFilter(string, string, string) error   { return nil }
-func (m *fakeMatcherManager) RemoveFilter(string)                               {}
-func (m *fakeMatcherManager) AddMatcher(string, string) error                   { return nil }
-func (m *fakeMatcherManager) GetFilters() map[string]FilterProvider             { return m.filters }
-func (m *fakeMatcherManager) GetMatchers() map[string]FilterProvider            { return m.matchers }
-func (m *fakeMatcherManager) FiltersForDomain(string) map[string]FilterProvider { return nil }
-func (m *fakeMatcherManager) CalibratedForDomain(string) bool                   { return false }
-func (m *fakeMatcherManager) Calibrated() bool                                  { return false }
-func (m *fakeMatcherManager) Matches(*Response, bool, string, string) bool      { return false }
+func (m *fakeMatcherManager) SetCalibrated(bool)                                     {}
+func (m *fakeMatcherManager) SetCalibratedForHost(string, bool)                      {}
+func (m *fakeMatcherManager) AddFilter(string, string, bool) error                   { return nil }
+func (m *fakeMatcherManager) AddPerDomainFilter(string, string, string) error        { return nil }
+func (m *fakeMatcherManager) RemoveFilter(string)                                    {}
+func (m *fakeMatcherManager) AddMatcher(string, string) error                        { return nil }
+func (m *fakeMatcherManager) GetFilters() map[string]ffuf.FilterProvider             { return m.filters }
+func (m *fakeMatcherManager) GetMatchers() map[string]ffuf.FilterProvider            { return m.matchers }
+func (m *fakeMatcherManager) FiltersForDomain(string) map[string]ffuf.FilterProvider { return nil }
+func (m *fakeMatcherManager) CalibratedForDomain(string) bool                        { return false }
+func (m *fakeMatcherManager) Calibrated() bool                                       { return false }
+func (m *fakeMatcherManager) Matches(*ffuf.Response, bool, string, string) bool      { return false }
 
 // TestHistoryOptions_ReflectsRecursedURL locks the recursion fix: WriteHistoryEntry
 // serializes the LIVE Config.Url (rewritten per queued job by prepareQueueJob), not
 // the base URL frozen in the retained parse-time options. Without the fix, -search on
 // a recursive hit reconstructs the wrong (base) path.
 func TestHistoryOptions_ReflectsRecursedURL(t *testing.T) {
-	opts := NewConfigOptions()
+	opts := ffuf.NewConfigOptions()
 	opts.HTTP.URL = "https://example.org/FUZZ" // parse-time base
-	conf := &Config{Options: opts, Url: "https://example.org/admin/FUZZ"}
+	conf := &ffuf.Config{Options: opts, Url: "https://example.org/admin/FUZZ"}
 
 	got := historyOptions(conf)
 	if got.HTTP.URL != "https://example.org/admin/FUZZ" {
@@ -111,13 +113,13 @@ func TestHistoryOptions_ReflectsRecursedURL(t *testing.T) {
 // installed at runtime (e.g. by -ac) appear in the serialized history, rebuilt from
 // MatcherManager. The raw parse-time options never held them.
 func TestHistoryOptions_ReflectsRuntimeFilters(t *testing.T) {
-	opts := NewConfigOptions()
+	opts := ffuf.NewConfigOptions()
 	opts.HTTP.URL = "https://example.org/FUZZ"
-	conf := &Config{
+	conf := &ffuf.Config{
 		Options: opts,
 		Url:     "https://example.org/FUZZ",
 		MatcherManager: &fakeMatcherManager{
-			filters: map[string]FilterProvider{"size": fakeFilter{"4242"}},
+			filters: map[string]ffuf.FilterProvider{"size": fakeFilter{"4242"}},
 		},
 	}
 

--- a/pkg/engine/job.go
+++ b/pkg/engine/job.go
@@ -1,4 +1,4 @@
-package ffuf
+package engine
 
 import (
 	"fmt"
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 // Job ties together Config, Runner, Input and Output
@@ -28,13 +30,13 @@ type Job struct {
 	runningJob int32
 	skipQueue  int32
 
-	AuditLogger  AuditLogger
-	Config       *Config
-	Input        InputProvider
-	Runner       RunnerProvider
-	ReplayRunner RunnerProvider
-	Scraper      Scraper
-	Output       OutputProvider
+	AuditLogger  ffuf.AuditLogger
+	Config       *ffuf.Config
+	Input        ffuf.InputProvider
+	Runner       ffuf.RunnerProvider
+	ReplayRunner ffuf.RunnerProvider
+	Scraper      ffuf.Scraper
+	Output       ffuf.OutputProvider
 	Jobhash      string
 	Total        int
 	Rate         *RateThrottle
@@ -58,7 +60,7 @@ type Job struct {
 type QueueJob struct {
 	Url   string
 	depth int
-	req   Request
+	req   ffuf.Request
 }
 
 // jobContext carries the per-queue-job values a worker needs, passed BY VALUE so
@@ -67,11 +69,11 @@ type QueueJob struct {
 // makes the recursion-depth and base-request reads correct by construction rather
 // than by drain timing.
 type jobContext struct {
-	basereq Request
+	basereq ffuf.Request
 	depth   int
 }
 
-func NewJob(conf *Config) *Job {
+func NewJob(conf *ffuf.Config) *Job {
 	var j Job
 	j.Config = conf
 	j.queue = newJobQueue()
@@ -164,18 +166,18 @@ func (j *Job) Start() {
 	// capture it here.
 	j.recursion = newRecursionManager(j.Config, j.queue, j.Output)
 
-	basereq := BaseRequest(j.Config)
+	basereq := ffuf.BaseRequest(j.Config)
 
 	if j.Config.InputMode == "sniper" {
 		// process multiple payload locations and create a queue job for each location
-		reqs := SniperRequests(&basereq, j.Config.InputProviders[0].Template)
+		reqs := ffuf.SniperRequests(&basereq, j.Config.InputProviders[0].Template)
 		for _, r := range reqs {
 			j.queue.push(QueueJob{Url: j.Config.Url, depth: 0, req: r})
 		}
 		j.Total = j.Input.Total() * len(reqs)
 	} else {
 		// Add the default job to job queue
-		j.queue.push(QueueJob{Url: j.Config.Url, depth: 0, req: BaseRequest(j.Config)})
+		j.queue.push(QueueJob{Url: j.Config.Url, depth: 0, req: ffuf.BaseRequest(j.Config)})
 		j.Total = j.Input.Total()
 	}
 
@@ -235,7 +237,7 @@ func (j *Job) prepareQueueJob() jobContext {
 	kws := j.Input.Keywords()
 	found_kws := make([]string, 0)
 	for _, k := range kws {
-		if RequestContainsKeyword(job.req, k) {
+		if ffuf.RequestContainsKeyword(job.req, k) {
 			found_kws = append(found_kws, k)
 		}
 	}
@@ -418,7 +420,7 @@ func (j *Job) runBackgroundTasks(wg *sync.WaitGroup) {
 }
 
 func (j *Job) updateProgress() {
-	prog := Progress{
+	prog := ffuf.Progress{
 		StartedAt:  j.getStartTimeJob(),
 		ReqCount:   j.getCounter(),
 		ReqTotal:   j.Input.Total(),
@@ -432,7 +434,7 @@ func (j *Job) updateProgress() {
 
 // isMatch delegates the match/filter decision to the MatcherManager seam, adapting
 // the Config fields it needs. The logic itself now lives in filter.MatcherManager.
-func (j *Job) isMatch(resp Response) bool {
+func (j *Job) isMatch(resp ffuf.Response) bool {
 	return j.Config.MatcherManager.Matches(&resp, j.Config.AutoCalibrationPerHost, j.Config.MatcherMode, j.Config.FilterMode)
 }
 
@@ -533,7 +535,7 @@ func (j *Job) runTask(ctx jobContext, input map[string][]byte, position int, ret
 	j.pauseCheckpoint()
 
 	// Handle autocalibration, must be done after the actual request to ensure sane value in req.Host
-	_ = j.CalibrateIfNeeded(HostURLFromRequest(req), input)
+	_ = j.CalibrateIfNeeded(ffuf.HostURLFromRequest(req), input)
 
 	// Handle scraper actions
 	if j.Scraper != nil {
@@ -575,7 +577,7 @@ func (j *Job) runTask(ctx jobContext, input map[string][]byte, position int, ret
 	}
 }
 
-func (j *Job) handleScraperResult(resp *Response, sres ScraperResult) {
+func (j *Job) handleScraperResult(resp *ffuf.Response, sres ffuf.ScraperResult) {
 	for _, a := range sres.Action {
 		switch a {
 		case "output":

--- a/pkg/engine/jobqueue.go
+++ b/pkg/engine/jobqueue.go
@@ -1,4 +1,4 @@
-package ffuf
+package engine
 
 import "sync"
 

--- a/pkg/engine/pausegate_test.go
+++ b/pkg/engine/pausegate_test.go
@@ -1,10 +1,12 @@
-package ffuf
+package engine
 
 import (
 	"context"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 // TestPauseGate_ConcurrentIdempotent regresses C8: the pause gate used a
@@ -83,7 +85,7 @@ func TestPauseGate_ConcurrentPauseResume(t *testing.T) {
 // Config.Cancel() without a nil panic.
 func runningJobWithCancel() *Job {
 	ctx, cancel := context.WithCancel(context.Background())
-	j := &Job{Output: NewNullOutput(), Config: &Config{Context: ctx, Cancel: cancel}}
+	j := &Job{Output: NewNullOutput(), Config: &ffuf.Config{Context: ctx, Cancel: cancel}}
 	j.setRunning(true)
 	return j
 }

--- a/pkg/engine/rate.go
+++ b/pkg/engine/rate.go
@@ -1,20 +1,22 @@
-package ffuf
+package engine
 
 import (
 	"container/ring"
 	"sync"
 	"time"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type RateThrottle struct {
 	rateCounter    *ring.Ring
-	Config         *Config
+	Config         *ffuf.Config
 	RateMutex      sync.Mutex
 	RateLimiter    *time.Ticker
 	lastAdjustment time.Time
 }
 
-func NewRateThrottle(conf *Config) *RateThrottle {
+func NewRateThrottle(conf *ffuf.Config) *RateThrottle {
 	r := &RateThrottle{
 		Config:         conf,
 		lastAdjustment: time.Now(),

--- a/pkg/engine/ratethrottle_test.go
+++ b/pkg/engine/ratethrottle_test.go
@@ -1,18 +1,22 @@
-package ffuf
+package engine
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
 
 // TestNewRateThrottle_HugeRateNoPanic regresses P3: conf.Rate > 1000000 makes
 // 1000000/rate integer-divide to 0, and a non-positive ticker interval panics.
 func TestNewRateThrottle_HugeRateNoPanic(t *testing.T) {
-	_ = NewRateThrottle(&Config{Rate: 2000000, Threads: 40})
-	_ = NewRateThrottle(&Config{Rate: 1000001, Threads: 40})
+	_ = NewRateThrottle(&ffuf.Config{Rate: 2000000, Threads: 40})
+	_ = NewRateThrottle(&ffuf.Config{Rate: 1000001, Threads: 40})
 }
 
 // TestChangeRate_HugeRateNoPanic regresses the same on the interactive `rate`
 // command path, plus the zero/negative branches.
 func TestChangeRate_HugeRateNoPanic(t *testing.T) {
-	r := NewRateThrottle(&Config{Rate: 0, Threads: 40})
+	r := NewRateThrottle(&ffuf.Config{Rate: 0, Threads: 40})
 	r.ChangeRate(2000000) // 1000000/2000000 == 0
 	r.ChangeRate(1000001)
 	r.ChangeRate(0)

--- a/pkg/engine/recursion.go
+++ b/pkg/engine/recursion.go
@@ -1,6 +1,10 @@
-package ffuf
+package engine
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
 
 // recursionManager owns the recursion policy: deciding whether a matched response
 // should spawn a deeper queue job and enqueuing it. It was lifted out of Job so the
@@ -8,22 +12,22 @@ import "fmt"
 // engine. It holds only what it needs: the config (for the depth limit and to build
 // recursion requests), the queue to push onto, and the output for its messages.
 type recursionManager struct {
-	config *Config
+	config *ffuf.Config
 	queue  *jobQueue
-	output OutputProvider
+	output ffuf.OutputProvider
 }
 
-func newRecursionManager(conf *Config, queue *jobQueue, output OutputProvider) *recursionManager {
+func newRecursionManager(conf *ffuf.Config, queue *jobQueue, output ffuf.OutputProvider) *recursionManager {
 	return &recursionManager{config: conf, queue: queue, output: output}
 }
 
 // handleGreedy queues a recursion job for a matched response (greedy strategy: a
 // match is enough), if the recursion depth allows. The match has been determined
 // by the caller.
-func (r *recursionManager) handleGreedy(ctx jobContext, resp Response) {
+func (r *recursionManager) handleGreedy(ctx jobContext, resp ffuf.Response) {
 	if r.config.RecursionDepth == 0 || ctx.depth < r.config.RecursionDepth {
 		recUrl := resp.Request.Url + "/" + "FUZZ"
-		newJob := QueueJob{Url: recUrl, depth: ctx.depth + 1, req: RecursionRequest(r.config, recUrl)}
+		newJob := QueueJob{Url: recUrl, depth: ctx.depth + 1, req: ffuf.RecursionRequest(r.config, recUrl)}
 		r.queue.push(newJob)
 		r.output.Info(fmt.Sprintf("Adding a new job to the queue: %s", recUrl))
 	} else {
@@ -34,7 +38,7 @@ func (r *recursionManager) handleGreedy(ctx jobContext, resp Response) {
 // handleDefault queues a recursion job when a matched response is a directory
 // (default strategy: the response redirects to its own path with a trailing
 // slash), if the recursion depth allows.
-func (r *recursionManager) handleDefault(ctx jobContext, resp Response) {
+func (r *recursionManager) handleDefault(ctx jobContext, resp ffuf.Response) {
 	recUrl := resp.Request.Url + "/" + "FUZZ"
 	if (resp.Request.Url + "/") != resp.GetRedirectLocation(true) {
 		// Not a directory, return early
@@ -42,7 +46,7 @@ func (r *recursionManager) handleDefault(ctx jobContext, resp Response) {
 	}
 	if r.config.RecursionDepth == 0 || ctx.depth < r.config.RecursionDepth {
 		// We have yet to reach the maximum recursion depth
-		newJob := QueueJob{Url: recUrl, depth: ctx.depth + 1, req: RecursionRequest(r.config, recUrl)}
+		newJob := QueueJob{Url: recUrl, depth: ctx.depth + 1, req: ffuf.RecursionRequest(r.config, recUrl)}
 		r.queue.push(newJob)
 		r.output.Info(fmt.Sprintf("Adding a new job to the queue: %s", recUrl))
 	} else {

--- a/pkg/engine/recursion_test.go
+++ b/pkg/engine/recursion_test.go
@@ -1,11 +1,15 @@
-package ffuf
+package engine
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
 
 func TestRecursionManager_GreedyQueuesWithinDepth(t *testing.T) {
 	q := newJobQueue()
-	rm := newRecursionManager(&Config{Method: "GET", RecursionDepth: 2}, q, NewNullOutput())
-	resp := Response{Request: &Request{Url: "http://x/admin"}}
+	rm := newRecursionManager(&ffuf.Config{Method: "GET", RecursionDepth: 2}, q, NewNullOutput())
+	resp := ffuf.Response{Request: &ffuf.Request{Url: "http://x/admin"}}
 
 	rm.handleGreedy(jobContext{depth: 0}, resp)
 
@@ -23,8 +27,8 @@ func TestRecursionManager_GreedyQueuesWithinDepth(t *testing.T) {
 
 func TestRecursionManager_GreedyRespectsMaxDepth(t *testing.T) {
 	q := newJobQueue()
-	rm := newRecursionManager(&Config{Method: "GET", RecursionDepth: 1}, q, NewNullOutput())
-	resp := Response{Request: &Request{Url: "http://x/admin"}}
+	rm := newRecursionManager(&ffuf.Config{Method: "GET", RecursionDepth: 1}, q, NewNullOutput())
+	resp := ffuf.Response{Request: &ffuf.Request{Url: "http://x/admin"}}
 
 	// depth == RecursionDepth: at the limit, nothing more is queued.
 	rm.handleGreedy(jobContext{depth: 1}, resp)
@@ -36,11 +40,11 @@ func TestRecursionManager_GreedyRespectsMaxDepth(t *testing.T) {
 
 func TestRecursionManager_DefaultSkipsNonDirectory(t *testing.T) {
 	q := newJobQueue()
-	rm := newRecursionManager(&Config{Method: "GET", RecursionDepth: 0}, q, NewNullOutput())
+	rm := newRecursionManager(&ffuf.Config{Method: "GET", RecursionDepth: 0}, q, NewNullOutput())
 
 	// A 200 with no redirect is not a directory, so the default strategy queues
 	// nothing.
-	resp := Response{Request: &Request{Url: "http://x/file"}, StatusCode: 200}
+	resp := ffuf.Response{Request: &ffuf.Request{Url: "http://x/file"}, StatusCode: 200}
 	rm.handleDefault(jobContext{depth: 0}, resp)
 
 	if q.total() != 0 {
@@ -50,11 +54,11 @@ func TestRecursionManager_DefaultSkipsNonDirectory(t *testing.T) {
 
 func TestRecursionManager_DefaultQueuesDirectory(t *testing.T) {
 	q := newJobQueue()
-	rm := newRecursionManager(&Config{Method: "GET", RecursionDepth: 0}, q, NewNullOutput())
+	rm := newRecursionManager(&ffuf.Config{Method: "GET", RecursionDepth: 0}, q, NewNullOutput())
 
 	// A 301 redirecting to url + "/" is a directory; the default strategy descends.
-	resp := Response{
-		Request:    &Request{Url: "http://x/dir"},
+	resp := ffuf.Response{
+		Request:    &ffuf.Request{Url: "http://x/dir"},
 		StatusCode: 301,
 		Headers:    map[string][]string{"Location": {"http://x/dir/"}},
 	}

--- a/pkg/ffuf/autocalibration_strategies.go
+++ b/pkg/ffuf/autocalibration_strategies.go
@@ -1,0 +1,46 @@
+package ffuf
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+type AutocalibrationStrategy map[string][]string
+
+func setupDefaultAutocalibrationStrategies() error {
+	basic_strategy := AutocalibrationStrategy{
+		"basic_admin":  []string{"admin" + RandomString(16), "admin" + RandomString(8)},
+		"htaccess":     []string{".htaccess" + RandomString(16), ".htaccess" + RandomString(8)},
+		"basic_random": []string{RandomString(16), RandomString(8)},
+	}
+	basic_strategy_json, err := json.Marshal(basic_strategy)
+	if err != nil {
+		return err
+	}
+
+	advanced_strategy := AutocalibrationStrategy{
+		"basic_admin":  []string{"admin" + RandomString(16), "admin" + RandomString(8)},
+		"htaccess":     []string{".htaccess" + RandomString(16), ".htaccess" + RandomString(8)},
+		"basic_random": []string{RandomString(16), RandomString(8)},
+		"admin_dir":    []string{"admin" + RandomString(16) + "/", "admin" + RandomString(8) + "/"},
+		"random_dir":   []string{RandomString(16) + "/", RandomString(8) + "/"},
+	}
+	advanced_strategy_json, err := json.Marshal(advanced_strategy)
+	if err != nil {
+		return err
+	}
+
+	basic_strategy_file := filepath.Join(AUTOCALIBDIR, "basic.json")
+	if !FileExists(basic_strategy_file) {
+		err = os.WriteFile(filepath.Join(AUTOCALIBDIR, "basic.json"), basic_strategy_json, 0640)
+		return err
+	}
+	advanced_strategy_file := filepath.Join(AUTOCALIBDIR, "advanced.json")
+	if !FileExists(advanced_strategy_file) {
+		err = os.WriteFile(filepath.Join(AUTOCALIBDIR, "advanced.json"), advanced_strategy_json, 0640)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/ffuf/util.go
+++ b/pkg/ffuf/util.go
@@ -145,19 +145,19 @@ func FormattedVersion() string {
 
 func CheckOrCreateConfigDir() error {
 	var err error
-	err = createConfigDir(CONFIGDIR)
+	err = CreateConfigDir(CONFIGDIR)
 	if err != nil {
 		return err
 	}
-	err = createConfigDir(HISTORYDIR)
+	err = CreateConfigDir(HISTORYDIR)
 	if err != nil {
 		return err
 	}
-	err = createConfigDir(SCRAPERDIR)
+	err = CreateConfigDir(SCRAPERDIR)
 	if err != nil {
 		return err
 	}
-	err = createConfigDir(AUTOCALIBDIR)
+	err = CreateConfigDir(AUTOCALIBDIR)
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func CheckOrCreateConfigDir() error {
 	return err
 }
 
-func createConfigDir(path string) error {
+func CreateConfigDir(path string) error {
 	_, err := os.Stat(path)
 	if err != nil {
 		var pError *os.PathError
@@ -184,24 +184,4 @@ func StrInSlice(key string, slice []string) bool {
 		}
 	}
 	return false
-}
-
-func mergeMaps(m1 map[string][]string, m2 map[string][]string) map[string][]string {
-	merged := make(map[string][]string)
-	for k, v := range m1 {
-		merged[k] = v
-	}
-	for key, value := range m2 {
-		if _, ok := merged[key]; !ok {
-			// Key not found, add it
-			merged[key] = value
-			continue
-		}
-		for _, entry := range value {
-			if !StrInSlice(entry, merged[key]) {
-				merged[key] = append(merged[key], entry)
-			}
-		}
-	}
-	return merged
 }

--- a/pkg/interactive/termhandler.go
+++ b/pkg/interactive/termhandler.go
@@ -7,15 +7,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ffuf/ffuf/v2/pkg/engine"
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 type interactive struct {
-	Job    *ffuf.Job
+	Job    *engine.Job
 	paused bool
 }
 
-func Handle(job *ffuf.Job) error {
+func Handle(job *engine.Job) error {
 	i := interactive{job, false}
 	tty, err := termHandle()
 	if err != nil {


### PR DESCRIPTION
Final S6 item from the architecture plan (S6a). Pure move, behavior-preserving.

Splits the `pkg/ffuf` god-package into a **kernel** (domain types, interfaces, `Config`/`ConfigOptions`, utils - what every satellite package already depended on) and a new **`pkg/engine`** holding the Job engine: `Job`, `jobQueue`, `recursionManager`, `RateThrottle`, `history`, and the Job autocalibration methods. Dependency is one-directional (`engine` -> `ffuf`, never the reverse), verified with `go list -deps` - no import cycle. The satellite packages (`filter`/`input`/`runner`/`output`/`scraper`) are untouched; they already imported only the kernel.

**The one non-mechanical bit:** `util.go`'s `CheckOrCreateConfigDir` (kernel) calls `setupDefaultAutocalibrationStrategies`, so `autocalibration.go` is split - the `AutocalibrationStrategy` type + strategy-file setup stay in the kernel (`autocalibration_strategies.go`), the Job calibration methods move to engine. `createConfigDir` is exported as `CreateConfigDir` (engine's `history.go` needs it) - the only new kernel symbol, no behavior change.

Consumers rewired: `main.go`, `pkg/assembly/build.go` (BuildJob now returns `*engine.Job`), `pkg/interactive`. Tests moved with the code they exercise.

No logic changed. `go build`/`vet` clean, no import cycle, full `go test -race ./...` green on the go 1.20 + stable matrix.