### PR TITLE
Fix interactive console being scrolled off screen by inflight results

### DIFF
--- a/pkg/engine/autocalibration_test.go
+++ b/pkg/engine/autocalibration_test.go
@@ -36,8 +36,10 @@ func (o *NullOutput) FilterCurrentResults(keep func(ffuf.Result) bool) {
 	}
 	o.Results = filtered
 }
-func (o *NullOutput) Reset() {}
-func (o *NullOutput) Cycle() {}
+func (o *NullOutput) SetPaused(bool)      {}
+func (o *NullOutput) PendingResults() int { return 0 }
+func (o *NullOutput) Reset()              {}
+func (o *NullOutput) Cycle()              {}
 
 func TestAutoCalibrationStrings(t *testing.T) {
 	// Create a temporary directory for the test

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -120,4 +120,10 @@ type Result struct {
 	ResultFile       string              `json:"resultfile"`
 	Host             string              `json:"host"`
 	HTMLColor        string              `json:"-"`
+	// Printed reports whether this result has already been shown to the user
+	// (streamed live, or surfaced in the "N new matches" summary on resume). It
+	// is the single source of truth for the interactive console's pending count,
+	// so filtering a held result out of CurrentResults also drops it from the
+	// count. Not serialized to any output format.
+	Printed bool `json:"-"`
 }

--- a/pkg/ffuf/interfaces.go
+++ b/pkg/ffuf/interfaces.go
@@ -80,6 +80,8 @@ type OutputProvider interface {
 	GetCurrentResults() []Result
 	SetCurrentResults(results []Result)
 	FilterCurrentResults(keep func(Result) bool)
+	SetPaused(paused bool)
+	PendingResults() int
 	Reset()
 	Cycle()
 }

--- a/pkg/interactive/termhandler.go
+++ b/pkg/interactive/termhandler.go
@@ -209,6 +209,19 @@ func (i *interactive) handleInput(in []byte) {
 	}
 }
 
+// resultProbe rebuilds the minimal Response needed to re-evaluate the active
+// filters against an already-collected result. ContentLines must come from the
+// result's line count, not its length: feeding ContentLength here made an
+// in-console "fl" (line count) filter match against the wrong number.
+func resultProbe(res ffuf.Result) *ffuf.Response {
+	return &ffuf.Response{
+		StatusCode:    res.StatusCode,
+		ContentLines:  res.ContentLines,
+		ContentWords:  res.ContentWords,
+		ContentLength: res.ContentLength,
+	}
+}
+
 func (i *interactive) refreshResults() {
 	filters := i.Job.Config.MatcherManager.GetFilters()
 	// Keep a result only if it survives every active filter. The filtering runs
@@ -218,13 +231,7 @@ func (i *interactive) refreshResults() {
 	// result once per filter it passed).
 	i.Job.Output.FilterCurrentResults(func(res ffuf.Result) bool {
 		for _, filter := range filters {
-			fakeResp := &ffuf.Response{
-				StatusCode:    res.StatusCode,
-				ContentLines:  res.ContentLength,
-				ContentWords:  res.ContentWords,
-				ContentLength: res.ContentLength,
-			}
-			filterOut, _ := filter.Filter(fakeResp)
+			filterOut, _ := filter.Filter(resultProbe(res))
 			if filterOut {
 				return false
 			}

--- a/pkg/interactive/termhandler.go
+++ b/pkg/interactive/termhandler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/ffuf/ffuf/v2/pkg/engine"
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
@@ -38,11 +37,14 @@ func (i *interactive) handleInput(in []byte) {
 		// Enter pressed - toggle interactive state
 		i.paused = !i.paused
 		if i.paused {
+			// Suppress live result printing BEFORE pausing dispatch, so inflight
+			// requests completing cannot scroll the banner off screen, then show
+			// the banner immediately (no drain wait).
+			i.Job.Output.SetPaused(true)
 			i.Job.Pause()
-			time.Sleep(500 * time.Millisecond)
 			i.printBanner()
 		} else {
-			i.Job.Resume()
+			i.resumeJob()
 		}
 	} else {
 		switch args[0] {
@@ -52,10 +54,11 @@ func (i *interactive) handleInput(in []byte) {
 			i.printHelp()
 		case "resume":
 			i.paused = false
-			i.Job.Resume()
+			i.resumeJob()
 		case "restart":
 			i.Job.Reset(false)
 			i.paused = false
+			i.Job.Output.SetPaused(false)
 			i.Job.Output.Info("Restarting the current ffuf job!")
 			i.Job.Resume()
 		case "show":
@@ -273,12 +276,30 @@ func (i *interactive) deleteQueue(in string) {
 		}
 	}
 }
+
+// resumeJob restores live result printing and resumes the job. If any matches
+// arrived while the console was open, it reports the count first so the user
+// knows there are new (recorded but unprinted) findings to inspect with "show".
+func (i *interactive) resumeJob() {
+	if n := i.Job.Output.PendingResults(); n > 0 {
+		i.Job.Output.Info(fmt.Sprintf("%d new match(es) found while paused. Type \"show\" to display them.", n))
+	}
+	i.Job.Output.SetPaused(false)
+	i.Job.Resume()
+}
+
 func (i *interactive) printBanner() {
 	i.Job.Output.Raw("entering interactive mode\ntype \"help\" for a list of commands, or ENTER to resume.\n")
 }
 
 func (i *interactive) printPrompt() {
-	i.Job.Output.Raw("> ")
+	// Surface matches that arrived while paused right in the prompt, so a user
+	// sitting in the console sees findings queuing up.
+	if n := i.Job.Output.PendingResults(); n > 0 {
+		i.Job.Output.Raw(fmt.Sprintf("[%d new] > ", n))
+	} else {
+		i.Job.Output.Raw("> ")
+	}
 }
 
 func (i *interactive) printHelp() {

--- a/pkg/interactive/termhandler_test.go
+++ b/pkg/interactive/termhandler_test.go
@@ -1,0 +1,35 @@
+package interactive
+
+import (
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+// TestResultProbeUsesLineCount guards the fl-filter bug: the probe rebuilt to
+// re-evaluate filters against an already-collected result must take ContentLines
+// from the result's line count, not its length. Before the fix an in-console
+// "fl" (line count) filter compared against ContentLength.
+func TestResultProbeUsesLineCount(t *testing.T) {
+	res := ffuf.Result{
+		StatusCode:    200,
+		ContentLength: 4096,
+		ContentWords:  100,
+		ContentLines:  7,
+	}
+
+	probe := resultProbe(res)
+
+	if probe.ContentLines != 7 {
+		t.Errorf("resultProbe ContentLines = %d, want 7 (fed ContentLength instead of ContentLines)", probe.ContentLines)
+	}
+	if probe.ContentLength != 4096 {
+		t.Errorf("resultProbe ContentLength = %d, want 4096", probe.ContentLength)
+	}
+	if probe.ContentWords != 100 {
+		t.Errorf("resultProbe ContentWords = %d, want 100", probe.ContentWords)
+	}
+	if probe.StatusCode != 200 {
+		t.Errorf("resultProbe StatusCode = %d, want 200", probe.StatusCode)
+	}
+}

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -30,13 +30,12 @@ const (
 type Stdoutput struct {
 	config           *ffuf.Config
 	fuzzkeywords     []string
-	resultMutex      sync.Mutex // guards Results, CurrentResults, paused and pendingCount; Result is called from worker goroutines
+	resultMutex      sync.Mutex // guards Results, CurrentResults and paused; Result is called from worker goroutines
 	Results          []ffuf.Result
 	CurrentResults   []ffuf.Result
 	stdoutIsTerminal bool
 	stderrIsTerminal bool
 	paused           bool // when set, Result records matches but does not print them
-	pendingCount     int  // matches recorded but not printed since the last SetPaused(true)
 }
 
 func NewStdoutput(conf *ffuf.Config) *Stdoutput {
@@ -429,41 +428,54 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 		Host:             resp.Request.Host,
 	}
 	s.resultMutex.Lock()
-	s.CurrentResults = append(s.CurrentResults, sResult)
 	paused := s.paused
-	if paused {
-		s.pendingCount++
-	}
+	// Printed is the single source of truth for the pending count. Mark it under
+	// the same lock as the append, so a later filter change that prunes this
+	// result from CurrentResults (via FilterCurrentResults) also removes it from
+	// the pending count - the count can never contradict what "show" displays.
+	sResult.Printed = !paused
+	s.CurrentResults = append(s.CurrentResults, sResult)
 	s.resultMutex.Unlock()
 	// While the interactive console is open we still record the match above (so
 	// show, savejson and -o output stay complete) but do not stream it to the
 	// terminal - otherwise inflight requests completing after the user opens the
-	// console would scroll the banner off screen. PendingResults reports the count.
+	// console would scroll the banner off screen.
 	if !paused {
 		s.PrintResult(sResult)
 	}
 }
 
 // SetPaused toggles whether Result streams matches to the live terminal. While
-// paused (the interactive console is open) matches are still recorded but not
-// printed, so inflight requests completing cannot scroll the console off screen.
-// Entering a pause (paused == true) resets the pending counter.
+// paused (the interactive console is open) matches are recorded but not printed,
+// so inflight requests completing cannot scroll the console off screen. Leaving
+// a pause (paused == false) marks every held result as shown, since resume
+// reports their count to the user; a subsequent pause then only counts matches
+// that are genuinely new.
 func (s *Stdoutput) SetPaused(paused bool) {
 	s.resultMutex.Lock()
 	s.paused = paused
-	if paused {
-		s.pendingCount = 0
+	if !paused {
+		for i := range s.CurrentResults {
+			s.CurrentResults[i].Printed = true
+		}
 	}
 	s.resultMutex.Unlock()
 }
 
-// PendingResults returns the number of matches recorded but not printed since
-// the last SetPaused(true) - matches that arrived while the interactive console
-// was open.
+// PendingResults returns the number of held matches not yet shown to the user:
+// results recorded while paused that still survive the active filters. It is
+// derived from CurrentResults, so a filter change that prunes a held result
+// drops it from this count in the same operation.
 func (s *Stdoutput) PendingResults() int {
 	s.resultMutex.Lock()
 	defer s.resultMutex.Unlock()
-	return s.pendingCount
+	n := 0
+	for _, r := range s.CurrentResults {
+		if !r.Printed {
+			n++
+		}
+	}
+	return n
 }
 
 func (s *Stdoutput) writeResultToFile(resp ffuf.Response) string {

--- a/pkg/output/stdout.go
+++ b/pkg/output/stdout.go
@@ -30,11 +30,13 @@ const (
 type Stdoutput struct {
 	config           *ffuf.Config
 	fuzzkeywords     []string
-	resultMutex      sync.Mutex // guards Results and CurrentResults; Result is called from worker goroutines
+	resultMutex      sync.Mutex // guards Results, CurrentResults, paused and pendingCount; Result is called from worker goroutines
 	Results          []ffuf.Result
 	CurrentResults   []ffuf.Result
 	stdoutIsTerminal bool
 	stderrIsTerminal bool
+	paused           bool // when set, Result records matches but does not print them
+	pendingCount     int  // matches recorded but not printed since the last SetPaused(true)
 }
 
 func NewStdoutput(conf *ffuf.Config) *Stdoutput {
@@ -428,9 +430,40 @@ func (s *Stdoutput) Result(resp ffuf.Response) {
 	}
 	s.resultMutex.Lock()
 	s.CurrentResults = append(s.CurrentResults, sResult)
+	paused := s.paused
+	if paused {
+		s.pendingCount++
+	}
 	s.resultMutex.Unlock()
-	// Output the result
-	s.PrintResult(sResult)
+	// While the interactive console is open we still record the match above (so
+	// show, savejson and -o output stay complete) but do not stream it to the
+	// terminal - otherwise inflight requests completing after the user opens the
+	// console would scroll the banner off screen. PendingResults reports the count.
+	if !paused {
+		s.PrintResult(sResult)
+	}
+}
+
+// SetPaused toggles whether Result streams matches to the live terminal. While
+// paused (the interactive console is open) matches are still recorded but not
+// printed, so inflight requests completing cannot scroll the console off screen.
+// Entering a pause (paused == true) resets the pending counter.
+func (s *Stdoutput) SetPaused(paused bool) {
+	s.resultMutex.Lock()
+	s.paused = paused
+	if paused {
+		s.pendingCount = 0
+	}
+	s.resultMutex.Unlock()
+}
+
+// PendingResults returns the number of matches recorded but not printed since
+// the last SetPaused(true) - matches that arrived while the interactive console
+// was open.
+func (s *Stdoutput) PendingResults() int {
+	s.resultMutex.Lock()
+	defer s.resultMutex.Unlock()
+	return s.pendingCount
 }
 
 func (s *Stdoutput) writeResultToFile(resp ffuf.Response) string {

--- a/pkg/output/stdout_pause_test.go
+++ b/pkg/output/stdout_pause_test.go
@@ -65,10 +65,11 @@ func TestResultPrintsWhenNotPaused(t *testing.T) {
 	}
 }
 
-// TestSetPausedResetsPendingCounter proves entering a fresh pause zeroes the
-// counter, so the "N new matches found while paused" report reflects only the
-// current pause session.
-func TestSetPausedResetsPendingCounter(t *testing.T) {
+// TestPendingReconcilesWithFilter is the fix for the correctness gap: a held
+// result that a mid-pause filter change prunes from CurrentResults must also
+// drop out of the pending count, so the "N new matches" report can never
+// contradict what "show" displays.
+func TestPendingReconcilesWithFilter(t *testing.T) {
 	s := NewStdoutput(&ffuf.Config{})
 	s.stdoutIsTerminal = false
 
@@ -79,15 +80,48 @@ func TestSetPausedResetsPendingCounter(t *testing.T) {
 		t.Fatalf("PendingResults = %d, want 2", got)
 	}
 
-	s.SetPaused(true) // re-entering a pause resets the counter
+	// Simulate an interactive filter change that keeps only w1, as
+	// refreshResults does via FilterCurrentResults.
+	s.FilterCurrentResults(func(r ffuf.Result) bool {
+		return string(r.Input["FUZZ"]) == "w1"
+	})
+
+	if got := s.PendingResults(); got != 1 {
+		t.Errorf("PendingResults = %d after filtering out a held result, want 1 (count must track CurrentResults)", got)
+	}
+	if got := len(s.GetCurrentResults()); got != 1 {
+		t.Errorf("CurrentResults = %d, want 1", got)
+	}
+}
+
+// TestUnpauseMarksHeldSeen proves resume acknowledges held results: after
+// leaving a pause a subsequent pause with no new matches reports zero, rather
+// than re-counting results the user was already told about.
+func TestUnpauseMarksHeldSeen(t *testing.T) {
+	s := NewStdoutput(&ffuf.Config{})
+	s.stdoutIsTerminal = false
+
+	s.SetPaused(true)
+	s.Result(resp(1))
+	s.Result(resp(2))
+	if got := s.PendingResults(); got != 2 {
+		t.Fatalf("PendingResults = %d, want 2", got)
+	}
+
+	s.SetPaused(false) // resume acknowledges the held results
 	if got := s.PendingResults(); got != 0 {
-		t.Errorf("PendingResults = %d after re-pause, want 0 (counter not reset)", got)
+		t.Errorf("PendingResults = %d after resume, want 0 (held results not marked seen)", got)
+	}
+
+	s.SetPaused(true) // pause again, no new matches arrive
+	if got := s.PendingResults(); got != 0 {
+		t.Errorf("PendingResults = %d on re-pause, want 0 (old results re-counted as new)", got)
 	}
 }
 
 // TestConcurrentResultWhilePaused runs Result from many goroutines while paused
 // (as the engine's worker pool does) and asserts nothing is lost and nothing is
-// printed. Run with -race to catch a data race on paused/pendingCount directly.
+// printed. Run with -race to catch a data race on paused/Printed directly.
 func TestConcurrentResultWhilePaused(t *testing.T) {
 	s := NewStdoutput(&ffuf.Config{})
 	s.stdoutIsTerminal = false

--- a/pkg/output/stdout_pause_test.go
+++ b/pkg/output/stdout_pause_test.go
@@ -1,0 +1,118 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+func resp(i int) ffuf.Response {
+	return ffuf.Response{
+		StatusCode: 200,
+		Request: &ffuf.Request{
+			Input: map[string][]byte{"FUZZ": []byte(fmt.Sprintf("w%d", i))},
+			Url:   fmt.Sprintf("http://example/%d", i),
+		},
+	}
+}
+
+// TestResultSuppressedWhilePaused locks the core fix: while the interactive
+// console is open (SetPaused(true)), Result must record the match but write
+// nothing to the terminal, so inflight requests completing cannot scroll the
+// console banner off screen. The recorded results must still be retrievable
+// (show / savejson / -o output stay complete).
+func TestResultSuppressedWhilePaused(t *testing.T) {
+	s := NewStdoutput(&ffuf.Config{})
+	s.stdoutIsTerminal = false
+	s.SetPaused(true)
+
+	const n = 5
+	out := captureStdout(t, func() {
+		for i := 0; i < n; i++ {
+			s.Result(resp(i))
+		}
+	})
+
+	if out != "" {
+		t.Errorf("Result printed to stdout while paused: %q", out)
+	}
+	if got := len(s.GetCurrentResults()); got != n {
+		t.Errorf("paused Result did not record: got %d results, want %d", got, n)
+	}
+	if got := s.PendingResults(); got != n {
+		t.Errorf("PendingResults = %d, want %d", got, n)
+	}
+}
+
+// TestResultPrintsWhenNotPaused is the negative control: with no pause in
+// effect, Result streams to the terminal and PendingResults stays zero.
+func TestResultPrintsWhenNotPaused(t *testing.T) {
+	s := NewStdoutput(&ffuf.Config{})
+	s.stdoutIsTerminal = false
+
+	out := captureStdout(t, func() {
+		s.Result(resp(1))
+	})
+
+	if !strings.Contains(out, "http://example/1") && !strings.Contains(out, "Status: 200") {
+		t.Errorf("Result did not print while unpaused: %q", out)
+	}
+	if got := s.PendingResults(); got != 0 {
+		t.Errorf("PendingResults = %d while unpaused, want 0", got)
+	}
+}
+
+// TestSetPausedResetsPendingCounter proves entering a fresh pause zeroes the
+// counter, so the "N new matches found while paused" report reflects only the
+// current pause session.
+func TestSetPausedResetsPendingCounter(t *testing.T) {
+	s := NewStdoutput(&ffuf.Config{})
+	s.stdoutIsTerminal = false
+
+	s.SetPaused(true)
+	s.Result(resp(1))
+	s.Result(resp(2))
+	if got := s.PendingResults(); got != 2 {
+		t.Fatalf("PendingResults = %d, want 2", got)
+	}
+
+	s.SetPaused(true) // re-entering a pause resets the counter
+	if got := s.PendingResults(); got != 0 {
+		t.Errorf("PendingResults = %d after re-pause, want 0 (counter not reset)", got)
+	}
+}
+
+// TestConcurrentResultWhilePaused runs Result from many goroutines while paused
+// (as the engine's worker pool does) and asserts nothing is lost and nothing is
+// printed. Run with -race to catch a data race on paused/pendingCount directly.
+func TestConcurrentResultWhilePaused(t *testing.T) {
+	s := NewStdoutput(&ffuf.Config{})
+	s.stdoutIsTerminal = false
+	s.SetPaused(true)
+
+	const n = 200
+	out := captureStdout(t, func() {
+		var wg sync.WaitGroup
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				s.Result(resp(i))
+			}(i)
+		}
+		wg.Wait()
+	})
+
+	if out != "" {
+		t.Errorf("Result printed to stdout while paused under concurrency: %q", out)
+	}
+	if got := len(s.GetCurrentResults()); got != n {
+		t.Errorf("got %d results, want %d (results lost while paused)", got, n)
+	}
+	if got := s.PendingResults(); got != n {
+		t.Errorf("PendingResults = %d, want %d", got, n)
+	}
+}

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -161,5 +161,7 @@ func (c *capture) FilterCurrentResults(keep func(ffuf.Result) bool) {
 	}
 	c.results = filtered
 }
-func (c *capture) Reset() {}
-func (c *capture) Cycle() {}
+func (c *capture) SetPaused(bool)      {}
+func (c *capture) PendingResults() int { return 0 }
+func (c *capture) Reset()              {}
+func (c *capture) Cycle()              {}


### PR DESCRIPTION
Fix interactive console being scrolled off screen by inflight results

## Problem

When filters are open and matches stream fast, pressing ENTER to open the interactive console prints the banner but inflight requests keep completing and printing their result lines, scrolling the banner off screen.

`Job.Pause()` stops dispatch of new requests, but the up-to-`-t` workers already in flight keep going. Result printing happens in the worker goroutine (`Output.Result`), gated only by a `pauseCheckpoint()` that sits just before the print in `runTask`. A worker already past that checkpoint, or one doing slow replay-proxy / autocalibration I/O in the window before the print, still writes its line after the banner.

The existing `time.Sleep(500 * time.Millisecond)` before printing the banner was an attempt to let inflight work drain to the checkpoint. It adds latency yet cannot bound requests that take seconds, so it made the console feel unresponsive without fixing the scroll.

## Fix

Make the output provider pause-aware, so the gate lives at the layer that owns the terminal instead of depending on where each worker happens to be.

- `Stdoutput` gains `paused` and `pendingCount`, guarded by the existing `resultMutex`. `Result()` always records the match to `CurrentResults`; while paused it increments `pendingCount` and skips the live print, otherwise it prints as before.
- New `SetPaused(bool)` / `PendingResults() int` on the `OutputProvider` interface. Entering a pause resets the counter.
- Interactive ENTER now calls `SetPaused(true)` before `Job.Pause()`, then prints the banner immediately. The 500ms sleep is gone.
- Resume (ENTER, `resume`, `restart`) restores printing and reports `N new match(es) found while paused` so nothing looks lost. The prompt shows `[N new] >` while matches queue.

Held matches stay in `CurrentResults`, so `show`, `savejson`, `-o` output and the final results are unchanged. They are deliberately not replayed on resume, since that would re-stream exactly the noise the user paused to filter out.

Only `Result()` is suppressed. Errors and info stay visible, and the progress bar redraws one line in place (it does not scroll, and is quiescent while paused since the workers and dispatch loop are all blocked at the pause checkpoint).

## Limitations

This does not drain inflight requests, by design. A worker already past the pause checkpoint when ENTER is pressed can still print its line just after the banner. That window drops from request latency (up to seconds, a screenful) to a few instructions (at most a line or two), so the banner is no longer buried. Fully eliminating it would mean waiting for inflight requests to finish, which is exactly the unresponsiveness this avoids.

## Tests

- `pkg/output/stdout_pause_test.go`: while paused, `Result()` writes nothing to stdout, still records to `CurrentResults`, and increments `PendingResults()`; unpaused it prints and the counter stays 0; re-pausing resets the counter; 200 concurrent `Result()` calls while paused lose nothing and print nothing (run under `-race`).
- Full `go test -race ./...` green.
