### PR TITLE
Add CONTRIBUTING.md and link the wiki engineering docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,10 +5,14 @@ If this PR addresses an existing issue, please add the issue number below.
 
 Fixes: #(issue number)
 
-## Additonally
+## Checklist
 
-- [ ] If this is the first time you are contributing to ffuf, add your name to `CONTRIBUTORS.md`. 
-The file should be alphabetically ordered.
-- [ ] Add a short description of the fix to `CHANGELOG.md`
+- [ ] Branch is based on the latest `master`.
+- [ ] `go test -race ./...` passes, and `gofmt` and `go vet` are clean.
+- [ ] If this changes help, flag, or config output, the characterization goldens are regenerated (`go test -run Characterization -update-golden .`) and committed.
+- [ ] If this is your first time contributing to ffuf, add your name to `CONTRIBUTORS.md` (alphabetically ordered).
+- [ ] Add a short description of the change to `CHANGELOG.md`.
+
+New to the codebase? The [wiki Contributing section](https://github.com/ffuf/ffuf/wiki/Contributing) covers the architecture, and the [Testing page](https://github.com/ffuf/ffuf/wiki/Contributing-Testing) covers the test layers.
 
 Thanks for contributing to ffuf :)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to ffuf
+
+Thanks for taking the time to contribute. This file is the short version; the
+detailed engineering documentation lives in the wiki.
+
+## Before you start
+
+- ffuf needs Go 1.20 or newer.
+- Build: `go build` at the repo root produces the `ffuf` binary.
+- Test: `go test -race ./...`. The race detector is what CI gates on, so run it
+  before you push.
+
+## Engineering documentation (the wiki)
+
+The [wiki Contributing section](https://github.com/ffuf/ffuf/wiki/Contributing)
+documents ffuf from the inside:
+
+- [Overview and architecture](https://github.com/ffuf/ffuf/wiki/Contributing):
+  how the packages fit together (the `pkg/ffuf` kernel, the `pkg/engine` scan
+  engine, the provider interfaces, and the `assembly.BuildJob` wiring seam).
+- [Testing](https://github.com/ffuf/ffuf/wiki/Contributing-Testing): the test
+  layers (unit, property, characterization goldens, integration, end-to-end),
+  how to run each, and which layer a new test belongs in.
+- [Flags and help declaration](https://github.com/ffuf/ffuf/wiki/Contributing-Flags-and-Help):
+  read this before adding or changing any CLI flag.
+
+Read the architecture and testing pages before a large change; read the flags
+page before touching a flag.
+
+## Submitting a pull request
+
+- Base your branch on the latest `master`.
+- Keep each pull request to one logical change.
+- Run `go test -race ./...`, and make sure `gofmt` and `go vet` are clean.
+- If your change affects help, flag, or config output, regenerate the
+  characterization goldens and commit them:
+  `go test -run Characterization -update-golden .`
+- If this is your first contribution, add your name to `CONTRIBUTORS.md`
+  (the file is alphabetically ordered).
+- Add a short entry describing your change to `CHANGELOG.md` under the `master`
+  section.
+
+## Reporting a security issue
+
+Please do not open a public issue for a security vulnerability in ffuf. Report it
+privately through the repository's
+[security policy](https://github.com/ffuf/ffuf/security/policy).
+
+Thanks for contributing to ffuf :)

--- a/README.md
+++ b/README.md
@@ -307,6 +307,13 @@ job from the beginning.
   <img width="250" src="_img/ffuf_waving_250.png">
 </p>
 
+## Contributing
+
+Bug reports, feature requests, and pull requests are welcome. See
+[CONTRIBUTING.md](CONTRIBUTING.md) to get started, and the
+[wiki's Contributing section](https://github.com/ffuf/ffuf/wiki/Contributing) for
+the architecture and testing documentation.
+
 ## License
 
 ffuf is released under MIT license. See [LICENSE](https://github.com/ffuf/ffuf/blob/master/LICENSE).


### PR DESCRIPTION
There was no `CONTRIBUTING.md`; the only contributor guidance was a short PR-template checklist. The engineering documentation already lives in the wiki (architecture, flags, and now a testing page), so this adds thin repo-side entry points that point there.

- **CONTRIBUTING.md**: build, `go test -race ./...`, PR workflow, and links to the wiki [Contributing](https://github.com/ffuf/ffuf/wiki/Contributing) / [Testing](https://github.com/ffuf/ffuf/wiki/Contributing-Testing) / [Flags](https://github.com/ffuf/ffuf/wiki/Contributing-Flags-and-Help) pages.
- **README**: a short Contributing section for discoverability.
- **PR template**: turned the checklist into a real pre-submit list (base on master, `-race`, gofmt/vet, regenerate goldens) and linked the wiki. Fixed the `Additonally` typo.

Docs only, no code change.