### PR TITLE
Add YAML issue forms routing to the wiki

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Report a bug in ffuf
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, please skim the [wiki](https://github.com/ffuf/ffuf/wiki) and the [CLI flag reference](https://github.com/ffuf/ffuf/wiki/CLI-flags). Many "it doesn't work" reports turn out to be configuration questions the docs already answer.
+
+        Found a security vulnerability in ffuf itself? Do not file it here. Report it privately through the [security policy](https://github.com/ffuf/ffuf/security/policy).
+  - type: input
+    id: version
+    attributes:
+      label: ffuf version
+      description: Output of `ffuf -V`. If you built from source, give the commit.
+      placeholder: "e.g. v2.1.0"
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command line
+      description: The exact ffuf command you ran. Redact anything sensitive.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened?
+      description: Include the relevant output. Paste text rather than screenshots where you can.
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Operating system and Go version
+      description: Your OS, and `go version` if you built from source.
+      placeholder: "e.g. Ubuntu 24.04, go1.22"
+    validations:
+      required: false
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Config file contents, wordlist characteristics, target behavior, anything that helps reproduce.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation and usage (wiki)
+    url: https://github.com/ffuf/ffuf/wiki
+    about: The full CLI flag reference, configuration, and feature guides. Check here first, most usage questions are answered in the wiki.
+  - name: Report a security vulnerability
+    url: https://github.com/ffuf/ffuf/security/policy
+    about: Do not file security vulnerabilities as public issues. Report them privately through the security policy.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Suggest an idea or improvement for ffuf
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check the [wiki](https://github.com/ffuf/ffuf/wiki) and the [CLI flag reference](https://github.com/ffuf/ffuf/wiki/CLI-flags) first: ffuf may already do what you want. The [Input methods](https://github.com/ffuf/ffuf/wiki/Input-methods), [Recursion](https://github.com/ffuf/ffuf/wiki/Recursion), [Scraper](https://github.com/ffuf/ffuf/wiki/Scraper), and [Autocalibration](https://github.com/ffuf/ffuf/wiki/Autocalibration) pages cover features people often miss.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the use case, not just the feature. What are you trying to do?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like ffuf to do? A flag, a behavior, an output format?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing flags or workarounds you tried, and why they fall short.
+    validations:
+      required: false


### PR DESCRIPTION
There were no issue templates. This adds GitHub issue **forms** (YAML) for bug reports and feature requests, plus a `config.yml`.

- **Bug form** requires the ffuf version (`ffuf -V`) and the exact command, the two things most reports leave out, and links the wiki + CLI flag reference up front so configuration questions get self-served.
- **Feature form** points at the Input methods / Recursion / Scraper / Autocalibration pages so requesters can check whether ffuf already does it.
- **config.yml** adds contact links to the wiki (docs) and the security policy. Blank issues stay enabled because Discussions is not turned on; if you enable Discussions later, you may want to set `blank_issues_enabled: false` and add a Discussions contact link.

Labels used (`bug`, `enhancement`) already exist. YAML validated locally.