### PR TITLE
Remove duplicate security link from issue chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Documentation and usage (wiki)
     url: https://github.com/ffuf/ffuf/wiki
     about: The full CLI flag reference, configuration, and feature guides. Check here first, most usage questions are answered in the wiki.
-  - name: Report a security vulnerability
-    url: https://github.com/ffuf/ffuf/security/policy
-    about: Do not file security vulnerabilities as public issues. Report them privately through the security policy.


### PR DESCRIPTION
After #917 (SECURITY.md) merged, the issue chooser shows two "Report a security vulnerability" entries: GitHub adds one automatically whenever a `SECURITY.md` exists, and #918's `config.yml` added a second explicit one.

Drop the explicit `contact_links` entry and let GitHub's built-in link (which points at the security policy) stand alone. The wiki docs contact link stays.