### PR TITLE
Support fuzzing keywords in preflight/postflight requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - New
     - Added audit logging functionality
     - Added preflight/postflight requests: raw HTTP request files run before/after each fuzzing request (`-preflight`/`-postflight`), with regex variable extraction (`-preflight-var "NAME:regex"`) injected into the main request, a per-request or amortized per-thread mode (`-preflight-mode`), and abort/ignore error handling (`-preflight-error`)
+    - Preflight/postflight requests now support the fuzzing keywords (FUZZ, custom wordlist keywords, and FFUFHASH), substituted with the current payload just like the main request
   - Changed
     - Fix a bug in autocalibration strategy merging, when two files have the same strategy key
     - Fix a bug in -or, causing output to not to be written in any case

--- a/pkg/engine/job.go
+++ b/pkg/engine/job.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -237,11 +238,14 @@ func (j *Job) prepareQueueJob() jobContext {
 	// never read it; they use the immutable jobContext returned from here.
 	j.Config.Url = job.Url
 
-	//Find all keywords present in new queued job
+	//Find all keywords present in the new queued job, including in the preflight/
+	//postflight request files so a keyword used only there still activates its
+	//wordlist.
 	kws := j.Input.Keywords()
+	flightBlob := preflightBlob(j.Config)
 	found_kws := make([]string, 0)
 	for _, k := range kws {
-		if ffuf.RequestContainsKeyword(job.req, k) {
+		if ffuf.RequestContainsKeyword(job.req, k) || strings.Contains(flightBlob, k) {
 			found_kws = append(found_kws, k)
 		}
 	}
@@ -249,6 +253,24 @@ func (j *Job) prepareQueueJob() jobContext {
 	j.Input.ActivateKeywords(found_kws)
 	j.Jobhash, _ = WriteHistoryEntry(j.Config)
 	return jobContext{basereq: job.req, depth: job.depth}
+}
+
+// preflightBlob concatenates the raw content of every preflight/postflight
+// request file, so keyword activation can detect a fuzzing keyword used only in
+// those files rather than in the main request template.
+func preflightBlob(conf *ffuf.Config) string {
+	var b strings.Builder
+	read := func(flights []ffuf.PreflightConfig) {
+		for _, pf := range flights {
+			if data, err := os.ReadFile(pf.RequestFile); err == nil {
+				b.Write(data)
+				b.WriteByte('\n')
+			}
+		}
+	}
+	read(conf.Preflights)
+	read(conf.Postflights)
+	return b.String()
 }
 
 // SkipQueue allows to skip the current job and advance to the next queued recursion job

--- a/pkg/engine/preflight_blob_test.go
+++ b/pkg/engine/preflight_blob_test.go
@@ -1,0 +1,38 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+// TestPreflightBlobIncludesFiles guards the engine-side half of keyword support:
+// preflightBlob concatenates the preflight/postflight file contents so keyword
+// activation can see a keyword used only there.
+func TestPreflightBlobIncludesFiles(t *testing.T) {
+	dir := t.TempDir()
+	pre := filepath.Join(dir, "pre.txt")
+	post := filepath.Join(dir, "post.txt")
+	if err := os.WriteFile(pre, []byte("GET /pre/FUZZ HTTP/1.1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(post, []byte("GET /post/HASHKW HTTP/1.1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	conf := &ffuf.Config{
+		Preflights:  []ffuf.PreflightConfig{{RequestFile: pre}},
+		Postflights: []ffuf.PreflightConfig{{RequestFile: post}},
+	}
+	blob := preflightBlob(conf)
+
+	if !strings.Contains(blob, "FUZZ") {
+		t.Error("blob missing preflight keyword FUZZ")
+	}
+	if !strings.Contains(blob, "HASHKW") {
+		t.Error("blob missing postflight keyword HASHKW")
+	}
+}

--- a/pkg/ffuf/optionsparser.go
+++ b/pkg/ffuf/optionsparser.go
@@ -818,6 +818,22 @@ func keywordPresent(keyword string, conf *Config) bool {
 			return true
 		}
 	}
+	// A keyword used only in a preflight/postflight request file also counts, so its
+	// wordlist isn't dropped when the keyword isn't in the main request.
+	if keywordInFlights(keyword, conf.Preflights) || keywordInFlights(keyword, conf.Postflights) {
+		return true
+	}
+	return false
+}
+
+// keywordInFlights reports whether keyword appears in any preflight/postflight
+// request file.
+func keywordInFlights(keyword string, flights []PreflightConfig) bool {
+	for _, pf := range flights {
+		if data, err := os.ReadFile(pf.RequestFile); err == nil && strings.Contains(string(data), keyword) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/pkg/ffuf/preflight_keyword_test.go
+++ b/pkg/ffuf/preflight_keyword_test.go
@@ -1,0 +1,59 @@
+package ffuf
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestKeywordInPreflightRetainsWordlist guards the config-side half of keyword
+// support: a wordlist keyword used ONLY in a preflight file (not the main request)
+// must not have its provider dropped by keywordPresent.
+func TestKeywordInPreflightRetainsWordlist(t *testing.T) {
+	dir := t.TempDir()
+	wl := filepath.Join(dir, "wl.txt")
+	if err := os.WriteFile(wl, []byte("admin\nroot\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	pre := filepath.Join(dir, "pre.txt")
+	if err := os.WriteFile(pre, []byte("GET /pre/FUZZ HTTP/1.1\nHost: example.com\n\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := NewConfigOptions()
+	opts.HTTP.URL = "http://example.com/" // no FUZZ in the main request
+	opts.Input.Wordlists = []string{wl}   // default keyword FUZZ
+	opts.HTTP.Preflights = []PreflightConfig{{RequestFile: pre}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conf, _ := ConfigFromOptions(opts, ctx, cancel)
+
+	found := false
+	for _, ip := range conf.InputProviders {
+		if ip.Keyword == "FUZZ" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("FUZZ wordlist provider was dropped even though FUZZ is used in the preflight file")
+	}
+}
+
+// TestKeywordPresentChecksPreflightFiles is the direct unit test for the gate.
+func TestKeywordPresentChecksPreflightFiles(t *testing.T) {
+	dir := t.TempDir()
+	pre := filepath.Join(dir, "pre.txt")
+	if err := os.WriteFile(pre, []byte("GET /login?u=FUZZ HTTP/1.1\n\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	conf := &Config{Preflights: []PreflightConfig{{RequestFile: pre}}}
+
+	if !keywordPresent("FUZZ", conf) {
+		t.Error("keywordPresent should find a keyword used in a preflight file")
+	}
+	if keywordPresent("NOPE", conf) {
+		t.Error("keywordPresent should not find an absent keyword")
+	}
+}

--- a/pkg/runner/preflight_hardening_test.go
+++ b/pkg/runner/preflight_hardening_test.go
@@ -121,14 +121,14 @@ func TestPreflightRejectsControlCharValue(t *testing.T) {
 	confAbort := newTestConfig(srv.URL)
 	confAbort.PreflightError = "abort"
 	confAbort.Preflights = []ffuf.PreflightConfig{{RequestFile: reqFile, Vars: []ffuf.VarExtract{{Name: "T", Regex: `token=(.+)`}}}}
-	if _, err := newTestRunner(confAbort).runPreflightChain(confAbort.Preflights, nil); err == nil {
+	if _, err := newTestRunner(confAbort).runPreflightChain(confAbort.Preflights, nil, nil); err == nil {
 		t.Error("abort mode: expected an error for a control-char value")
 	}
 
 	confIgnore := newTestConfig(srv.URL)
 	confIgnore.PreflightError = "ignore"
 	confIgnore.Preflights = []ffuf.PreflightConfig{{RequestFile: reqFile, Vars: []ffuf.VarExtract{{Name: "T", Regex: `token=(.+)`}}}}
-	vars, err := newTestRunner(confIgnore).runPreflightChain(confIgnore.Preflights, nil)
+	vars, err := newTestRunner(confIgnore).runPreflightChain(confIgnore.Preflights, nil, nil)
 	if err != nil {
 		t.Fatalf("ignore mode should not error: %s", err)
 	}
@@ -142,7 +142,7 @@ func TestPreflightRejectsControlCharValue(t *testing.T) {
 func TestParsePreflightKeepsLastHeader(t *testing.T) {
 	r := newTestRunner(newTestConfig("http://example.com/"))
 	f := writeTempRequest(t, "GET / HTTP/1.1\r\nHost: example.com\r\nX-Last: kept")
-	req, err := r.parsePreflightRequest(f, nil)
+	req, err := r.parsePreflightRequest(f, nil, nil)
 	if err != nil {
 		t.Fatalf("parsePreflightRequest: %s", err)
 	}

--- a/pkg/runner/preflight_keywords_test.go
+++ b/pkg/runner/preflight_keywords_test.go
@@ -1,0 +1,126 @@
+package runner
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+// recordingServer records the path of each request to /pre/... (the preflight
+// target) so a test can assert what keyword substitution produced.
+func recordingServer(t *testing.T) (*httptest.Server, func() string) {
+	t.Helper()
+	var mu sync.Mutex
+	var last string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/pre/", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		last = r.URL.Path
+		mu.Unlock()
+		fmt.Fprint(w, "ok")
+	})
+	mux.HandleFunc("/main", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+	srv := httptest.NewServer(mux)
+	return srv, func() string { mu.Lock(); defer mu.Unlock(); return last }
+}
+
+// TestKeywordSubstitutedIntoPreflight is the feature: a fuzzing input keyword in a
+// preflight request is substituted with the current payload, just like the main
+// request.
+func TestKeywordSubstitutedIntoPreflight(t *testing.T) {
+	srv, prePath := recordingServer(t)
+	defer srv.Close()
+
+	reqFile := writeTempRequest(t, fmt.Sprintf("GET /pre/FUZZ HTTP/1.1\nHost: %s\n\n", srv.Listener.Addr().String()))
+	conf := newTestConfig(srv.URL)
+	conf.Preflights = []ffuf.PreflightConfig{{RequestFile: reqFile}}
+	r := newTestRunner(conf)
+
+	req := &ffuf.Request{
+		Method:  "GET",
+		Url:     srv.URL + "/main",
+		Headers: map[string]string{},
+		Input:   map[string][]byte{"FUZZ": []byte("admin")},
+	}
+	if _, err := r.Execute(req); err != nil {
+		t.Fatalf("Execute: %s", err)
+	}
+	if got := prePath(); got != "/pre/admin" {
+		t.Errorf("preflight path = %q, want /pre/admin (FUZZ not substituted into the preflight)", got)
+	}
+}
+
+// TestFFUFHASHSubstitutedIntoPreflight confirms it isn't special-cased to FUZZ:
+// any input keyword, including FFUFHASH, is substituted.
+func TestFFUFHASHSubstitutedIntoPreflight(t *testing.T) {
+	srv, prePath := recordingServer(t)
+	defer srv.Close()
+
+	reqFile := writeTempRequest(t, fmt.Sprintf("GET /pre/FFUFHASH HTTP/1.1\nHost: %s\n\n", srv.Listener.Addr().String()))
+	conf := newTestConfig(srv.URL)
+	conf.Preflights = []ffuf.PreflightConfig{{RequestFile: reqFile}}
+	r := newTestRunner(conf)
+
+	req := &ffuf.Request{
+		Method:  "GET",
+		Url:     srv.URL + "/main",
+		Headers: map[string]string{},
+		Input:   map[string][]byte{"FFUFHASH": []byte("deadbeef")},
+	}
+	if _, err := r.Execute(req); err != nil {
+		t.Fatalf("Execute: %s", err)
+	}
+	if got := prePath(); got != "/pre/deadbeef" {
+		t.Errorf("preflight path = %q, want /pre/deadbeef", got)
+	}
+}
+
+// TestPreflightVhostHostResolved confirms the vhost case now works: a relative-path
+// preflight whose host is derived from a keyworded target (-u FUZZ.example.com)
+// resolves the keyword instead of erroring.
+func TestPreflightVhostHostResolved(t *testing.T) {
+	r := newTestRunner(newTestConfig("http://FUZZ.example.com/"))
+	f := writeTempRequest(t, "GET /login HTTP/1.1\n\n") // relative path, no Host header
+	req, err := r.parsePreflightRequest(f, map[string][]byte{"FUZZ": []byte("admin")}, nil)
+	if err != nil {
+		t.Fatalf("parsePreflightRequest: %s", err)
+	}
+	if req.Host != "admin.example.com" {
+		t.Errorf("derived host = %q, want admin.example.com (keyword not resolved)", req.Host)
+	}
+}
+
+// TestPerThreadPreflightAmortizesKeyword documents the per-thread semantics: the
+// preflight runs once per lane, so its keyword reflects the payload of the request
+// that initialized the lane and is reused for the rest.
+func TestPerThreadPreflightAmortizesKeyword(t *testing.T) {
+	srv, prePath := recordingServer(t)
+	defer srv.Close()
+
+	reqFile := writeTempRequest(t, fmt.Sprintf("GET /pre/FUZZ HTTP/1.1\nHost: %s\n\n", srv.Listener.Addr().String()))
+	conf := newTestConfig(srv.URL)
+	conf.PreflightMode = "per-thread"
+	conf.Preflights = []ffuf.PreflightConfig{{RequestFile: reqFile}}
+	r := newTestRunner(conf)
+
+	for _, payload := range []string{"first", "second"} {
+		req := &ffuf.Request{
+			Method:  "GET",
+			Url:     srv.URL + "/main",
+			Headers: map[string]string{},
+			Input:   map[string][]byte{"FUZZ": []byte(payload)},
+		}
+		if _, err := r.Execute(req); err != nil {
+			t.Fatalf("Execute: %s", err)
+		}
+	}
+	// The lane initialized on the first request, so the preflight ran once with
+	// "first" and was not re-run for "second".
+	if got := prePath(); got != "/pre/first" {
+		t.Errorf("preflight path = %q, want /pre/first (per-thread amortizes to the first payload)", got)
+	}
+}

--- a/pkg/runner/preflight_test.go
+++ b/pkg/runner/preflight_test.go
@@ -64,7 +64,7 @@ func TestPreflightVarsSubstitutedIntoMainRequest(t *testing.T) {
 	}}
 
 	r := newTestRunner(conf)
-	vars, err := r.runPreflightChain(conf.Preflights, nil)
+	vars, err := r.runPreflightChain(conf.Preflights, nil, nil)
 	if err != nil {
 		t.Fatalf("runPreflightChain: %s", err)
 	}
@@ -253,7 +253,7 @@ func TestPreflightErrorAbort(t *testing.T) {
 		Vars:        []ffuf.VarExtract{{Name: "X", Regex: `token=(\w+)`}},
 	}}
 	r := newTestRunner(conf)
-	if _, err := r.runPreflightChain(conf.Preflights, nil); err == nil {
+	if _, err := r.runPreflightChain(conf.Preflights, nil, nil); err == nil {
 		t.Error("expected an error when the extraction regex does not match in abort mode")
 	}
 }
@@ -272,7 +272,7 @@ func TestPreflightErrorIgnore(t *testing.T) {
 		Vars:        []ffuf.VarExtract{{Name: "X", Regex: `token=(\w+)`}},
 	}}
 	r := newTestRunner(conf)
-	vars, err := r.runPreflightChain(conf.Preflights, nil)
+	vars, err := r.runPreflightChain(conf.Preflights, nil, nil)
 	if err != nil {
 		t.Fatalf("ignore mode should not error, got: %s", err)
 	}

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -159,7 +159,7 @@ func (r *SimpleRunner) Execute(req *ffuf.Request) (resp ffuf.Response, err error
 	// skipped when the request itself errors.
 	defer func() {
 		if err == nil {
-			r.runPostflights(appliedVars)
+			r.runPostflights(req.Input, appliedVars)
 		}
 	}()
 	if pferr != nil {
@@ -286,7 +286,7 @@ func (r *SimpleRunner) Execute(req *ffuf.Request) (resp ffuf.Response, err error
 // parsePreflightRequest reads a Burp-style raw HTTP request file and builds an
 // *http.Request. Main-config headers are inherited (so auth carries over) and any
 // already-known vars are substituted into the request before it is built.
-func (r *SimpleRunner) parsePreflightRequest(filename string, vars map[string]string) (*http.Request, error) {
+func (r *SimpleRunner) parsePreflightRequest(filename string, input map[string][]byte, vars map[string]string) (*http.Request, error) {
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, fmt.Errorf("preflight: could not open %q: %s", filename, err)
@@ -337,10 +337,12 @@ func (r *SimpleRunner) parsePreflightRequest(filename string, vars map[string]st
 	body, _ := io.ReadAll(reader)
 	body = bytes.TrimRight(body, "\r\n") // trim trailing newline editors add
 
-	// Substitute known variables into method, path, headers, host and body, in a
-	// single deterministic pass.
-	if len(vars) > 0 {
-		rep := varsReplacer(vars)
+	// Substitute the fuzzing input keywords AND the extracted variables into the
+	// request, in one deterministic pass. Input keywords (FUZZ, custom wordlist
+	// keywords, FFUFHASH) give preflight/postflight the same keyword treatment as
+	// the main request; extracted vars chain from earlier steps.
+	rep := mergedReplacer(input, vars)
+	if rep != nil {
 		method = rep.Replace(method)
 		path = rep.Replace(path)
 		body = []byte(rep.Replace(string(body)))
@@ -361,11 +363,13 @@ func (r *SimpleRunner) parsePreflightRequest(filename string, vars map[string]st
 			scheme = u.Scheme
 			if host == "" {
 				host = u.Host
+				if rep != nil {
+					host = rep.Replace(host) // resolve keywords in the derived (vhost) host
+				}
 			}
 		}
-		// A relative-path preflight whose host was derived from the target template
-		// during host/vhost fuzzing would carry an unsubstituted keyword; fail loudly
-		// rather than send the request to a literal "FUZZ.example.com".
+		// If a keyword still survives here it had no value in the current input, so
+		// the request would go to a literal "FUZZ.example.com"; fail loudly instead.
 		if kw, ok := r.hostHasKeyword(host); ok {
 			return nil, fmt.Errorf("preflight %q: derived target host %q still contains fuzz keyword %q; give the preflight file an absolute URL or a Host header", filename, host, kw)
 		}
@@ -392,7 +396,7 @@ func (r *SimpleRunner) parsePreflightRequest(filename string, vars map[string]st
 // variables. inheritVars seeds the map (e.g. with vars from an earlier step). The
 // result is returned; no shared state is touched. On error it honours
 // -preflight-error: "ignore" returns the vars gathered so far, "abort" errors.
-func (r *SimpleRunner) runPreflightChain(chain []ffuf.PreflightConfig, inheritVars map[string]string) (map[string]string, error) {
+func (r *SimpleRunner) runPreflightChain(chain []ffuf.PreflightConfig, input map[string][]byte, inheritVars map[string]string) (map[string]string, error) {
 	vars := make(map[string]string, len(inheritVars))
 	for k, v := range inheritVars {
 		vars[k] = v
@@ -400,7 +404,7 @@ func (r *SimpleRunner) runPreflightChain(chain []ffuf.PreflightConfig, inheritVa
 	ignore := r.config.PreflightError == "ignore"
 
 	for _, pf := range chain {
-		httpreq, err := r.parsePreflightRequest(pf.RequestFile, vars)
+		httpreq, err := r.parsePreflightRequest(pf.RequestFile, input, vars)
 		if err != nil {
 			if ignore {
 				log.Printf("preflight ignored error building request from %q: %s", pf.RequestFile, err)
@@ -478,6 +482,24 @@ func (r *SimpleRunner) runPreflightChain(chain []ffuf.PreflightConfig, inheritVa
 // simultaneous pass, so a replaced value is never rescanned. That makes
 // substitution independent of map iteration order and free of value-contains-name
 // cascades.
+// mergedReplacer builds one deterministic replacer over both the fuzzing input
+// keywords and the extracted preflight variables, so a preflight/postflight
+// request gets the same keyword substitution as the main request. Returns nil
+// when there is nothing to substitute.
+func mergedReplacer(input map[string][]byte, vars map[string]string) *strings.Replacer {
+	if len(input) == 0 && len(vars) == 0 {
+		return nil
+	}
+	all := make(map[string]string, len(input)+len(vars))
+	for k, v := range input {
+		all[k] = string(v)
+	}
+	for k, v := range vars { // an extracted var wins over an input keyword on a name clash
+		all[k] = v
+	}
+	return varsReplacer(all)
+}
+
 func varsReplacer(vars map[string]string) *strings.Replacer {
 	names := make([]string, 0, len(vars))
 	for k := range vars {
@@ -544,7 +566,7 @@ func (r *SimpleRunner) runPreflights(req *ffuf.Request) (applied map[string]stri
 		lane := r.lanes.get()
 		cleanup = func() { r.lanes.put(lane) }
 		if !lane.initialized {
-			v, ferr := r.runPreflightChain(r.config.Preflights, nil)
+			v, ferr := r.runPreflightChain(r.config.Preflights, req.Input, nil)
 			if ferr != nil {
 				cleanup()
 				return nil, func() {}, ferr
@@ -554,7 +576,7 @@ func (r *SimpleRunner) runPreflights(req *ffuf.Request) (applied map[string]stri
 		}
 		applied = lane.vars
 	} else {
-		v, ferr := r.runPreflightChain(r.config.Preflights, nil)
+		v, ferr := r.runPreflightChain(r.config.Preflights, req.Input, nil)
 		if ferr != nil {
 			return nil, cleanup, ferr
 		}
@@ -569,11 +591,11 @@ func (r *SimpleRunner) runPreflights(req *ffuf.Request) (applied map[string]stri
 // runPostflights executes the postflight chain after the main request, seeded
 // with the vars applied to it so chained extractions work. Postflight failure is
 // non-fatal: the main result is always kept, the error is only logged.
-func (r *SimpleRunner) runPostflights(seedVars map[string]string) {
+func (r *SimpleRunner) runPostflights(input map[string][]byte, seedVars map[string]string) {
 	if len(r.config.Postflights) == 0 {
 		return
 	}
-	if _, ferr := r.runPreflightChain(r.config.Postflights, seedVars); ferr != nil {
+	if _, ferr := r.runPreflightChain(r.config.Postflights, input, seedVars); ferr != nil {
 		log.Printf("postflight error (result still recorded): %s", ferr)
 	}
 }


### PR DESCRIPTION
Follow-up to the preflight/postflight feature: the raw request files now substitute the fuzzing keywords (`FUZZ`, custom wordlist keywords, `FFUFHASH`) with the current payload, the same way the main request does. Before, only the extracted `-preflight-var` values were substituted.

## Why three layers

A keyword used *only* in a preflight was invisible to ffuf's keyword handling, so it took a change at each layer:

- **runner** (`pkg/runner/simple.go`): `parsePreflightRequest`/`runPreflightChain` thread the request's input map through and substitute it, merged deterministically with the extracted vars. The vhost case now resolves as a bonus: a relative-path preflight whose host derives from a keyworded `-u` target gets the keyword substituted instead of erroring.
- **config** (`pkg/ffuf/optionsparser.go`): `keywordPresent` also scans the preflight/postflight files, so a wordlist whose keyword appears only there isn't dropped.
- **engine** (`pkg/engine/job.go`): keyword activation also scans those files (`preflightBlob`), so the wordlist is activated and produces values.

**Per-thread** mode amortizes as before: the preflight runs once per lane, so its keyword reflects the payload of the request that initialized the lane (documented in the tests).

## Tests

Runner keyword substitution + per-thread amortization, the config provider-retention gate, and the engine blob helper. Verified end to end with the built binary: `FUZZ` used only in a preflight resolves per payload. Full `go test -race ./...` green; characterization goldens unchanged.

Note: the wiki page currently says keywords are not substituted into preflight files; I'll update it once this merges.