### PR TITLE
Fix scrambled keyword/value columns in CSV, HTML and Markdown output with multiple wordlists

### DIFF
--- a/pkg/output/file_csv.go
+++ b/pkg/output/file_csv.go
@@ -30,6 +30,11 @@ func writeCSV(filename string, config *ffuf.Config, res []ffuf.Result, encode bo
 	if err := w.Write(header); err != nil {
 		return err
 	}
+	keywords := make([]string, 0)
+	for _, inputprovider := range config.InputProviders {
+		keywords = append(keywords, inputprovider.Keyword)
+	}
+
 	for _, r := range res {
 		if encode {
 			inputs := make(map[string][]byte, len(r.Input))
@@ -39,7 +44,7 @@ func writeCSV(filename string, config *ffuf.Config, res []ffuf.Result, encode bo
 			r.Input = inputs
 		}
 
-		err := w.Write(toCSV(r))
+		err := w.Write(toCSV(r, keywords))
 		if err != nil {
 			return err
 		}
@@ -51,15 +56,14 @@ func base64encode(in []byte) string {
 	return base64.StdEncoding.EncodeToString(in)
 }
 
-func toCSV(r ffuf.Result) []string {
+func toCSV(r ffuf.Result, keywords []string) []string {
 	res := make([]string, 0)
 	ffufhash := ""
-	for k, v := range r.Input {
-		if k == "FFUFHASH" {
-			ffufhash = string(v)
-		} else {
-			res = append(res, string(v))
-		}
+	if hash, ok := r.Input["FFUFHASH"]; ok {
+		ffufhash = string(hash)
+	}
+	for _, k := range keywords {
+		res = append(res, string(r.Input[k]))
 	}
 	res = append(res, r.Url)
 	res = append(res, r.RedirectLocation)

--- a/pkg/output/file_csv_test.go
+++ b/pkg/output/file_csv_test.go
@@ -24,7 +24,7 @@ func TestToCSV(t *testing.T) {
 		Host:             "host",
 	}
 
-	csv := toCSV(result)
+	csv := toCSV(result, []string{"x"})
 
 	if !reflect.DeepEqual(csv, []string{
 		"B",
@@ -40,5 +40,35 @@ func TestToCSV(t *testing.T) {
 		"resultfile",
 		"A"}) {
 		t.Errorf("CSV was not generated in expected format")
+	}
+}
+
+func TestToCSV_MultipleKeywords(t *testing.T) {
+	result := ffuf.Result{
+		Input:            map[string][]byte{"FUZ2": []byte("bbb"), "FUZZ": []byte("aaa"), "FFUFHASH": []byte("A")},
+		Position:         1,
+		StatusCode:       200,
+		ContentLength:    3,
+		ContentWords:     4,
+		ContentLines:     5,
+		ContentType:      "application/json",
+		RedirectLocation: "http://no.pe",
+		Url:              "http://as.df",
+		Duration:         time.Duration(123),
+		ResultFile:       "resultfile",
+		Host:             "host",
+	}
+
+	csv := toCSV(result, []string{"FUZZ", "FUZ2"})
+	expected := []string{"aaa", "bbb", "http://as.df", "http://no.pe", "1", "200", "3", "4", "5", "application/json", "123ns", "resultfile", "A"}
+	if !reflect.DeepEqual(csv, expected) {
+		t.Errorf("CSV was not generated in expected format. Expected: %v, Got: %v", expected, csv)
+	}
+
+	// Test reversed keyword order
+	csvReversed := toCSV(result, []string{"FUZ2", "FUZZ"})
+	expectedReversed := []string{"bbb", "aaa", "http://as.df", "http://no.pe", "1", "200", "3", "4", "5", "application/json", "123ns", "resultfile", "A"}
+	if !reflect.DeepEqual(csvReversed, expectedReversed) {
+		t.Errorf("CSV was not generated in expected format. Expected: %v, Got: %v", expectedReversed, csvReversed)
 	}
 }

--- a/pkg/output/file_html.go
+++ b/pkg/output/file_html.go
@@ -106,12 +106,12 @@ const (
         <tbody>
 			{{range $result := .Results}}
                 <div style="display:none">
-|result_raw|{{ $result.StatusCode }}{{ range $keyword, $value := $result.Input }}|{{ $value | printf "%s" }}{{ end }}|{{ $result.Url }}|{{ $result.RedirectLocation }}|{{ $result.Position }}|{{ $result.ContentLength }}|{{ $result.ContentWords }}|{{ $result.ContentLines }}|{{ $result.ContentType }}|{{ $result.Duration }}|{{ $result.ResultFile }}|{{ $result.ScraperData }}|{{ $result.FfufHash }}|
+|result_raw|{{ $result.StatusCode }}{{ $input := $result.Input }}{{ range $keyword := $.Keys }}|{{ index $input $keyword | printf "%s" }}{{ end }}|{{ $result.Url }}|{{ $result.RedirectLocation }}|{{ $result.Position }}|{{ $result.ContentLength }}|{{ $result.ContentWords }}|{{ $result.ContentLines }}|{{ $result.ContentType }}|{{ $result.Duration }}|{{ $result.ResultFile }}|{{ $result.ScraperData }}|{{ $result.FfufHash }}|
                 </div>
                 <tr class="result-{{ $result.StatusCode }}" style="background-color: {{ $result.HTMLColor }};">
                     <td><font color="black" class="status-code">{{ $result.StatusCode }}</font></td>
-                    {{ range $keyword, $value := $result.Input }}
-                        <td>{{ $value | printf "%s" }}</td>
+                    {{ $input := $result.Input }}{{ range $keyword := $.Keys }}
+                        <td>{{ index $input $keyword | printf "%s" }}</td>
                     {{ end }}
                     <td><a href="{{ $result.Url }}">{{ $result.Url }}</a></td>
                     <td><a href="{{ $result.RedirectLocation }}">{{ $result.RedirectLocation }}</a></td>

--- a/pkg/output/file_md.go
+++ b/pkg/output/file_md.go
@@ -16,7 +16,7 @@ const (
 
   {{ range .Keys }}| {{ . }} {{ end }}| URL | Redirectlocation | Position | Status Code | Content Length | Content Words | Content Lines | Content Type | Duration | ResultFile | ScraperData | Ffufhash
   {{ range .Keys }}| :- {{ end }}| :-- | :--------------- | :---- | :------- | :---------- | :------------- | :------------ | :--------- | :----------- | :------------ | :-------- |
-  {{range .Results}}{{ range $keyword, $value := .Input }}| {{ $value | printf "%s" }} {{ end }}| {{ .Url }} | {{ .RedirectLocation }} | {{ .Position }} | {{ .StatusCode }} | {{ .ContentLength }} | {{ .ContentWords }} | {{ .ContentLines }} | {{ .ContentType }} | {{ .Duration}} | {{ .ResultFile }} | {{ .ScraperData }} | {{ .FfufHash }}
+  {{range .Results}}{{ $input := .Input }}{{ range $keyword := $.Keys }}| {{ index $input $keyword | printf "%s" }} {{ end }}| {{ .Url }} | {{ .RedirectLocation }} | {{ .Position }} | {{ .StatusCode }} | {{ .ContentLength }} | {{ .ContentWords }} | {{ .ContentLines }} | {{ .ContentType }} | {{ .Duration}} | {{ .ResultFile }} | {{ .ScraperData }} | {{ .FfufHash }}
   {{end}}` // The template format is not pretty but follows the markdown guide
 )
 


### PR DESCRIPTION
Fixes #851.

When ffuf runs with more than one wordlist, the CSV, HTML and Markdown output files stop lining the values up under the right column headers.

The header row is built from `config.InputProviders`, which has a fixed order. The data rows were built by ranging over `r.Input`, which is a map. In CSV, Go's map iteration order is randomized, so the value columns shuffle from one row to the next. In the HTML and Markdown templates, `text/template` and `html/template` range maps in sorted-key order, so those come out in a consistent but still wrong order relative to the header.

The fix builds the keyword order once, the same way the header is built, and indexes into `r.Input` by keyword in that order for all three writers. `toCSV` now takes the keyword slice, and the HTML/Markdown templates range over `.Keys` and use `index` instead of ranging the map. `FFUFHASH` is still pulled out separately and stays as the last column. The output schema and headers don't change, the values just land under the correct header in every row now.

Added `TestToCSV_MultipleKeywords`, which uses two keywords with distinguishable values and asserts each lands in its declared column, including with the keyword order reversed. The input map is deliberately populated out of order, so the test fails against the old map-ranging code and passes with this change. Existing tests and gofmt pass.
