### PR TITLE
Strip wordlist comments before the %ext% branch, not only after it

### DIFF
--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -130,33 +130,29 @@ func (w *WordlistInput) readFile(path string) error {
 	reader := bufio.NewScanner(file)
 	re := regexp.MustCompile(`(?i)%ext%`)
 	for reader.Scan() {
+		text := reader.Text()
+
+		// Strip comments before anything else so a commented-out line (or a
+		// trailing "# ..." comment) can never leak into the generated
+		// candidates, regardless of whether it also contains "%ext%".
+		if w.config.IgnoreWordlistComments {
+			text, ok = stripComments(text)
+			if !ok {
+				continue
+			}
+		}
+
 		if w.config.DirSearchCompat && len(w.config.Extensions) > 0 {
-			text := []byte(reader.Text())
-			if re.Match(text) {
+			btext := []byte(text)
+			if re.Match(btext) {
 				for _, ext := range w.config.Extensions {
-					contnt := re.ReplaceAll(text, []byte(ext))
+					contnt := re.ReplaceAll(btext, []byte(ext))
 					data = append(data, []byte(contnt))
 				}
 			} else {
-				text := reader.Text()
-
-				if w.config.IgnoreWordlistComments {
-					text, ok = stripComments(text)
-					if !ok {
-						continue
-					}
-				}
 				data = append(data, []byte(text))
 			}
 		} else {
-			text := reader.Text()
-
-			if w.config.IgnoreWordlistComments {
-				text, ok = stripComments(text)
-				if !ok {
-					continue
-				}
-			}
 			data = append(data, []byte(text))
 			if w.keyword == "FUZZ" && len(w.config.Extensions) > 0 {
 				for _, ext := range w.config.Extensions {

--- a/pkg/input/wordlist_test.go
+++ b/pkg/input/wordlist_test.go
@@ -1,7 +1,10 @@
 package input
 
 import (
+	"os"
 	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 func TestStripCommentsIgnoresCommentLines(t *testing.T) {
@@ -17,5 +20,49 @@ func TestStripCommentsStripsCommentAfterText(t *testing.T) {
 
 	if text != "text" {
 		t.Errorf("Comment was not stripped or pre-comment text was not returned")
+	}
+}
+
+// A wordlist line that contains the "%ext%" placeholder used to skip comment
+// stripping entirely: a fully commented-out "%ext%" line leaked straight into
+// the fuzzed candidates, and a trailing "# comment" on a "%ext%" line was
+// never trimmed off. Both must behave the same as any other line.
+func TestReadFileStripsCommentsOnExtLines(t *testing.T) {
+	f, err := os.CreateTemp("", "ffuf-wordlist-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	if _, err := f.WriteString("admin.%ext% # internal, do not scan\n# %ext% fully commented out\n"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	conf := &ffuf.Config{
+		DirSearchCompat:        true,
+		IgnoreWordlistComments: true,
+		Extensions:             []string{".php"},
+	}
+
+	wl, err := NewWordlistInput("FUZZ", f.Name(), conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got []string
+	for wl.Next() {
+		got = append(got, string(wl.Value()))
+		wl.IncrementPosition()
+	}
+
+	want := []string{"admin..php"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("expected %q, got %q", want[i], got[i])
+		}
 	}
 }


### PR DESCRIPTION
`readFile()` has two code paths depending on whether a wordlist line contains `%ext%`, and the `IgnoreWordlistComments` stripping was only wired into the non-`%ext%` path. Any line containing `%ext%` skipped it.

So with `-d` (dirsearch compat) and `--ic` (ignore wordlist comments) both set, a `%ext%` line with a trailing comment kept the comment, and a fully commented-out line that happens to mention `%ext%` became live fuzz candidates instead of being dropped:

```
admin.%ext%  # internal-only, do not scan   ->  admin..php # internal-only, do not scan
# %ext% placeholder, see docs               ->  # .php placeholder, see docs
```

Both of those get sent to the target.

The fix moves the comment strip to the top of the loop so it runs before the `%ext%` branch, the same way every other line is handled. Nothing else about the `%ext%` expansion changes.

## Verification

Added `TestReadFileStripsCommentsOnExtLines` in `pkg/input/wordlist_test.go` (a temp wordlist with `DirSearchCompat` and `IgnoreWordlistComments` on). It fails against the current code:

```
expected [admin..php], got [admin..php # internal, do not scan # .php fully commented out]
```

and passes with this change. `go build ./...` and the full `pkg/input` suite pass, `gofmt` is clean on both files.
