### PR TITLE
engine, filter: detect reflected/dynamic response sizes during autocalibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 - master
   - New
+    - Auto-calibration now recognizes reflected/dynamic response sizes (eg. custom 404 pages that echo the fuzzed value back into the body) as a fourth calibration dimension, via a new internal `dynamicsize` filter
     - Added audit logging functionality
     - Added preflight/postflight requests: raw HTTP request files run before/after each fuzzing request (`-preflight`/`-postflight`), with regex variable extraction (`-preflight-var "NAME:regex"`) injected into the main request, a per-request or amortized per-thread mode (`-preflight-mode`), and abort/ignore error handling (`-preflight-error`)
   - Changed

--- a/pkg/engine/autocalibration.go
+++ b/pkg/engine/autocalibration.go
@@ -166,110 +166,117 @@ func (j *Job) CalibrateIfNeeded(host string, input map[string][]byte) error {
 	return j.Calibrate(input)
 }
 
-func (j *Job) calibrateFilters(responses []ffuf.Response, perHost bool) error {
-	// Work down from the most specific common denominator
-	if len(responses) > 0 {
-		// Content length
-		baselineSize := responses[0].ContentLength
-		sizeMatch := true
-		for _, r := range responses {
-			if baselineSize != r.ContentLength {
-				sizeMatch = false
+// registerCalibrationFilter adds a calibration-derived filter (name/value) for
+// the current scope (global, or per-host when perHost is set), unless a filter
+// already installed for that scope would filter the sample response - in which
+// case a new, redundant filter is skipped.
+func (j *Job) registerCalibrationFilter(name, value string, perHost bool, sample ffuf.Response) error {
+	if perHost {
+		host := ffuf.HostURLFromRequest(*sample.Request)
+		for _, f := range j.Config.MatcherManager.FiltersForDomain(host) {
+			if match, _ := f.Filter(&sample); match {
+				return nil // Already filtered
 			}
 		}
-		if sizeMatch {
-			if perHost {
-				// Check if already filtered
-				for _, f := range j.Config.MatcherManager.FiltersForDomain(ffuf.HostURLFromRequest(*responses[0].Request)) {
-					match, _ := f.Filter(&responses[0])
-					if match {
-						// Already filtered
-						return nil
-					}
-				}
-				_ = j.Config.MatcherManager.AddPerDomainFilter(ffuf.HostURLFromRequest(*responses[0].Request), "size", strconv.FormatInt(baselineSize, 10))
-				return nil
-			} else {
-				// Check if already filtered
-				for _, f := range j.Config.MatcherManager.GetFilters() {
-					match, _ := f.Filter(&responses[0])
-					if match {
-						// Already filtered
-						return nil
-					}
-				}
-				_ = j.Config.MatcherManager.AddFilter("size", strconv.FormatInt(baselineSize, 10), false)
-				return nil
-			}
-		}
-
-		// Content words
-		baselineWords := responses[0].ContentWords
-		wordsMatch := true
-		for _, r := range responses {
-			if baselineWords != r.ContentWords {
-				wordsMatch = false
-			}
-		}
-		if wordsMatch {
-			if perHost {
-				// Check if already filtered
-				for _, f := range j.Config.MatcherManager.FiltersForDomain(ffuf.HostURLFromRequest(*responses[0].Request)) {
-					match, _ := f.Filter(&responses[0])
-					if match {
-						// Already filtered
-						return nil
-					}
-				}
-				_ = j.Config.MatcherManager.AddPerDomainFilter(ffuf.HostURLFromRequest(*responses[0].Request), "word", strconv.FormatInt(baselineWords, 10))
-				return nil
-			} else {
-				// Check if already filtered
-				for _, f := range j.Config.MatcherManager.GetFilters() {
-					match, _ := f.Filter(&responses[0])
-					if match {
-						// Already filtered
-						return nil
-					}
-				}
-				_ = j.Config.MatcherManager.AddFilter("word", strconv.FormatInt(baselineWords, 10), false)
-				return nil
-			}
-		}
-
-		// Content lines
-		baselineLines := responses[0].ContentLines
-		linesMatch := true
-		for _, r := range responses {
-			if baselineLines != r.ContentLines {
-				linesMatch = false
-			}
-		}
-		if linesMatch {
-			if perHost {
-				// Check if already filtered
-				for _, f := range j.Config.MatcherManager.FiltersForDomain(ffuf.HostURLFromRequest(*responses[0].Request)) {
-					match, _ := f.Filter(&responses[0])
-					if match {
-						// Already filtered
-						return nil
-					}
-				}
-				_ = j.Config.MatcherManager.AddPerDomainFilter(ffuf.HostURLFromRequest(*responses[0].Request), "line", strconv.FormatInt(baselineLines, 10))
-				return nil
-			} else {
-				// Check if already filtered
-				for _, f := range j.Config.MatcherManager.GetFilters() {
-					match, _ := f.Filter(&responses[0])
-					if match {
-						// Already filtered
-						return nil
-					}
-				}
-				_ = j.Config.MatcherManager.AddFilter("line", strconv.FormatInt(baselineLines, 10), false)
-				return nil
-			}
+		return j.Config.MatcherManager.AddPerDomainFilter(host, name, value)
+	}
+	for _, f := range j.Config.MatcherManager.GetFilters() {
+		if match, _ := f.Filter(&sample); match {
+			return nil // Already filtered
 		}
 	}
+	return j.Config.MatcherManager.AddFilter(name, value, false)
+}
+
+func (j *Job) calibrateFilters(responses []ffuf.Response, perHost bool) error {
+	if len(responses) == 0 {
+		return fmt.Errorf("No common filtering values found")
+	}
+
+	// Work down from the most specific common denominator.
+
+	// Content length
+	baselineSize := responses[0].ContentLength
+	sizeMatch := true
+	for _, r := range responses {
+		if baselineSize != r.ContentLength {
+			sizeMatch = false
+			break
+		}
+	}
+	if sizeMatch {
+		return j.registerCalibrationFilter("size", strconv.FormatInt(baselineSize, 10), perHost, responses[0])
+	}
+
+	// Content words
+	baselineWords := responses[0].ContentWords
+	wordsMatch := true
+	for _, r := range responses {
+		if baselineWords != r.ContentWords {
+			wordsMatch = false
+			break
+		}
+	}
+	if wordsMatch {
+		return j.registerCalibrationFilter("word", strconv.FormatInt(baselineWords, 10), perHost, responses[0])
+	}
+
+	// Content lines
+	baselineLines := responses[0].ContentLines
+	linesMatch := true
+	for _, r := range responses {
+		if baselineLines != r.ContentLines {
+			linesMatch = false
+			break
+		}
+	}
+	if linesMatch {
+		return j.registerCalibrationFilter("line", strconv.FormatInt(baselineLines, 10), perHost, responses[0])
+	}
+
+	// Dynamic (reflected) size: none of the dimensions above were constant,
+	// which is exactly what happens with a custom error page that echoes the
+	// requested value back into the body - e.g. an nginx/Express/Flask 404
+	// handler rendering "Cannot find /adminXXXXXXXXXXXXXXXX". Content-Length
+	// then tracks len(fuzz value) plus a fixed offset instead of being
+	// constant outright. Detect that relationship by subtracting each
+	// response's fuzz-value length from its ContentLength: if the *normalized*
+	// value is constant, the page is a reflected-but-otherwise-static 404, and
+	// a DynamicSizeFilter (pkg/filter/dynamicsize.go) can recognize it for any
+	// future fuzzed value, not just the calibration strings used here.
+	if offset, ok := j.reflectedSizeOffset(responses); ok {
+		value := fmt.Sprintf("%d:%s", offset, j.Config.AutoCalibrationKeyword)
+		return j.registerCalibrationFilter("dynamicsize", value, perHost, responses[0])
+	}
+
 	return fmt.Errorf("No common filtering values found")
+}
+
+// reflectedSizeOffset checks whether every response's ContentLength equals a
+// constant offset plus the length of the calibration value that produced it
+// (i.e. the fuzzed value was reflected into the response body). It returns
+// that offset and true when the relationship holds for every response, or
+// (0, false) when responses are missing the calibration input or the
+// normalized sizes disagree.
+func (j *Job) reflectedSizeOffset(responses []ffuf.Response) (int64, bool) {
+	keyword := j.Config.AutoCalibrationKeyword
+	var offset int64
+	for i, r := range responses {
+		if r.Request == nil {
+			return 0, false
+		}
+		fuzzval, ok := r.Request.Input[keyword]
+		if !ok {
+			return 0, false
+		}
+		normalized := r.ContentLength - int64(len(fuzzval))
+		if i == 0 {
+			offset = normalized
+			continue
+		}
+		if normalized != offset {
+			return 0, false
+		}
+	}
+	return offset, true
 }

--- a/pkg/engine/calibratefilters_test.go
+++ b/pkg/engine/calibratefilters_test.go
@@ -1,0 +1,192 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+	"github.com/ffuf/ffuf/v2/pkg/filter"
+)
+
+// calibJob builds a minimal Job wired to a real MatcherManager, which is
+// enough to drive calibrateFilters directly without any HTTP plumbing.
+func calibJob() (*Job, ffuf.MatcherManager) {
+	mm := filter.NewMatcherManager()
+	j := &Job{
+		Config: &ffuf.Config{
+			AutoCalibrationKeyword: "FUZZ",
+			MatcherManager:         mm,
+		},
+		Output: NewNullOutput(),
+	}
+	return j, mm
+}
+
+func calibResponse(fuzz string, length, words, lines int64) ffuf.Response {
+	return ffuf.Response{
+		ContentLength: length,
+		ContentWords:  words,
+		ContentLines:  lines,
+		Request: &ffuf.Request{
+			Url:   "http://example.com/FUZZ",
+			Host:  "example.com",
+			Input: map[string][]byte{"FUZZ": []byte(fuzz)},
+		},
+	}
+}
+
+func TestCalibrateFilters_SizeMatch(t *testing.T) {
+	j, mm := calibJob()
+	responses := []ffuf.Response{
+		calibResponse("aaaa", 512, 80, 20),
+		calibResponse("bbbbbbbb", 512, 90, 25),
+	}
+	if err := j.calibrateFilters(responses, false); err != nil {
+		t.Fatalf("calibrateFilters: %v", err)
+	}
+	f := mm.GetFilters()["size"]
+	if f == nil {
+		t.Fatalf("expected a \"size\" filter to be registered")
+	}
+	if f.Repr() != "512" {
+		t.Errorf("expected size filter value \"512\", got %q", f.Repr())
+	}
+}
+
+func TestCalibrateFilters_WordsMatchWhenSizeVaries(t *testing.T) {
+	j, mm := calibJob()
+	responses := []ffuf.Response{
+		calibResponse("aaaa", 500, 42, 20),
+		calibResponse("bbbbbbbb", 504, 42, 25),
+	}
+	if err := j.calibrateFilters(responses, false); err != nil {
+		t.Fatalf("calibrateFilters: %v", err)
+	}
+	f := mm.GetFilters()["word"]
+	if f == nil {
+		t.Fatalf("expected a \"word\" filter to be registered")
+	}
+	if f.Repr() != "42" {
+		t.Errorf("expected word filter value \"42\", got %q", f.Repr())
+	}
+}
+
+func TestCalibrateFilters_LinesMatchWhenSizeAndWordsVary(t *testing.T) {
+	j, mm := calibJob()
+	responses := []ffuf.Response{
+		calibResponse("aaaa", 500, 40, 9),
+		calibResponse("bbbbbbbb", 504, 44, 9),
+	}
+	if err := j.calibrateFilters(responses, false); err != nil {
+		t.Fatalf("calibrateFilters: %v", err)
+	}
+	f := mm.GetFilters()["line"]
+	if f == nil {
+		t.Fatalf("expected a \"line\" filter to be registered")
+	}
+	if f.Repr() != "9" {
+		t.Errorf("expected line filter value \"9\", got %q", f.Repr())
+	}
+}
+
+// TestCalibrateFilters_DynamicSizeWhenReflected covers the motivating case for
+// this change: a custom 404 page that echoes the fuzzed value back into the
+// body, so raw size, word count and line count all vary between calibration
+// samples even though the page is always "not found". Before this change,
+// calibrateFilters gave up here with "No common filtering values found" and
+// installed no filter at all, so this class of page flooded results with
+// false positives.
+func TestCalibrateFilters_DynamicSizeWhenReflected(t *testing.T) {
+	j, mm := calibJob()
+	// Simulated body: "Cannot find /" + fuzzvalue -> ContentLength = 13 + len(fuzzvalue).
+	// Word/line counts are made to disagree between samples so the test can't
+	// accidentally pass via the word/line branches instead.
+	responses := []ffuf.Response{
+		calibResponse("aaaa", 17, 3, 1),
+		calibResponse("bbbbbbbbbbbbbbbb", 29, 5, 2),
+	}
+	if err := j.calibrateFilters(responses, false); err != nil {
+		t.Fatalf("calibrateFilters: %v", err)
+	}
+	f := mm.GetFilters()["dynamicsize"]
+	if f == nil {
+		t.Fatalf("expected a \"dynamicsize\" filter to be registered, got filters: %v", mm.GetFilters())
+	}
+	if f.Repr() != "13:FUZZ" {
+		t.Errorf("expected dynamicsize filter value \"13:FUZZ\", got %q", f.Repr())
+	}
+
+	// The registered filter must generalize to a fuzz value that was never
+	// part of calibration.
+	live := calibResponse("totally-new-guess", 30, 4, 1) // len("totally-new-guess") == 17
+	match, err := f.Filter(&live)
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	if !match {
+		t.Errorf("expected the dynamicsize filter to match a live reflected 404 for an unseen fuzz value")
+	}
+
+	// And it must NOT match a response whose size doesn't fit the formula,
+	// i.e. an actual hit.
+	realHit := calibResponse("admin", 4096, 400, 120)
+	match, err = f.Filter(&realHit)
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	if match {
+		t.Errorf("dynamicsize filter incorrectly matched a response that does not fit the reflected-size formula")
+	}
+}
+
+func TestCalibrateFilters_NoCommonValue(t *testing.T) {
+	j, mm := calibJob()
+	// Sizes, words and lines all differ, and the size difference doesn't
+	// track the fuzz value's length either (both fuzz values are 4 bytes).
+	responses := []ffuf.Response{
+		calibResponse("aaaa", 100, 10, 2),
+		calibResponse("bbbb", 200, 20, 4),
+	}
+	err := j.calibrateFilters(responses, false)
+	if err == nil {
+		t.Fatalf("expected an error when no dimension is consistent, got nil")
+	}
+	if len(mm.GetFilters()) != 0 {
+		t.Errorf("expected no filters to be registered, got %v", mm.GetFilters())
+	}
+}
+
+func TestCalibrateFilters_PerHost(t *testing.T) {
+	j, mm := calibJob()
+	responses := []ffuf.Response{
+		calibResponse("aaaa", 512, 80, 20),
+		calibResponse("bbbbbbbb", 512, 90, 25),
+	}
+	if err := j.calibrateFilters(responses, true); err != nil {
+		t.Fatalf("calibrateFilters: %v", err)
+	}
+	domainFilters := mm.FiltersForDomain("example.com")
+	if domainFilters["size"] == nil {
+		t.Fatalf("expected a per-domain \"size\" filter for example.com")
+	}
+	if len(mm.GetFilters()) != 0 {
+		t.Errorf("expected no global filters to be registered in per-host mode, got %v", mm.GetFilters())
+	}
+}
+
+func TestCalibrateFilters_SkipsWhenAlreadyFiltered(t *testing.T) {
+	j, mm := calibJob()
+	// Pre-install a size filter that already matches the calibration baseline.
+	if err := mm.AddFilter("size", "512", false); err != nil {
+		t.Fatalf("AddFilter: %v", err)
+	}
+	responses := []ffuf.Response{
+		calibResponse("aaaa", 512, 80, 20),
+		calibResponse("bbbbbbbb", 512, 90, 25),
+	}
+	if err := j.calibrateFilters(responses, false); err != nil {
+		t.Fatalf("calibrateFilters: %v", err)
+	}
+	if len(mm.GetFilters()) != 1 {
+		t.Errorf("expected the pre-existing filter to be left alone, got %v", mm.GetFilters())
+	}
+}

--- a/pkg/filter/dynamicsize.go
+++ b/pkg/filter/dynamicsize.go
@@ -1,0 +1,88 @@
+package filter
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+// dynamicSizeEntry pairs a fixed byte offset with the fuzz keyword whose
+// per-request value length must be added to that offset to reproduce a
+// response's expected Content-Length.
+type dynamicSizeEntry struct {
+	Offset  int64
+	Keyword string
+}
+
+// DynamicSizeFilter filters responses whose Content-Length equals
+// Offset + len(request.Input[Keyword]) for one of its entries.
+//
+// The existing -fs/-fw/-fl filters compare a response against a single fixed
+// number, so they cannot express a page whose size legitimately depends on
+// how long the fuzzed value is. That is a common source of false positives:
+// a "custom 404" page that echoes the requested path back into the body
+// (e.g. "Cannot find /adminXXXXXXXXXXXXXXXX") has a Content-Length that
+// changes with every guess, so a static size/word/line filter never
+// stabilizes even though every one of those responses is functionally a
+// not-found. Auto-calibration derives entries for this filter by observing
+// that ContentLength scales linearly with the calibration keyword's length
+// (see engine.calibrateFilters); the filter itself just replays that
+// relationship per-request.
+type DynamicSizeFilter struct {
+	Entries []dynamicSizeEntry
+}
+
+// NewDynamicSizeFilter parses a comma-separated list of "offset:keyword"
+// pairs, e.g. "173:FUZZ" or "173:FUZZ,42:FUZZ2".
+func NewDynamicSizeFilter(value string) (ffuf.FilterProvider, error) {
+	var entries []dynamicSizeEntry
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		fields := strings.SplitN(part, ":", 2)
+		if len(fields) != 2 || fields[1] == "" {
+			return &DynamicSizeFilter{}, fmt.Errorf("dynamic size filter: invalid value %q, expected \"offset:keyword\"", part)
+		}
+		offset, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			return &DynamicSizeFilter{}, fmt.Errorf("dynamic size filter: invalid offset in %q: %s", part, err)
+		}
+		entries = append(entries, dynamicSizeEntry{Offset: offset, Keyword: fields[1]})
+	}
+	if len(entries) == 0 {
+		return &DynamicSizeFilter{}, fmt.Errorf("dynamic size filter: no valid entries in value %q", value)
+	}
+	return &DynamicSizeFilter{Entries: entries}, nil
+}
+
+func (f *DynamicSizeFilter) Filter(response *ffuf.Response) (bool, error) {
+	if response.Request == nil {
+		return false, nil
+	}
+	for _, e := range f.Entries {
+		fuzzval, ok := response.Request.Input[e.Keyword]
+		if !ok {
+			continue
+		}
+		if response.ContentLength == e.Offset+int64(len(fuzzval)) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (f *DynamicSizeFilter) Repr() string {
+	parts := make([]string, 0, len(f.Entries))
+	for _, e := range f.Entries {
+		parts = append(parts, fmt.Sprintf("%d:%s", e.Offset, e.Keyword))
+	}
+	return strings.Join(parts, ",")
+}
+
+func (f *DynamicSizeFilter) ReprVerbose() string {
+	return fmt.Sprintf("Dynamic response size (offset:keyword): %s", f.Repr())
+}

--- a/pkg/filter/dynamicsize_test.go
+++ b/pkg/filter/dynamicsize_test.go
@@ -1,0 +1,111 @@
+package filter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+func TestNewDynamicSizeFilter(t *testing.T) {
+	f, err := NewDynamicSizeFilter("173:FUZZ")
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if !strings.Contains(f.Repr(), "173:FUZZ") {
+		t.Errorf("Expected repr to contain \"173:FUZZ\", got %q", f.Repr())
+	}
+}
+
+func TestNewDynamicSizeFilterMultipleEntries(t *testing.T) {
+	f, err := NewDynamicSizeFilter("173:FUZZ,42:FUZZ2")
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	df, ok := f.(*DynamicSizeFilter)
+	if !ok {
+		t.Fatalf("Expected *DynamicSizeFilter, got %T", f)
+	}
+	if len(df.Entries) != 2 {
+		t.Errorf("Expected 2 entries, got %d", len(df.Entries))
+	}
+}
+
+func TestNewDynamicSizeFilterErrors(t *testing.T) {
+	for _, value := range []string{
+		"",
+		"notanumber:FUZZ",
+		"173",                  // missing keyword
+		"173:",                 // empty keyword
+		"173:FUZZ:extra:stuff", // still valid: SplitN(2) keeps "FUZZ:extra:stuff" as keyword
+	} {
+		_, err := NewDynamicSizeFilter(value)
+		if value == "173:FUZZ:extra:stuff" {
+			if err != nil {
+				t.Errorf("Value %q: expected no error (extra colons belong to the keyword), got %s", value, err)
+			}
+			continue
+		}
+		if err == nil {
+			t.Errorf("Value %q: expected an error, got none", value)
+		}
+	}
+}
+
+func TestDynamicSizeFilterMatches(t *testing.T) {
+	f, _ := NewDynamicSizeFilter("100:FUZZ")
+
+	for i, test := range []struct {
+		fuzzValue     string
+		contentLength int64
+		expected      bool
+	}{
+		{"admin", 105, true},         // 100 + len("admin") == 105
+		{"administrator", 113, true}, // 100 + len("administrator") == 113
+		{"admin", 999, false},        // wrong length for this fuzz value
+		{"", 100, true},              // empty fuzz value still honours the offset
+	} {
+		resp := &ffuf.Response{
+			ContentLength: test.contentLength,
+			Request: &ffuf.Request{
+				Input: map[string][]byte{"FUZZ": []byte(test.fuzzValue)},
+			},
+		}
+		got, err := f.Filter(resp)
+		if err != nil {
+			t.Errorf("Test %d: unexpected error: %s", i, err)
+		}
+		if got != test.expected {
+			t.Errorf("Test %d: expected %t, got %t", i, test.expected, got)
+		}
+	}
+}
+
+func TestDynamicSizeFilterNoRequest(t *testing.T) {
+	f, _ := NewDynamicSizeFilter("100:FUZZ")
+	resp := &ffuf.Response{ContentLength: 105}
+	got, err := f.Filter(resp)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if got {
+		t.Errorf("Expected no match when response has no associated Request")
+	}
+}
+
+func TestDynamicSizeFilterUnknownKeyword(t *testing.T) {
+	f, _ := NewDynamicSizeFilter("100:FUZZ")
+	resp := &ffuf.Response{
+		ContentLength: 105,
+		Request: &ffuf.Request{
+			Input: map[string][]byte{"OTHER": []byte("admin")},
+		},
+	}
+	got, err := f.Filter(resp)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if got {
+		t.Errorf("Expected no match when the entry's keyword is absent from the request input")
+	}
+}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -97,6 +97,9 @@ func NewFilterByName(name string, value string) (ffuf.FilterProvider, error) {
 	if name == "time" {
 		return NewTimeFilter(value)
 	}
+	if name == "dynamicsize" {
+		return NewDynamicSizeFilter(value)
+	}
 	return nil, fmt.Errorf("Could not create filter with name %s", name)
 }
 


### PR DESCRIPTION
## Problem

Auto-calibration (`-ac`) gives up — "No common filtering values found",
installing no filter at all — on any target whose baseline responses don't
have an *exactly* constant size, word count, or line count. That happens
routinely on real-world 404 handlers that echo the requested path/value back
into the body (eg. `Cannot find /adminXXXXXXXXXXXXXXXX` in common
Express/Flask/nginx default error pages): Content-Length then tracks the
length of the guessed word instead of being constant, and depending on how
the value is rendered, word/line counts can be just as unstable. Every one
of those pages then floods the results as a false positive.

## Fix

Adds a 4th calibration dimension that specifically detects that "reflected
input" relationship: normalize each calibration response's Content-Length by
subtracting the length of the calibration string that produced it. If the
*normalized* value is constant across all samples, the page's size is
`offset + len(fuzzed value)`, and a new `DynamicSizeFilter`
(`pkg/filter/dynamicsize.go`) is registered to replay that relationship
against every subsequent request's actual fuzzed value — not just the
calibration strings used to derive it.

Also factors the previously near-identical size/word/line/per-host branches
in `calibrateFilters` into one `registerCalibrationFilter` helper, which the
new dimension reuses. Behavior for the three existing dimensions is
unchanged (same order, same "already filtered" dedup, same per-host
handling).

No new CLI flag — this is purely an improvement to what `-ac`/`-acc` already
do, so it's on by default wherever autocalibration already runs, and stays
backward compatible with existing `-fs`/`-fw`/`-fl` filter files.

## Testing

- New unit tests for `DynamicSizeFilter` (parsing, matching, error paths).
- `calibrateFilters` had no dedicated tests before this change — added
  `pkg/engine/calibratefilters_test.go` covering the existing size/word/line
  paths, the new dynamic-size path, the no-match error path, per-host
  filtering, and the already-filtered dedup path.
- `gofmt`/`go vet` clean; full existing test suite passes unmodified.

---
Solves #928