### PR TITLE
Count response words/lines without allocating a []string

### DIFF
--- a/pkg/filter/count_equivalence_test.go
+++ b/pkg/filter/count_equivalence_test.go
@@ -1,0 +1,62 @@
+package filter
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
+)
+
+// The word/line counts are computed with bytes.Count(data, sep)+1 instead of
+// len(strings.Split(string(data), sep)) to avoid allocating a []string over the
+// whole response body. These tests pin the two to the same value across the edge
+// cases where an off-by-one would hide: empty body, only separators, and
+// leading/trailing separators. The filter is built with an exact [n,n] range so a
+// match proves the production count equals the old strings.Split count, and the
+// [n+1,n+1] miss proves it is not off by one.
+
+var countEquivalenceBodies = []string{
+	"",
+	"a",
+	"a b c",
+	"     ",
+	" a ",
+	"a\nb\nc",
+	"\n\n",
+	"abc",
+	"a\n",
+	"one two\nthree four\n",
+}
+
+func TestWordFilterCountMatchesSplit(t *testing.T) {
+	for _, body := range countEquivalenceBodies {
+		expected := len(strings.Split(body, " "))
+		resp := ffuf.Response{Data: []byte(body)}
+
+		hit, _ := NewWordFilter(strconv.Itoa(expected))
+		if match, _ := hit.Filter(&resp); !match {
+			t.Errorf("word count for %q: expected filter to match %d", body, expected)
+		}
+		miss, _ := NewWordFilter(strconv.Itoa(expected + 1))
+		if match, _ := miss.Filter(&resp); match {
+			t.Errorf("word count for %q: filter matched %d, count is off by one", body, expected+1)
+		}
+	}
+}
+
+func TestLineFilterCountMatchesSplit(t *testing.T) {
+	for _, body := range countEquivalenceBodies {
+		expected := len(strings.Split(body, "\n"))
+		resp := ffuf.Response{Data: []byte(body)}
+
+		hit, _ := NewLineFilter(strconv.Itoa(expected))
+		if match, _ := hit.Filter(&resp); !match {
+			t.Errorf("line count for %q: expected filter to match %d", body, expected)
+		}
+		miss, _ := NewLineFilter(strconv.Itoa(expected + 1))
+		if match, _ := miss.Filter(&resp); match {
+			t.Errorf("line count for %q: filter matched %d, count is off by one", body, expected+1)
+		}
+	}
+}

--- a/pkg/filter/lines.go
+++ b/pkg/filter/lines.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -42,7 +43,9 @@ func (f *LineFilter) MarshalJSON() ([]byte, error) {
 }
 
 func (f *LineFilter) Filter(response *ffuf.Response) (bool, error) {
-	linesSize := len(strings.Split(string(response.Data), "\n"))
+	// bytes.Count(...)+1 matches len(strings.Split(...)) for a single-byte
+	// separator without allocating a []string of the whole body. See runner.
+	linesSize := bytes.Count(response.Data, []byte("\n")) + 1
 	for _, iv := range f.Value {
 		if iv.Min <= int64(linesSize) && int64(linesSize) <= iv.Max {
 			return true, nil

--- a/pkg/filter/words.go
+++ b/pkg/filter/words.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -42,7 +43,9 @@ func (f *WordFilter) MarshalJSON() ([]byte, error) {
 }
 
 func (f *WordFilter) Filter(response *ffuf.Response) (bool, error) {
-	wordsSize := len(strings.Split(string(response.Data), " "))
+	// bytes.Count(...)+1 matches len(strings.Split(...)) for a single-byte
+	// separator without allocating a []string of the whole body. See runner.
+	wordsSize := bytes.Count(response.Data, []byte(" ")) + 1
 	for _, iv := range f.Value {
 		if iv.Min <= int64(wordsSize) && int64(wordsSize) <= iv.Max {
 			return true, nil

--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -273,8 +273,13 @@ func (r *SimpleRunner) Execute(req *ffuf.Request) (resp ffuf.Response, err error
 		resp.Data = respbody
 	}
 
-	wordsSize := len(strings.Split(string(resp.Data), " "))
-	linesSize := len(strings.Split(string(resp.Data), "\n"))
+	// Count words and lines without materializing a []string. For a single-byte
+	// separator len(strings.Split(s, sep)) == bytes.Count(s, sep)+1, but Split
+	// allocates one string header (~16 bytes) per element. On a max-size body
+	// (MAX_DOWNLOAD_SIZE) full of separators that is tens of MB of transient
+	// garbage per response, times the thread count; bytes.Count is O(1) extra.
+	wordsSize := bytes.Count(resp.Data, []byte(" ")) + 1
+	linesSize := bytes.Count(resp.Data, []byte("\n")) + 1
 	resp.ContentWords = int64(wordsSize)
 	resp.ContentLines = int64(linesSize)
 	resp.Duration = firstByteTime


### PR DESCRIPTION
## Problem

The response body word and line counts were computed as:

```go
wordsSize := len(strings.Split(string(resp.Data), " "))
linesSize := len(strings.Split(string(resp.Data), "\n"))
```

`strings.Split` allocates a `[]string` with one string header (~16 bytes on 64-bit)
per element. The body read is already capped at `MAX_DOWNLOAD_SIZE` (5 MiB), but a
5 MiB body made entirely of the separator byte splits into ~5.24M elements, so the
backing array alone is ~80 MB of transient allocation per response, plus two
`[]byte`->`string` copies. This runs on every response in the runner, and again in
the word/line filters when `-mw/-fw/-ml/-fl` are active. At the default 40 threads a
target returning such bodies can push peak memory into OOM territory.

This came in as a reported memory-consumption issue against v2.2.1. It is a client-side
robustness/efficiency problem (the operator points ffuf at the target, and `-t` /
`-ignore-body` / `-rate` already bound memory), not a remote DoS, but the allocation is
real and worth removing.

## Fix

Use `bytes.Count(data, sep) + 1`. For a single-byte separator,
`len(strings.Split(s, sep)) == bytes.Count(s, sep) + 1` in every case (including empty
input), so the reported counts are unchanged. It uses O(1) extra memory and skips the
`[]byte`->`string` conversion entirely.

## Changes

- `pkg/runner/simple.go`: word/line count via `bytes.Count`, on `resp.Data` directly.
- `pkg/filter/words.go`, `pkg/filter/lines.go`: same substitution at the filter count sites.
- `pkg/filter/count_equivalence_test.go`: new regression test pinning the `bytes.Count`
  result to the old `strings.Split` count across empty, all-separator, no-separator, and
  leading/trailing-separator bodies, with an off-by-one negative check.

## Verification

- `go build ./...`, `go vet ./pkg/runner/... ./pkg/filter/...`, `gofmt` all clean.
- `go test ./...` passes, including the existing `TestWordFiltering` / `TestLineFiltering`
  which already assert the counts for the common case.
