### PR TITLE
Support wordlist entries up to 512 KiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Added audit logging functionality
     - Added preflight/postflight requests: raw HTTP request files run before/after each fuzzing request (`-preflight`/`-postflight`), with regex variable extraction (`-preflight-var "NAME:regex"`) injected into the main request, a per-request or amortized per-thread mode (`-preflight-mode`), and abort/ignore error handling (`-preflight-error`)
   - Changed
+    - Allow wordlist entries up to 512 KiB instead of the scanner's 64 KiB default
     - Fix a bug in autocalibration strategy merging, when two files have the same strategy key
     - Fix a bug in -or, causing output to not to be written in any case
     - Fix panic when setting rate to 0 in the interactive console

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@
 * [gserrg](https://github.com/gserrg)
 * [fabiobauer](https://github.com/fabiobauer)
 * [fang0654](https://github.com/fang0654)
+* [Gh0stlyKn1ght](https://github.com/Gh0stlyKn1ght)
 * [haseobang](https://github.com/haseobang)
 * [Hazegard](https://github.com/Hazegard)
 * [helpermika](https://github.com/helpermika)

--- a/pkg/input/wordlist.go
+++ b/pkg/input/wordlist.go
@@ -9,6 +9,8 @@ import (
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
+const maxWordlistLineSize = 512 * 1024
+
 type WordlistInput struct {
 	active   bool
 	config   *ffuf.Config
@@ -128,6 +130,10 @@ func (w *WordlistInput) readFile(path string) error {
 	var data [][]byte
 	var ok bool
 	reader := bufio.NewScanner(file)
+	// Scanner defaults to 64 KiB tokens, which rejects valid large request-body
+	// payloads. Keep a finite ceiling to avoid unbounded allocation while
+	// supporting the large wordlist entries reported in #557 and #567.
+	reader.Buffer(nil, maxWordlistLineSize)
 	re := regexp.MustCompile(`(?i)%ext%`)
 	for reader.Scan() {
 		if w.config.DirSearchCompat && len(w.config.Extensions) > 0 {

--- a/pkg/input/wordlist_test.go
+++ b/pkg/input/wordlist_test.go
@@ -1,7 +1,12 @@
 package input
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 func TestStripCommentsIgnoresCommentLines(t *testing.T) {
@@ -17,5 +22,26 @@ func TestStripCommentsStripsCommentAfterText(t *testing.T) {
 
 	if text != "text" {
 		t.Errorf("Comment was not stripped or pre-comment text was not returned")
+	}
+}
+
+func TestWordlistAcceptsLinesLargerThanScannerDefault(t *testing.T) {
+	// Issue #567 reports a real 448 KiB single-entry wordlist.
+	payload := strings.Repeat("a", 448*1024)
+	wordlist := filepath.Join(t.TempDir(), "large-wordlist.txt")
+	if err := os.WriteFile(wordlist, []byte(payload+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	config := ffuf.NewConfig(nil, nil)
+	input, err := NewWordlistInput("FUZZ", wordlist, &config)
+	if err != nil {
+		t.Fatalf("reading large wordlist entry: %v", err)
+	}
+	if input.Total() != 1 {
+		t.Fatalf("got %d entries, want 1", input.Total())
+	}
+	if got := string(input.Value()); got != payload {
+		t.Fatalf("payload length = %d, want %d", len(got), len(payload))
 	}
 }

--- a/pkg/input/wordlist_test.go
+++ b/pkg/input/wordlist_test.go
@@ -1,6 +1,7 @@
 package input
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,7 +34,9 @@ func TestWordlistAcceptsLinesLargerThanScannerDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config := ffuf.NewConfig(nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	config := ffuf.NewConfig(ctx, cancel)
 	input, err := NewWordlistInput("FUZZ", wordlist, &config)
 	if err != nil {
 		t.Fatalf("reading large wordlist entry: %v", err)


### PR DESCRIPTION
# Description

Raise the bounded bufio.Scanner token limit for wordlist entries from the 64 KiB default to 512 KiB. This supports large request-body payloads, including the 448 KiB reproduction reported in #567, while retaining a finite allocation ceiling.

A regression test verifies that a 448 KiB entry is read intact. The changelog and CONTRIBUTORS.md are updated per the contribution checklist.

Fixes: #557
Fixes: #567

## Checklist

- [x] Branch is based on the latest master.
- [x] go test -race ./... -count=1 passes.
- [x] go vet ./... and gofmt are clean.
- [x] No help, flag, or config goldens are affected.
- [x] Added @Gh0stlyKn1ght to CONTRIBUTORS.md.
- [x] Added a CHANGELOG.md entry.

Validated with Go 1.27.1.