### PR TITLE
Bound the -od/-audit-log response snapshot and the response header size

### DIFF
--- a/pkg/runner/simple.go
+++ b/pkg/runner/simple.go
@@ -103,11 +103,17 @@ func NewSimpleRunner(conf *ffuf.Config, replay bool) ffuf.RunnerProvider {
 		CheckRedirect: func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse },
 		Timeout:       time.Duration(time.Duration(conf.Timeout) * time.Second),
 		Transport: &http.Transport{
-			ForceAttemptHTTP2:   conf.Http2,
-			Proxy:               proxyURL,
-			MaxIdleConns:        1000,
-			MaxIdleConnsPerHost: 500,
-			MaxConnsPerHost:     500,
+			ForceAttemptHTTP2: conf.Http2,
+			Proxy:             proxyURL,
+			// Response headers are not covered by MAX_DOWNLOAD_SIZE, and Go's default
+			// ceiling is 10 MB. A hostile target could spend that on every response,
+			// and the headers are retained per response and copied into resp.Raw, the
+			// scraper's source string and the audit log. 1 MB is far above anything a
+			// real server sends (nginx and Apache cap a header line at 8 KB).
+			MaxResponseHeaderBytes: 1 << 20,
+			MaxIdleConns:           1000,
+			MaxIdleConnsPerHost:    500,
+			MaxConnsPerHost:        500,
 			DialContext: (&net.Dialer{
 				Timeout: time.Duration(time.Duration(conf.Timeout) * time.Second),
 			}).DialContext,
@@ -229,15 +235,39 @@ func (r *SimpleRunner) Execute(req *ffuf.Request) (resp ffuf.Response, err error
 	resp = ffuf.NewResponse(httpresp, req)
 	defer httpresp.Body.Close()
 
-	// Check if we should download the resource or not
-	size, err := strconv.Atoi(httpresp.Header.Get("Content-Length"))
-	if err == nil {
+	// Record the server-declared length first, so it is set before any early return
+	// below and the size filters still observe it.
+	if size, serr := strconv.Atoi(httpresp.Header.Get("Content-Length")); serr == nil {
 		resp.ContentLength = int64(size)
-		if (r.config.IgnoreBody) || (size > MAX_DOWNLOAD_SIZE) {
+		if size > MAX_DOWNLOAD_SIZE {
 			resp.Cancelled = true
 			return resp, nil
 		}
 	}
+
+	// -ignore-body has to hold regardless of framing. Keeping this check inside the
+	// Content-Length branch above meant it was silently skipped for chunked
+	// responses, which carry no Content-Length.
+	if r.config.IgnoreBody {
+		resp.Cancelled = true
+		return resp, nil
+	}
+
+	// Bound the body at the source, before anything reads it. The Content-Length
+	// guard above cannot fire when the header is absent, which is the case for
+	// chunked responses and for any response the transport transparently decoded,
+	// and httputil.DumpResponse below drains the entire body with no bound of its
+	// own.
+	//
+	// This does not replace the LimitReader further down, and which stream each of
+	// them bounds depends on the path. Where the transport decoded the body itself,
+	// both bound the same decompressed stream. Where Content-Encoding survived and
+	// we decode manually, this one bounds the compressed bytes and that one bounds
+	// what they expand to, so that case needs both.
+	httpresp.Body = struct {
+		io.Reader
+		io.Closer
+	}{io.LimitReader(httpresp.Body, int64(MAX_DOWNLOAD_SIZE)+1), httpresp.Body}
 
 	if len(r.config.OutputDirectory) > 0 || len(r.config.AuditLog) > 0 {
 		rawresp, _ := httputil.DumpResponse(httpresp, true)
@@ -266,6 +296,10 @@ func (r *SimpleRunner) Execute(req *ffuf.Request) (resp ffuf.Response, err error
 	limited := io.LimitReader(bodyReader, int64(MAX_DOWNLOAD_SIZE)+1)
 	if respbody, rerr := io.ReadAll(limited); rerr == nil {
 		if len(respbody) > MAX_DOWNLOAD_SIZE {
+			// The snapshot taken above holds a body truncated at the cap, which would
+			// be written out as a well-formed response that merely looks complete.
+			// Drop it rather than store a misleading artifact.
+			resp.Raw = ""
 			resp.Cancelled = true
 			return resp, nil
 		}

--- a/pkg/runner/simple_test.go
+++ b/pkg/runner/simple_test.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ffuf/ffuf/v2/pkg/ffuf"
@@ -121,5 +124,210 @@ func TestExecute_NormalResponseUnaffected(t *testing.T) {
 	}
 	if !bytes.Equal(resp.Data, body) {
 		t.Fatalf("body = %q, want %q", resp.Data, body)
+	}
+}
+
+// chunkedBodyServer streams `total` bytes with no Content-Length, so the response
+// is framed chunked and the numeric size guard cannot fire.
+func chunkedBodyServer(t *testing.T, total int) *httptest.Server {
+	t.Helper()
+	chunk := bytes.Repeat([]byte("A"), 1<<20)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for written := 0; written < total; written += len(chunk) {
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}))
+}
+
+func runnerWithConfig(t *testing.T, url string, mutate func(*ffuf.Config)) (ffuf.RunnerProvider, ffuf.Request) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	conf := ffuf.NewConfig(ctx, cancel)
+	conf.Method = "GET"
+	if mutate != nil {
+		mutate(&conf)
+	}
+	runner := NewSimpleRunner(&conf, false)
+	req := ffuf.NewRequest(&conf)
+	req.Method = "GET"
+	req.Url = url
+	return runner, req
+}
+
+// allocatedBy reports how many bytes were allocated while fn ran.
+func allocatedBy(fn func()) uint64 {
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	fn()
+	runtime.ReadMemStats(&after)
+	return after.TotalAlloc - before.TotalAlloc
+}
+
+// The -od and -audit-log snapshot path takes its own copy of the response body,
+// and it runs before the LimitReader that bounds resp.Data. Without a bound of its
+// own it reads an attacker-chosen amount into memory, so the size cap held for
+// resp.Data but not for resp.Raw. Regression test for that: with either output
+// feature enabled, a body far over the cap must not be materialised.
+func TestExecute_SnapshotIsBoundedWithOutputFeatures(t *testing.T) {
+	const body = 64 << 20 // 64 MiB against a 5 MiB cap
+	// Generous ceiling: the bounded path allocates a small multiple of the cap,
+	// the unbounded one allocates several times the body.
+	const allocCeiling = 64 << 20
+
+	cases := []struct {
+		name   string
+		mutate func(*ffuf.Config)
+	}{
+		{"output directory", func(c *ffuf.Config) { c.OutputDirectory = t.TempDir() }},
+		{"audit log", func(c *ffuf.Config) { c.AuditLog = filepath.Join(t.TempDir(), "audit.log") }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := chunkedBodyServer(t, body)
+			defer srv.Close()
+
+			runner, req := runnerWithConfig(t, srv.URL+"/", tc.mutate)
+			var resp ffuf.Response
+			allocated := allocatedBy(func() {
+				var err error
+				resp, err = runner.Execute(&req)
+				if err != nil {
+					t.Fatalf("execute: %v", err)
+				}
+			})
+
+			if allocated > allocCeiling {
+				t.Errorf("allocated %d bytes for a %d byte body, want at most %d", allocated, body, allocCeiling)
+			}
+			if len(resp.Raw) > MAX_DOWNLOAD_SIZE {
+				t.Errorf("resp.Raw is %d bytes, must not exceed MAX_DOWNLOAD_SIZE (%d)", len(resp.Raw), MAX_DOWNLOAD_SIZE)
+			}
+			if !resp.Cancelled {
+				t.Error("expected an over-cap response to be cancelled")
+			}
+		})
+	}
+}
+
+// A gzip bomb reaches the same snapshot path: the transport requests gzip itself,
+// decompresses transparently and strips Content-Length, so the numeric guard is
+// skipped and the snapshot sees the expanded stream.
+func TestExecute_SnapshotIsBoundedForGzipBomb(t *testing.T) {
+	const decompressed = 64 << 20
+	bomb := gzipBomb(t, decompressed)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(bomb)
+	}))
+	defer srv.Close()
+
+	runner, req := runnerWithConfig(t, srv.URL+"/", func(c *ffuf.Config) {
+		c.OutputDirectory = t.TempDir()
+	})
+	resp, err := runner.Execute(&req)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(resp.Raw) > MAX_DOWNLOAD_SIZE {
+		t.Errorf("resp.Raw is %d bytes, must not exceed MAX_DOWNLOAD_SIZE (%d)", len(resp.Raw), MAX_DOWNLOAD_SIZE)
+	}
+}
+
+// A response within the cap must still be captured in full, so the size bound does
+// not quietly truncate ordinary -od output.
+func TestExecute_SnapshotKeptForNormalResponse(t *testing.T) {
+	body := []byte("hello world")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	runner, req := runnerWithConfig(t, srv.URL+"/", func(c *ffuf.Config) {
+		c.OutputDirectory = t.TempDir()
+	})
+	resp, err := runner.Execute(&req)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if resp.Cancelled {
+		t.Fatal("a normal response must not be cancelled")
+	}
+	if !strings.Contains(resp.Raw, string(body)) {
+		t.Errorf("resp.Raw does not contain the body: %q", resp.Raw)
+	}
+}
+
+// -ignore-body used to live inside the Content-Length branch, so it did nothing for
+// a chunked response. It must hold regardless of framing.
+func TestExecute_IgnoreBodyAppliesToChunkedResponse(t *testing.T) {
+	srv := chunkedBodyServer(t, 32<<10)
+	defer srv.Close()
+
+	runner, req := runnerWithConfig(t, srv.URL+"/", func(c *ffuf.Config) { c.IgnoreBody = true })
+	resp, err := runner.Execute(&req)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !resp.Cancelled {
+		t.Error("expected the response to be cancelled")
+	}
+	if len(resp.Data) != 0 {
+		t.Errorf("read %d bytes of body despite -ignore-body", len(resp.Data))
+	}
+}
+
+// Moving the -ignore-body check must not lose the server-declared length, which the
+// size filters read.
+func TestExecute_IgnoreBodyKeepsContentLength(t *testing.T) {
+	body := make([]byte, 32<<10)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	runner, req := runnerWithConfig(t, srv.URL+"/", func(c *ffuf.Config) { c.IgnoreBody = true })
+	resp, err := runner.Execute(&req)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !resp.Cancelled {
+		t.Error("expected the response to be cancelled")
+	}
+	if resp.ContentLength != int64(len(body)) {
+		t.Errorf("ContentLength = %d, want %d", resp.ContentLength, len(body))
+	}
+}
+
+// Response headers sit outside MAX_DOWNLOAD_SIZE, so the transport needs its own
+// ceiling; Go's default is 10 MB.
+func TestNewSimpleRunner_BoundsResponseHeaders(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	conf := ffuf.NewConfig(ctx, cancel)
+	runner := NewSimpleRunner(&conf, false).(*SimpleRunner)
+
+	transport, ok := runner.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport is %T, want *http.Transport", runner.client.Transport)
+	}
+	if transport.MaxResponseHeaderBytes <= 0 {
+		t.Fatal("MaxResponseHeaderBytes is unset, response headers are bounded only by the net/http default")
+	}
+	if transport.MaxResponseHeaderBytes > 4<<20 {
+		t.Errorf("MaxResponseHeaderBytes = %d, larger than intended", transport.MaxResponseHeaderBytes)
 	}
 }

--- a/pkg/runner/simple_test.go
+++ b/pkg/runner/simple_test.go
@@ -179,9 +179,13 @@ func allocatedBy(fn func()) uint64 {
 // feature enabled, a body far over the cap must not be materialised.
 func TestExecute_SnapshotIsBoundedWithOutputFeatures(t *testing.T) {
 	const body = 64 << 20 // 64 MiB against a 5 MiB cap
-	// Generous ceiling: the bounded path allocates a small multiple of the cap,
-	// the unbounded one allocates several times the body.
-	const allocCeiling = 64 << 20
+	// The ceiling is a multiple of the body, not an absolute figure. The test origin
+	// runs in this process and allocates the body it streams, so roughly one body's
+	// worth is charged here no matter how little the client reads; the race detector
+	// adds more on top. The signal is the multiple: bounded stays near that floor,
+	// unbounded allocates several times the body because it buffers, copies and
+	// re-serialises it.
+	const allocCeiling = 2 * body
 
 	cases := []struct {
 		name   string
@@ -207,7 +211,8 @@ func TestExecute_SnapshotIsBoundedWithOutputFeatures(t *testing.T) {
 			})
 
 			if allocated > allocCeiling {
-				t.Errorf("allocated %d bytes for a %d byte body, want at most %d", allocated, body, allocCeiling)
+				t.Errorf("allocated %d bytes for a %d byte body, want at most %d; the snapshot is reading past the cap",
+					allocated, body, allocCeiling)
 			}
 			if len(resp.Raw) > MAX_DOWNLOAD_SIZE {
 				t.Errorf("resp.Raw is %d bytes, must not exceed MAX_DOWNLOAD_SIZE (%d)", len(resp.Raw), MAX_DOWNLOAD_SIZE)

--- a/pkg/scraper/util.go
+++ b/pkg/scraper/util.go
@@ -1,19 +1,25 @@
 package scraper
 
 import (
-	"fmt"
-	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 	"strings"
+
+	"github.com/ffuf/ffuf/v2/pkg/ffuf"
 )
 
 func headerString(headers map[string][]string) string {
-	val := ""
+	// Built with a Builder rather than repeated concatenation: the headers come
+	// from the scanned target, and += in this nested loop copies the accumulated
+	// string on every header value.
+	var sb strings.Builder
 	for k, vslice := range headers {
 		for _, v := range vslice {
-			val += fmt.Sprintf("%s: %s\n", k, v)
+			sb.WriteString(k)
+			sb.WriteString(": ")
+			sb.WriteString(v)
+			sb.WriteByte('\n')
 		}
 	}
-	return val
+	return sb.String()
 }
 
 func isActive(name string, activegroups []string) bool {


### PR DESCRIPTION
## What

`httputil.DumpResponse(httpresp, true)` takes its own full copy of the response body whenever `-od` or `-audit-log` is set, and it runs 23 lines before the `io.LimitReader` added in #897. That LimitReader bounds `resp.Data`. Nothing bounded the snapshot, so a scanned target could still drive ffuf's memory with a body of its choosing.

The `Content-Length` guard does not cover it. The whole check, including `size > MAX_DOWNLOAD_SIZE`, sat inside the `if err == nil` from `strconv.Atoi`, and that errors for chunked responses and for any response the transport transparently decompressed. Both arrive with no `Content-Length`.

ffuf sets no `Accept-Encoding` of its own and does not set `DisableCompression`, so the transport adds the header, decodes transparently, and strips `Content-Encoding`/`Content-Length`. That is the default path.

## Impact measured

Local target streaming an 8 MiB body of NUL bytes, gzipped to ~8 KB on the wire, 80 requests, default `-t 40`, unpatched binary:

| run | peak RSS |
|---|---|
| no output flags | 318 MiB |
| `-audit-log` | 1451 MiB |
| `-od` | 1861 MiB |

The same run wrote a 3.84 GiB `audit.log`. Body size is chosen by the target, so there is no ceiling. Scaling from `-t 1` to `-t 40` is roughly 5-6x rather than 40x, because the GC reclaims between responses.

Affects every released version. `-od` alone reaches it in 1.5.0 through 2.1.0 (`AuditLog` did not exist yet); `-od` or `-audit-log` in 2.2.0 and 2.2.1.

## Changes

- Wrap `httpresp.Body` in `io.LimitReader(..., MAX_DOWNLOAD_SIZE+1)` before the snapshot, so every later reader inherits the bound. The decompressed-side LimitReader stays: where `Content-Encoding` survives and we decode manually, the new one bounds compressed bytes and the existing one bounds what they expand to. Both are needed.
- Drop `resp.Raw` when the body turns out to be over the cap. `Response.Write` re-frames a truncated body as well-formed chunked, so the old behaviour would have written an `-od` file that reads as a complete response but silently stops at 5 MB.
- Set `Transport.MaxResponseHeaderBytes` to 1 MB. Headers are outside `MAX_DOWNLOAD_SIZE`, the net/http default ceiling is 10 MB, and they are retained per response and copied into `resp.Raw`, the scraper's source string and the audit log. nginx and Apache cap a header line at 8 KB, so 1 MB is well clear of anything real.
- Build the scraper's header string with a `strings.Builder` instead of `+=` in a nested loop, since that input is attacker controlled.
- Move the `-ignore-body` check out of the `Content-Length` branch. It was silently skipped for chunked responses. It now applies regardless of framing, and the server-declared length is still recorded first so `-fs`/`-ms` keep seeing it.

## Tests

Six new cases in `pkg/runner`. All of them fail on `master` and pass here, except the `Content-Length` preservation one, which is a regression guard for the `-ignore-body` move:

- `-od` and `-audit-log` against a 64 MiB chunked body: bounded `resp.Raw`, plus an allocation ceiling on the whole `Execute` call
- the same path against a gzip bomb
- an under-cap response still captured in full, so ordinary `-od` output does not regress
- `-ignore-body` on a chunked response
- `-ignore-body` preserving `ContentLength`
- `MaxResponseHeaderBytes` set

The #897 tests never set `-od` or `-audit-log`, which is why they stayed green through this. The new ones do.

`go test ./...` green across all 13 packages, `go vet ./...` clean, `golangci-lint v1.64.8` (the CI pin) clean.

## Note on disclosure

This was reported privately by three separate researchers. A security advisory and a follow-up CVE request are being prepared; this PR is public, so merge timing and advisory publication should be coordinated.
