### PR TITLE
Report the real version for `go install module@version` builds

### DIFF
--- a/pkg/ffuf/constants.go
+++ b/pkg/ffuf/constants.go
@@ -6,9 +6,16 @@ import (
 )
 
 var (
-	//VERSION holds the current version number
-	VERSION = "2.1.0"
-	//VERSION_APPENDIX holds additional version definition
+	// VERSION is the linker injection target for the release version: goreleaser
+	// sets it to the git tag via -ldflags -X (see .goreleaser.yml). Do not delete
+	// it because nothing in this package appears to read it; the linker reference
+	// is invisible to a Go-source search, and -X against a missing symbol fails
+	// silently. The literal below is a placeholder, not a real version, and is
+	// only ever seen when the ldflags injection, the VCS metadata and the module
+	// version are all unavailable.
+	VERSION = "0.0.0"
+	// VERSION_APPENDIX marks a non-release build. goreleaser empties it via -X,
+	// which is how Version() tells a release binary from a development one.
 	VERSION_APPENDIX = "-dev"
 	CONFIGDIR        = filepath.Join(xdg.ConfigHome, "ffuf")
 	HISTORYDIR       = filepath.Join(CONFIGDIR, "history")

--- a/pkg/ffuf/util.go
+++ b/pkg/ffuf/util.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -81,22 +82,82 @@ func HostURLFromRequest(req Request) string {
 
 // Version returns the ffuf version string.
 //
-// Release builds have their version injected via -ldflags by goreleaser: VERSION
-// is set to the git tag and VERSION_APPENDIX is emptied, so they report a plain
-// semantic version like "2.2.0" with no manual constant bump required.
+// It resolves through four sources, in this order:
 //
-// Builds from a source checkout (VERSION_APPENDIX still set) instead report a
-// "git-<UTC date>-<short commit>" identifier derived from the VCS metadata that
-// `go build` embeds into the binary, e.g. "git-20260613-aabbccdd". When that
-// metadata is unavailable it falls back to VERSION+VERSION_APPENDIX.
+//  1. Release builds have VERSION injected via -ldflags by goreleaser and
+//     VERSION_APPENDIX emptied, so they report a plain semantic version like
+//     "2.2.0" with no manual constant bump required.
+//  2. Builds from a source checkout report a "git-<UTC date>-<short commit>"
+//     identifier derived from the VCS metadata `go build` embeds, e.g.
+//     "git-20260613-aabbccdd". VCS metadata takes precedence over the module
+//     version below, because a working tree can sit on a tagged commit while
+//     carrying uncommitted changes.
+//  3. Binaries produced by `go install github.com/ffuf/ffuf/v2@vX.Y.Z` carry no
+//     VCS metadata, but the toolchain records the module version they were built
+//     from, so report that.
+//  4. Failing all of those, VERSION+VERSION_APPENDIX, which is a placeholder
+//     rather than a real version.
 func Version() string {
-	if VERSION_APPENDIX == "" {
-		return VERSION
+	v, _ := resolveVersion()
+	return v
+}
+
+var (
+	versionOnce     sync.Once
+	resolvedVersion string
+	versionReleased bool
+)
+
+// resolveVersion resolves the version once and caches it. Version() sits on the
+// per-request path since it fills in the default User-Agent, and both metadata
+// lookups below parse data embedded in the binary, so resolving on every call
+// spends microseconds per request on a value that cannot change.
+func resolveVersion() (string, bool) {
+	versionOnce.Do(func() {
+		resolvedVersion, versionReleased = selectVersion(VERSION, VERSION_APPENDIX, gitVersion(), moduleVersion())
+	})
+	return resolvedVersion, versionReleased
+}
+
+// selectVersion picks which of the available version sources to report, and
+// reports whether the result identifies a released version.
+//
+// VCS metadata deliberately outranks the module version: a working tree can sit
+// on a tagged commit while carrying uncommitted changes, and the toolchain
+// records the tag as the module version regardless, so preferring it would let a
+// dirty build claim to be a clean release.
+func selectVersion(injected, appendix, git, module string) (version string, released bool) {
+	if appendix == "" {
+		return injected, true
 	}
-	if v := gitVersion(); v != "" {
-		return v
+	if git != "" {
+		return git, false
 	}
-	return fmt.Sprintf("%s%s", VERSION, VERSION_APPENDIX)
+	if module != "" {
+		return module, true
+	}
+	return injected + appendix, false
+}
+
+// moduleVersion returns the version of the main module this binary was built
+// from, as recorded by `go install module@version`. It returns "" when there is
+// no real version to report, which is the case for a plain `go build` in a
+// working tree.
+func moduleVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	return normalizeModuleVersion(info.Main.Version)
+}
+
+// normalizeModuleVersion strips the module version's leading "v" and rejects the
+// placeholders the toolchain uses when no version is available.
+func normalizeModuleVersion(v string) string {
+	if v == "" || v == "(devel)" {
+		return ""
+	}
+	return strings.TrimPrefix(v, "v")
 }
 
 // gitVersion assembles a "git-<date>-<shorthash>" string from the VCS metadata
@@ -133,14 +194,15 @@ func gitVersion() string {
 	return fmt.Sprintf("git-%s-%s%s", stamp.UTC().Format("20060102"), revision, dirty)
 }
 
-// FormattedVersion returns the version prepared for display. Release builds are
-// prefixed with "v" (e.g. "v2.2.0"); development builds are returned unprefixed
-// (e.g. "git-20260613-aabbccdd") since a "v" reads as noise there.
+// FormattedVersion returns the version prepared for display. Released versions
+// are prefixed with "v" (e.g. "v2.2.0"); development builds are returned
+// unprefixed (e.g. "git-20260613-aabbccdd") since a "v" reads as noise there.
 func FormattedVersion() string {
-	if VERSION_APPENDIX == "" {
-		return "v" + Version()
+	v, released := resolveVersion()
+	if released {
+		return "v" + v
 	}
-	return Version()
+	return v
 }
 
 func CheckOrCreateConfigDir() error {

--- a/pkg/ffuf/version_test.go
+++ b/pkg/ffuf/version_test.go
@@ -1,0 +1,131 @@
+package ffuf
+
+import (
+	"strings"
+	"testing"
+)
+
+// selectVersion holds the whole decision, so every build path can be driven
+// deterministically without needing a binary built that way.
+func TestSelectVersion(t *testing.T) {
+	cases := []struct {
+		name         string
+		injected     string
+		appendix     string
+		git          string
+		module       string
+		wantVersion  string
+		wantReleased bool
+	}{
+		{
+			name:     "release build reports the injected tag",
+			injected: "2.3.0", appendix: "", git: "git-20260909-256c1b02", module: "2.3.0",
+			wantVersion: "2.3.0", wantReleased: true,
+		},
+		{
+			name:     "source checkout reports the git identifier",
+			injected: "0.0.0", appendix: "-dev", git: "git-20260909-256c1b02", module: "",
+			wantVersion: "git-20260909-256c1b02", wantReleased: false,
+		},
+		{
+			name:     "vcs metadata outranks the module version so a dirty tree cannot claim a release",
+			injected: "0.0.0", appendix: "-dev", git: "git-20260909-256c1b02-dirty", module: "2.3.0",
+			wantVersion: "git-20260909-256c1b02-dirty", wantReleased: false,
+		},
+		{
+			name:     "go install reports the module version it was built from",
+			injected: "0.0.0", appendix: "-dev", git: "", module: "2.2.1",
+			wantVersion: "2.2.1", wantReleased: true,
+		},
+		{
+			name:     "no metadata at all falls back to the placeholder",
+			injected: "0.0.0", appendix: "-dev", git: "", module: "",
+			wantVersion: "0.0.0-dev", wantReleased: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, released := selectVersion(tc.injected, tc.appendix, tc.git, tc.module)
+			if got != tc.wantVersion {
+				t.Errorf("version = %q, want %q", got, tc.wantVersion)
+			}
+			if released != tc.wantReleased {
+				t.Errorf("released = %v, want %v", released, tc.wantReleased)
+			}
+		})
+	}
+}
+
+// A git identifier must never be reported as a released version, because
+// FormattedVersion would then render it as "vgit-20260909-...".
+func TestSelectVersion_GitIdentifierIsNeverReleased(t *testing.T) {
+	for _, module := range []string{"", "2.3.0", "2.3.1-0.20260909191139-256c1b024995"} {
+		got, released := selectVersion("0.0.0", "-dev", "git-20260909-256c1b02", module)
+		if released {
+			t.Errorf("git identifier %q reported as released with module=%q", got, module)
+		}
+	}
+}
+
+// normalizeModuleVersion decides whether the module version recorded by
+// `go install module@version` is usable. The toolchain writes "(devel)" when
+// there is no version, and prefixes real ones with "v".
+func TestNormalizeModuleVersion(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{"exact release tag", "v2.3.0", "2.3.0"},
+		{"prerelease tag", "v2.3.0-rc1", "2.3.0-rc1"},
+		{"pseudo version for an untagged commit", "v2.3.1-0.20260909191139-256c1b024995", "2.3.1-0.20260909191139-256c1b024995"},
+		{"local build placeholder", "(devel)", ""},
+		{"no version recorded", "", ""},
+		{"already unprefixed", "2.3.0", "2.3.0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeModuleVersion(tc.in); got != tc.want {
+				t.Errorf("normalizeModuleVersion(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// FormattedVersion adds a "v" only for released versions, so it must never
+// produce a v-prefixed git identifier whatever this test binary was built from.
+func TestFormattedVersion_MatchesVersion(t *testing.T) {
+	v := Version()
+	formatted := FormattedVersion()
+	if formatted != v && formatted != "v"+v {
+		t.Errorf("FormattedVersion() = %q, want %q or %q", formatted, v, "v"+v)
+	}
+	if strings.HasPrefix(formatted, "vgit-") {
+		t.Errorf("FormattedVersion() = %q, a git identifier must not be v-prefixed", formatted)
+	}
+}
+
+// Version() fills in the default User-Agent on every request, so the build
+// metadata lookups behind it are resolved once rather than per call.
+func TestVersion_IsResolvedOnce(t *testing.T) {
+	first, firstReleased := resolveVersion()
+	second, secondReleased := resolveVersion()
+	if first != second || firstReleased != secondReleased {
+		t.Errorf("resolveVersion() is not stable: (%q,%v) then (%q,%v)", first, firstReleased, second, secondReleased)
+	}
+}
+
+// The constant is a linker injection target, not a version to maintain by hand.
+// It sat at "2.1.0" through the 2.2.0, 2.2.1 and 2.3.0 releases, which is what a
+// binary from `go install module@version` reported.
+func TestVersion_ConstantIsAPlaceholder(t *testing.T) {
+	if VERSION != "0.0.0" {
+		t.Errorf("VERSION = %q, want the 0.0.0 placeholder; a real version here goes stale silently", VERSION)
+	}
+	if VERSION_APPENDIX == "" {
+		t.Error("VERSION_APPENDIX must be non-empty in source, it is what marks a build as not-a-release")
+	}
+}
+
+func BenchmarkVersion(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = Version()
+	}
+}


### PR DESCRIPTION
## The stale constant is not dead code

`pkg/ffuf/constants.go` has said `VERSION = "2.1.0"` through the 2.2.0, 2.2.1 and 2.3.0 releases, which reads like a leftover. It is not removable:

```yaml
# .goreleaser.yml:11
-X github.com/ffuf/ffuf/v2/pkg/ffuf.VERSION={{ .Version }} -X github.com/ffuf/ffuf/v2/pkg/ffuf.VERSION_APPENDIX=
```

Both symbols are linker injection targets. That reference is invisible to any search of the Go source, and `-X` against a symbol that does not exist fails silently, so deleting either would break release versioning with no build error. Both now carry a comment saying exactly that.

## The bug the staleness was pointing at

A binary built by `go install` has no VCS metadata, so `Version()` fell through to the constant:

```
$ go install github.com/ffuf/ffuf/v2@v2.2.1
$ ffuf -V
ffuf version: 2.1.0-dev
```

Someone installing a release to pick up a security fix cannot tell from the version string whether they have it, and a bug report from such a build sends triage at the wrong release.

The right answer is already in the binary:

```
$ go version -m $(which ffuf)
    mod  github.com/ffuf/ffuf/v2  v2.2.1  h1:Ff/BpOlO9aoRU2hqF6RviuSvaKb1H03n9365CE4k2zM=
```

## Changes

- Read `debug.ReadBuildInfo().Main.Version` and report it when there is no VCS metadata. `(devel)` and the empty string are rejected, and the leading `v` is trimmed.
- VCS metadata keeps precedence over the module version. A working tree can sit on a tagged commit while carrying uncommitted changes, and the toolchain records the tag as the module version regardless, so preferring it would let a dirty build claim to be a clean release. There is a test for that ordering.
- `VERSION` drops to `"0.0.0"`. Bumping it to 2.3.0 would just restore the maintenance step that let it rot through three releases. As a placeholder it is only ever reported when the ldflags injection, the VCS metadata and the module version are all absent, and it can no longer be wrong about a specific release.
- The decision is now a pure `selectVersion(injected, appendix, git, module)` plus a memoized wrapper. `Version()` fills in the default User-Agent on every request (`pkg/runner/simple.go:204`) and was calling `ReadBuildInfo` on every call; adding a second lookup would have doubled that. Resolving once takes it from **2242 ns/op to 2.7 ns/op**.
- `FormattedVersion()` prefixes `v` for released versions, which now includes an exact module version, and still never prefixes a git identifier. There is a test for that too.

## Verification

All three build paths, checked before and after:

| build path | before | after |
| --- | --- | --- |
| `go build` in a checkout | `git-20260909-256c1b02` | `git-20260909-256c1b02` |
| goreleaser ldflags | `2.3.0` | `2.3.0` |
| `go install ...@v2.2.1` | `2.1.0-dev` | the installed version |

`go vet ./...`, `go test -race ./... -count=1`, `go test -tags=timing ./... -count=1` and `golangci-lint v1.64.8` (the CI pin) are all clean.

New tests drive every path through the pure selector rather than needing a binary built each way, and cover the version normalisation table, the VCS-over-module ordering, the "a git identifier is never a release" invariant, the memoization contract, and a guard against putting a real release number back into the constant.
